### PR TITLE
fix(ci): use golangci-lint-action@v6 and remove v2-incompatible flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,10 @@ jobs:
         run: cd web && npm ci && npm run build
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
-          args: --config .golangci.yml --max-issues-per-linter 0 --max-same-issues 0
+          args: --config .golangci.yml
 
       - name: Run tests
         run: go test ./... -v


### PR DESCRIPTION
golangci-lint-action@v7 does not exist; v6 is the correct tag.
The --max-issues-per-linter and --max-same-issues flags were removed
in golangci-lint v2, which is what .golangci.yml targets.

https://claude.ai/code/session_01WFcHEEKfvTKzXqWdXqBDUn