### PR TITLE
fix(review): harden plugin security and IPv6 support, use mountinfo for pool detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- `internal/unraid` package with `DiscoverPools()` and `PreferredPool()` for dynamic Unraid pool detection — replaces hardcoded `/mnt/cache` references across the codebase (closes #49)
+
 ### Fixed
 
+- Mirrored SSD cache pools (e.g. `/mnt/cache2`, `/mnt/cache3`) not detected under Settings → Database Location and Temporary Work Area — pool discovery now scans `/mnt/` at runtime using exclusion-based filtering (closes #49)
+- Browse handler filesystem roots now dynamically discover all pool drives instead of relying on a hardcoded "Cache" entry
 - Path traversal vulnerability (CWE-22) in `SnapshotManager` — added `validateSnapshotPath` defense-in-depth validation to `SaveSnapshot`, `SetSnapshotPath`, `RestoreFromSnapshot`, `RestoreFromPath`, `SetUSBBackupPath`, and `saveUSBBackup` using `filepath.Clean` + `filepath.Abs` with `..` component rejection (closes #27, closes #28)
 - Data race in `SaveSnapshot` reading `snapshotPath` without mutex protection — now reads the field under lock consistently with other accessors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,76 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
-### Added
-
-- Configuration persistence across Unraid server restarts: `SNAPSHOT_PATH` is now saved to `vault.cfg` on USB flash and read at startup before database restoration, resolving the chicken-and-egg problem where the snapshot path was only stored inside the database (Refs #48)
-- USB shadow backup: the daemon writes a throttled copy of the database to `/boot/config/plugins/vault/vault.db.backup` on USB flash as a last-resort fallback; forced on graceful shutdown
-- Immediate USB flash backup on configuration changes: any job, storage, settings, or replication mutation triggers an unthrottled `FlushToUSB` so the flash copy always has fresh data for reboot recovery
-- Fallback restoration chain at startup: tries configured snapshot path → default cache path → USB backup → fresh database, with detailed logging of which source was used
-- Cache mount detection at startup: distinguishes between `/mnt/cache` not existing, existing but unmounted, and mounted — logs warnings and falls back gracefully when cache is unavailable
-- Health endpoint (`GET /api/v1/health`) now includes `restoration_source`, `restoration_path`, `restoration_reason`, and `degraded` fields to report database restoration status
-- Database info endpoint (`GET /api/v1/settings/database`) now includes `restoration_source`, `restoration_reason`, and `degraded` fields
-- `internal/config/vaultcfg.go`: `ReadCfg`, `ReadCfgValue`, `WriteCfgValue` helpers for reading/writing the shell-sourceable `vault.cfg` INI file on USB flash
-- `internal/cli/restore.go`: `restoreWithFallback` implements the 4-level fallback chain; `validateConfiguredPaths` checks accessibility of user-configured paths at startup
-- ZFS dataset backup and restore engine using pure-Go `gzfs` library — supports full and incremental ZFS send/receive streams with progress tracking (Refs #4)
-- ZFS dataset discovery endpoint `GET /api/v1/zfs` lists ZFS filesystems and volumes available for backup
-- ZFS Datasets tab in the job creation item picker with dataset type badges (Filesystem/Volume), mountpoint, and used-space indicators
-- ZFS dataset count displayed in the job summary card alongside containers, VMs, folders, and plugins
-- `zfs_meta.json` sidecar written alongside each ZFS send stream to record dataset name, snapshot, pool, and backup type for reliable restore
-- Automatic cleanup of old vault-created ZFS snapshots after successful backup, keeping only the latest
-- Snapshot cleanup on send failure to prevent orphaned ZFS snapshots
-- Cloud replication targets — Google Drive and OneDrive now available as replication target types alongside Remote Vault Server
-- Push-based cloud sync engine (`syncCloudPush`) that uploads local backup restore points to cloud storage adapters
-- Type-aware replication target creation and editing with conditional forms for each target type
-- `type` and `config` columns on `replication_sources` table to support different target types (remote_vault, gdrive, onedrive)
-- Redesigned Create Backup Job wizard from 3 steps to a guided 6-step flow: Type → Items → Schedule → Details → Advanced → Review (closes #36)
-- New `TypePicker` component for Step 1: card-based multi-select grid with automatic item discovery, per-type color coding, and availability detection for Containers, VMs, Folders, Flash Drive, Plugins, and ZFS Datasets
-- `ItemPicker` now accepts an `allowedTypes` prop to filter visible tabs based on the types selected in Step 1; single-type selection hides the tab bar entirely
-- Auto-generated job name suggestions based on selected backup types (e.g. "Containers + VMs Backup")
-- Advanced settings (Step 5) grouped into collapsible accordion sections: Retention, Scripts, Verification, VM Restore Verify, and Container Exclusions — contextually shown based on selected types
-- Contextual tooltips across Settings, Jobs, Storage, and Replication pages — reusable `Tooltip.svelte` component with hover/click-to-toggle, viewport-aware positioning, keyboard dismissal, and full ARIA accessibility (Refs #34)
-- Enriched activity logs with contextual details for troubleshooting: backup started/completed and restore completed entries now include job name, backup type, storage destination, duration, and size; per-item container health check results are logged individually under a new "health" category; stop_all health check summary includes aggregate counts (containers checked/healthy/unhealthy) (Refs #30)
-- "Health" category filter on the Logs page to isolate container health check entries
-- Smart formatting for activity log detail badges: backup types are capitalised, durations show unit suffixes, byte sizes are human-readable (e.g. 2.2 GB), and null values are hidden
-- Diagnostic bundle download: `GET /api/v1/settings/diagnostics` endpoint and "Download diagnostics bundle" button on the Settings page generates a ZIP containing system info, database details, storage destinations, job configurations, recent run history, and activity logs with a unique correlation ID for support workflows (Refs #29)
-- `internal/diagnostics` package with collector, ZIP packager, and comprehensive redaction for sensitive data (passwords, API keys, tokens, webhook secrets, inline URL credentials)
-- `ListRecentRuns(limit)` database method for fetching recent job runs across all jobs
-- Purge activity logs: `DELETE /api/v1/activity` endpoint and "Purge" button on the Logs page with confirmation dialog to permanently delete all activity log entries (Refs #32)
-- Purge job run history: `DELETE /api/v1/history` endpoint and "Purge" button on the History page with confirmation dialog to permanently delete all job run records (Refs #32)
-- `PurgeJobRuns()` database method for bulk deletion of job run history; activity log purge reuses `DeleteOldActivityLogs(0)` to clear all entries
-- Job run history purge actions are logged in the activity log with the count of deleted records
-- Cancel API endpoint `POST /api/v1/jobs/{id}/cancel` to abort a running backup job (Refs #28)
-- Cancellable context propagated through the entire backup pipeline: Runner → engine handlers → tar/copy I/O operations
-- 4-hour job timeout with automatic cancellation via `context.WithTimeout`
-- Stall detection: warns after 30 minutes of no progress, auto-cancels after 2 hours of inactivity
-- `cancelling` field added to runner status for real-time UI feedback
-- `job_cancelling` WebSocket event broadcast when cancellation is requested
-- "cancelled" job run status with descriptive log messages (user-initiated vs timeout)
-- Context-aware `contextCopy` helper that checks for cancellation every 32 KiB during file I/O
-- `ctx.Err()` checks in `filepath.Walk` callbacks to abort directory traversal on cancellation
-- Backup target category toggles in Settings → General: independently enable/disable tracking for Containers, Virtual Machines, and Flash Drive; disabled categories are excluded from protection status on the Dashboard and readiness metrics on the Recovery page (Refs #20)
-- Three new settings keys (`container_backup_enabled`, `vm_backup_enabled`, `flash_backup_enabled`) with `"true"` defaults in the settings API
-- Monthly and yearly scheduling now support "First day of month" and "Last day of month" options in the schedule builder UI; last-day jobs use a daily-check pattern on the backend with an `isLastDayOfMonth()` guard so they fire correctly on months of any length (Refs #15)
-- Unraid display time format is now detected from `dynamix.cfg` and injected into the runtime config, allowing the UI to honour the user's 12-hour or 24-hour preference (Refs #12)
-- Go daemon (direct-access mode) now injects `window.__VAULT_RUNTIME_CONFIG__` into the SPA HTML, ensuring time format detection works when accessing Vault directly on port 24085 without the PHP proxy
-- `getTimeFormat()` and `getHour12()` helpers added to `runtime-config.js` for locale-aware time rendering
-- `formatDate()` utility now used consistently for all date/time display in the Storage and Settings pages
-
 ### Changed
 
-- `SnapshotManager` snapshot path is now mutable at runtime via `SetSnapshotPath()` — immediately saves a fresh snapshot at the new location when the user changes the database save location
-- `NewSnapshotManager` now accepts a separate `defaultPath` parameter so reset-to-default resolves correctly without relying on the database
-- Database Location UI: removed "Changes take effect on next daemon restart" text and updated tooltip to "Changes take effect immediately"
-- Runner now saves both the primary snapshot and USB shadow backup after each successful backup job (`SaveSnapshotAndUSBBackup`)
-- `SaveSnapshotAndUSBBackup` and `FlushToUSB` now attempt the USB backup even when the primary snapshot save fails, since the USB backup copies directly from the working in-memory DB
-- USB database file is preserved as `.backup` during hybrid mode migration instead of being deleted
-- Moved Google Drive and OneDrive from the Storage page to the Replication page — Storage now only handles local/network destinations (Local Path, SFTP, SMB, NFS)
-- OAuth endpoints for Google Drive and OneDrive moved from `/api/v1/storage/` to `/api/v1/replication/` (e.g. `/api/v1/replication/gdrive/status`)
-- OAuth handlers changed from `StorageHandler` to `ReplicationHandler` receiver
-- Replication "Add Target" modal now offers three target types: Remote Vault Server, Google Drive, and OneDrive
-- Removed "Local Storage Destination" field from Remote Vault replication targets — remote server uses its own configured storage path automatically
-- Replication target cards now display type-appropriate icons and labels (Google Drive, OneDrive, or server URL)
-- Renamed "Staging Directory" section to "Temporary Work Area" with descriptive subtitle explaining its purpose (Refs #13)
+- Renamed "Staging Directory" section to "Temporary Work Area" with descriptive subtitle explaining its purpose (closes #13)
 - Replaced "SSD Cache (automatic)" label with "Using SSD cache for fast backup processing" and "Custom override" with "Custom location"
 - Renamed "Custom Path (optional)" to "Custom Location" with description: "Override the automatic location. Use this if you want backups to be assembled on a specific drive."
 - Renamed "Cascade order" to "Fallback locations" with description: "Vault tries each location in order and uses the first available one."
@@ -86,37 +19,55 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Renamed "Custom Snapshot Path (optional)" to "Custom save location" with description: "Choose where the persistent database copy is stored. Defaults to SSD cache."
 - Enhanced USB warning to suggest adding a cache drive or setting a custom save location
 - Simplified Backup Targets subtitle to "Select what Vault should monitor. Disabled items won't show as unprotected on Dashboard or Recovery."
-- `engine.Handler` interface now accepts `context.Context` as the first parameter for `Backup()` and `Restore()`
-- All engine handlers (Container, VM, Folder, Plugin) updated to accept and propagate context
-- `Runner.backupItem()` now receives and passes context to engine handlers
+
+### Added
+
+- Contextual tooltips across Settings, Jobs, Storage, and Replication pages — reusable `Tooltip.svelte` component with hover/click-to-toggle, viewport-aware positioning, keyboard dismissal, and full ARIA accessibility (closes #34)
 
 ### Fixed
 
-- Bind address dropdown now auto-detects the server's network interfaces (NICs) and lists each IPv4 address with its interface name (e.g. `192.168.20.21 (br0)`), allowing users with multiple NICs to bind to a specific interface; duplicate IPs across virtual/shim interfaces are deduplicated
-- Bind address configuration: replaced free-text input with a dropdown (`127.0.0.1` / `0.0.0.0` / detected NICs) to prevent users from entering invalid IPs that break the daemon
-- PHP proxy now uses the actual bind address instead of hardcoded `127.0.0.1`, fixing the issue where changing the bind address made the Settings page show the daemon as stopped and the Web UI unreachable
-- Default button on the Settings/Vault page now properly resets configuration to defaults (`127.0.0.1:24085`) and restarts the daemon; previously the Unraid `#default` mechanism silently failed
-- Bind address validation added to `rc.vault` and `apply.sh` — invalid addresses (not bound to a local interface) are rejected with a fallback to `127.0.0.1`
-- INI injection prevention in config reset: values read from existing config are sanitized before interpolation
-- Removed obsolete API key warning from bind address help text (API Access feature was previously removed)
-- Database location changes now take effect immediately without requiring a daemon restart; previously, changing or resetting the custom snapshot path required a restart and could be silently reversed by stale data in the old snapshot (Refs #48)
-- Resetting the custom database location back to defaults no longer gets reversed on restart — removed the DB override sync-back that read stale `snapshot_path_override` from cached snapshots and overwrote vault.cfg; `vault.cfg` is now the sole authority for the snapshot path
-- Setting a custom snapshot path to a directory (e.g. `/mnt/garbage`) now automatically appends `/vault.db` instead of rejecting the input, so users can just pick a folder
-- Database Location UI: added an "Apply" button for manually typed paths and "Reset to default" link when a custom location is set
-- PathBrowser breadcrumb navigation: fixed duplicate `/mnt` segments in the breadcrumb trail; breadcrumbs now correctly show `/mnt`, `/mnt / cache`, `/mnt / cache / appdata`, etc. without repetition
 - Tooltip clipping when positioned near viewport edges — switched from `position: absolute` to `position: fixed` with JS-calculated viewport coordinates and horizontal clamping
-- Container path exclusion presets now load correctly when Vault runs behind the Unraid web proxy; `fetchContainerPresets()` uses `buildApiRequest()` instead of raw `fetch()` to route through the authenticated proxy endpoint (Refs #11)
-- Stuck backup jobs can no longer run indefinitely — timeout and stall detection ensure jobs are always bounded (Refs #28)
+- Enriched activity logs with contextual details for troubleshooting: backup started/completed and restore completed entries now include job name, backup type, storage destination, duration, and size; per-item container health check results are logged individually under a new "health" category; stop_all health check summary includes aggregate counts (containers checked/healthy/unhealthy) (closes #30)
+- "Health" category filter on the Logs page to isolate container health check entries
+- Smart formatting for activity log detail badges: backup types are capitalised, durations show unit suffixes, byte sizes are human-readable (e.g. 2.2 GB), and null values are hidden
+- Diagnostic bundle download: `GET /api/v1/settings/diagnostics` endpoint and "Download diagnostics bundle" button on the Settings page generates a ZIP containing system info, database details, storage destinations, job configurations, recent run history, and activity logs with a unique correlation ID for support workflows (closes #29)
+- `internal/diagnostics` package with collector, ZIP packager, and comprehensive redaction for sensitive data (passwords, API keys, tokens, webhook secrets, inline URL credentials)
+- `ListRecentRuns(limit)` database method for fetching recent job runs across all jobs
+- Purge activity logs: `DELETE /api/v1/activity` endpoint and "Purge" button on the Logs page with confirmation dialog to permanently delete all activity log entries (closes #32)
+- Purge job run history: `DELETE /api/v1/history` endpoint and "Purge" button on the History page with confirmation dialog to permanently delete all job run records (closes #32)
+- `PurgeJobRuns()` database method for bulk deletion of job run history; activity log purge reuses `DeleteOldActivityLogs(0)` to clear all entries
+- Job run history purge actions are logged in the activity log with the count of deleted records
+- Cancel API endpoint `POST /api/v1/jobs/{id}/cancel` to abort a running backup job (closes #28)
+- Cancellable context propagated through the entire backup pipeline: Runner → engine handlers → tar/copy I/O operations
+- 4-hour job timeout with automatic cancellation via `context.WithTimeout`
+- Stall detection: warns after 30 minutes of no progress, auto-cancels after 2 hours of inactivity
+- `cancelling` field added to runner status for real-time UI feedback
+- `job_cancelling` WebSocket event broadcast when cancellation is requested
+- "cancelled" job run status with descriptive log messages (user-initiated vs timeout)
+- Context-aware `contextCopy` helper that checks for cancellation every 32 KiB during file I/O
+- `ctx.Err()` checks in `filepath.Walk` callbacks to abort directory traversal on cancellation
+- Backup target category toggles in Settings → General: independently enable/disable tracking for Containers, Virtual Machines, and Flash Drive; disabled categories are excluded from protection status on the Dashboard and readiness metrics on the Recovery page (closes #20)
+- Three new settings keys (`container_backup_enabled`, `vm_backup_enabled`, `flash_backup_enabled`) with `"true"` defaults in the settings API
+- Monthly and yearly scheduling now support "First day of month" and "Last day of month" options in the schedule builder UI; last-day jobs use a daily-check pattern on the backend with an `isLastDayOfMonth()` guard so they fire correctly on months of any length (closes #15)
+- Unraid display time format is now detected from `dynamix.cfg` and injected into the runtime config, allowing the UI to honour the user's 12-hour or 24-hour preference
+- Go daemon (direct-access mode) now injects `window.__VAULT_RUNTIME_CONFIG__` into the SPA HTML, ensuring time format detection works when accessing Vault directly on port 24085 without the PHP proxy
+- `getTimeFormat()` and `getHour12()` helpers added to `runtime-config.js` for locale-aware time rendering
+- `formatDate()` utility now used consistently for all date/time display in the Storage and Settings pages
+
+### Fixed
+
+- Container path exclusion presets now load correctly when Vault runs behind the Unraid web proxy; `fetchContainerPresets()` uses `buildApiRequest()` instead of raw `fetch()` to route through the authenticated proxy endpoint (closes #11)
+- Stuck backup jobs can no longer run indefinitely — timeout and stall detection ensure jobs are always bounded (closes #28)
 - Time format detection now falls back to `[notify][time]` in `dynamix.cfg` when `[display][time]` is absent, fixing detection on Unraid 7.x where the time format preference is stored in the notification settings section
 - Unraid Settings/Vault page was blank due to duplicated PHP code in `api.php` causing a syntax error; removed the corrupted duplicate block to restore the service control panel, Web UI button, and port/binding configuration
-- SMB and SFTP storage adapters now honour the "Path" field: frontend forms send `base_path` matching the backend struct, and adapters accept the legacy `path` JSON key as a fallback for backward compatibility (Refs #25)
-- Job deletion with "Delete Backup Files" now properly removes empty directories after deleting their contents, fixing the issue where backup files and directories were left on Local and SMB storage (Refs #26)
+- SMB and SFTP storage adapters now honour the "Path" field: frontend forms send `base_path` matching the backend struct, and adapters accept the legacy `path` JSON key as a fallback for backward compatibility (closes #25)
+- Job deletion with "Delete Backup Files" now properly removes empty directories after deleting their contents, fixing the issue where backup files and directories were left on Local and SMB storage (closes #26)
 - SMB adapter `Write()` now propagates `MkdirAll` errors instead of silently ignoring them
-- `ItemPicker` selected-items map wrapped in `$state()` to ensure Svelte 5 reactive tracking (Refs #22)
-- Items deleted from Unraid (containers, VMs, folders, plugins) can now be removed from backup jobs via the new remove button in the Backup Order list; stale items that no longer exist on the system are visually flagged with a "Not found" warning indicator (Refs #24)
-- Container volume backups now skip Unix sockets, character/block devices, and named pipes instead of failing with "sockets not supported" errors; affected containers (e.g. those mounting `/var/run/docker.sock`) will complete successfully with a log entry for each skipped special file (Refs #5)
-- Monthly schedule day picker now shows all 31 days instead of only days 1–28; previously `Array(27)` omitted days 29, 30, and 31 (Refs #9)
-- Storage destination save dialog now has a `saving` guard to prevent double-click duplicate submissions, matching the pattern already used in Jobs (Refs #10)
+- `ItemPicker` selected-items map wrapped in `$state()` to ensure Svelte 5 reactive tracking (closes #22)
+- Items deleted from Unraid (containers, VMs, folders, plugins) can now be removed from backup jobs via the new remove button in the Backup Order list; stale items that no longer exist on the system are visually flagged with a "Not found" warning indicator (closes #24)
+- Storage form "Save" button now guards against double-submission with a `saving` flag and shows a "Saving…" state while the request is in flight
+- Container volume backups now skip Unix sockets, character/block devices, and named pipes instead of failing with "sockets not supported" errors; affected containers (e.g. those mounting `/var/run/docker.sock`) will complete successfully with a log entry for each skipped special file (closes #5)
+- Monthly schedule day picker now shows all 31 days instead of only days 1–28; previously `Array(27)` omitted days 29, 30, and 31 (closes #9)
 
 ### Removed
 
@@ -127,6 +78,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `/auth/status`, `/settings/api-key/generate`, `/settings/api-key/rotate`, `/settings/api-key/revoke`, `/settings/api-key` endpoints removed
 - `api_key` column removed from `replication_sources` database schema
 - `LoginPrompt.svelte` component deleted (unused)
+
+### Changed
+
+- `engine.Handler` interface now accepts `context.Context` as the first parameter for `Backup()` and `Restore()`
+- All engine handlers (Container, VM, Folder, Plugin) updated to accept and propagate context
+- `Runner.backupItem()` now receives and passes context to engine handlers
 
 ## [2026.03.02] - 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- Path traversal vulnerability (CWE-22) in `SnapshotManager` — added `validateSnapshotPath` defense-in-depth validation to `SaveSnapshot`, `SetSnapshotPath`, `RestoreFromSnapshot`, `RestoreFromPath`, `SetUSBBackupPath`, and `saveUSBBackup` using `filepath.Clean` + `filepath.Abs` with `..` component rejection (closes #27, closes #28)
+- Data race in `SaveSnapshot` reading `snapshotPath` without mutex protection — now reads the field under lock consistently with other accessors
+
 ### Changed
 
 - Renamed "Staging Directory" section to "Temporary Work Area" with descriptive subtitle explaining its purpose (closes #13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - Mirrored SSD cache pools (e.g. `/mnt/cache2`, `/mnt/cache3`) not detected under Settings → Database Location and Temporary Work Area — pool discovery now scans `/mnt/` at runtime using exclusion-based filtering (closes #49)
 - Browse handler filesystem roots now dynamically discover all pool drives instead of relying on a hardcoded "Cache" entry
-- Path traversal vulnerability (CWE-22) in `SnapshotManager` — added `validateSnapshotPath` defense-in-depth validation to `SaveSnapshot`, `SetSnapshotPath`, `RestoreFromSnapshot`, `RestoreFromPath`, `SetUSBBackupPath`, and `saveUSBBackup` with `..` component rejection before `filepath.Clean` + `filepath.Abs` normalisation (closes #27, closes #28)
+- Path traversal vulnerability (CWE-22) in `SnapshotManager` — added `validateSnapshotPath` defense-in-depth validation to `SaveSnapshot`, `SetSnapshotPath`, `RestoreFromSnapshot`, `RestoreFromPath`, `SetUSBBackupPath`, and `saveUSBBackup` with `..` component rejection before `filepath.Clean` + `filepath.Abs` normalisation; uses `filepath.ToSlash` for cross-platform traversal detection (closes #27, closes #28)
 - Data race in `SaveSnapshot` reading `snapshotPath` without mutex protection — now reads the field under lock consistently with other accessors
 - Diagnostics collector hybrid-mode detection now checks that the preferred pool is mounted (matching daemon startup behaviour) instead of only checking directory existence
-- CSRF token validation added to `control.php` for state-changing actions (start, stop, restart, reset-config)
+- CSRF token validation added to `control.php` for state-changing actions (start, stop, restart, reset-config) — token sourced exclusively from POST
 - IPv6 loopback (`::1`) bind address now connects via `[::1]` instead of `127.0.0.1` in the PHP proxy, fixing connectivity when the daemon binds exclusively to IPv6
 - Bind-address validation in `apply.sh` and `rc.vault` now uses `grep -F` (fixed-string) to prevent regex wildcard matching of IPv4 dots, and `apply.sh` accepts IPv6 loopback/wildcard (`::1`, `::`)
+- `apply.sh` no longer sources the config file directly — safely extracts only the `BIND_ADDRESS` key via grep/sed to prevent arbitrary code execution from user-editable config
+- `apply.sh` now checks `sed -i` exit status and aborts with an error if the config update fails
+- INI sanitisation in `control.php` now strips backslashes in addition to quotes and newlines, preventing backslash-escape attacks on INI quoting
 - Tooltip clipping when positioned near viewport edges — switched from `position: absolute` to `position: fixed` with JS-calculated viewport coordinates and horizontal clamping
 - Container path exclusion presets now load correctly when Vault runs behind the Unraid web proxy; `fetchContainerPresets()` uses `buildApiRequest()` instead of raw `fetch()` to route through the authenticated proxy endpoint (closes #11)
 - Stuck backup jobs can no longer run indefinitely — timeout and stall detection ensure jobs are always bounded (closes #28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,36 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- `internal/unraid` package with `DiscoverPools()` and `PreferredPool()` for dynamic Unraid pool detection — replaces hardcoded `/mnt/cache` references across the codebase (closes #49)
-
-### Fixed
-
-- Mirrored SSD cache pools (e.g. `/mnt/cache2`, `/mnt/cache3`) not detected under Settings → Database Location and Temporary Work Area — pool discovery now scans `/mnt/` at runtime using exclusion-based filtering (closes #49)
-- Browse handler filesystem roots now dynamically discover all pool drives instead of relying on a hardcoded "Cache" entry
-- Path traversal vulnerability (CWE-22) in `SnapshotManager` — added `validateSnapshotPath` defense-in-depth validation to `SaveSnapshot`, `SetSnapshotPath`, `RestoreFromSnapshot`, `RestoreFromPath`, `SetUSBBackupPath`, and `saveUSBBackup` using `filepath.Clean` + `filepath.Abs` with `..` component rejection (closes #27, closes #28)
-- Data race in `SaveSnapshot` reading `snapshotPath` without mutex protection — now reads the field under lock consistently with other accessors
-
-### Changed
-
-- Renamed "Staging Directory" section to "Temporary Work Area" with descriptive subtitle explaining its purpose (closes #13)
-- Replaced "SSD Cache (automatic)" label with "Using SSD cache for fast backup processing" and "Custom override" with "Custom location"
-- Renamed "Custom Path (optional)" to "Custom Location" with description: "Override the automatic location. Use this if you want backups to be assembled on a specific drive."
-- Renamed "Cascade order" to "Fallback locations" with description: "Vault tries each location in order and uses the first available one."
-- Updated Database Location subtitle to explain that Vault's database tracks jobs, schedules, and restore points
-- Replaced "Hybrid (RAM + SSD snapshots)" with "Hybrid — runs in memory for speed, saves to SSD periodically"
-- Renamed "Working" to "Active database" with tooltip explaining hybrid mode operates from RAM
-- Renamed "Snapshot" to "Saved copy", "Last snapshot" to "Last saved", and "Snapshot size" to "Saved copy size"
-- Renamed "Custom Snapshot Path (optional)" to "Custom save location" with description: "Choose where the persistent database copy is stored. Defaults to SSD cache."
-- Enhanced USB warning to suggest adding a cache drive or setting a custom save location
-- Simplified Backup Targets subtitle to "Select what Vault should monitor. Disabled items won't show as unprotected on Dashboard or Recovery."
-
-### Added
-
+- `internal/unraid` package with `DiscoverPools()`, `PreferredPool()`, and `IsMountedPool()` for dynamic Unraid pool detection — replaces hardcoded `/mnt/cache` references across the codebase (closes #49)
 - Contextual tooltips across Settings, Jobs, Storage, and Replication pages — reusable `Tooltip.svelte` component with hover/click-to-toggle, viewport-aware positioning, keyboard dismissal, and full ARIA accessibility (closes #34)
-
-### Fixed
-
-- Tooltip clipping when positioned near viewport edges — switched from `position: absolute` to `position: fixed` with JS-calculated viewport coordinates and horizontal clamping
 - Enriched activity logs with contextual details for troubleshooting: backup started/completed and restore completed entries now include job name, backup type, storage destination, duration, and size; per-item container health check results are logged individually under a new "health" category; stop_all health check summary includes aggregate counts (containers checked/healthy/unhealthy) (closes #30)
 - "Health" category filter on the Logs page to isolate container health check entries
 - Smart formatting for activity log detail badges: backup types are capitalised, durations show unit suffixes, byte sizes are human-readable (e.g. 2.2 GB), and null values are hidden
@@ -67,6 +39,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- Mirrored SSD cache pools (e.g. `/mnt/cache2`, `/mnt/cache3`) not detected under Settings → Database Location and Temporary Work Area — pool discovery now scans `/mnt/` at runtime using exclusion-based filtering (closes #49)
+- Browse handler filesystem roots now dynamically discover all pool drives instead of relying on a hardcoded "Cache" entry
+- Path traversal vulnerability (CWE-22) in `SnapshotManager` — added `validateSnapshotPath` defense-in-depth validation to `SaveSnapshot`, `SetSnapshotPath`, `RestoreFromSnapshot`, `RestoreFromPath`, `SetUSBBackupPath`, and `saveUSBBackup` with `..` component rejection before `filepath.Clean` + `filepath.Abs` normalisation (closes #27, closes #28)
+- Data race in `SaveSnapshot` reading `snapshotPath` without mutex protection — now reads the field under lock consistently with other accessors
+- Diagnostics collector hybrid-mode detection now checks that the preferred pool is mounted (matching daemon startup behaviour) instead of only checking directory existence
+- CSRF token validation added to `control.php` for state-changing actions (start, stop, restart, reset-config)
+- IPv6 loopback (`::1`) bind address now connects via `[::1]` instead of `127.0.0.1` in the PHP proxy, fixing connectivity when the daemon binds exclusively to IPv6
+- Bind-address validation in `apply.sh` and `rc.vault` now uses `grep -F` (fixed-string) to prevent regex wildcard matching of IPv4 dots, and `apply.sh` accepts IPv6 loopback/wildcard (`::1`, `::`)
+- Tooltip clipping when positioned near viewport edges — switched from `position: absolute` to `position: fixed` with JS-calculated viewport coordinates and horizontal clamping
 - Container path exclusion presets now load correctly when Vault runs behind the Unraid web proxy; `fetchContainerPresets()` uses `buildApiRequest()` instead of raw `fetch()` to route through the authenticated proxy endpoint (closes #11)
 - Stuck backup jobs can no longer run indefinitely — timeout and stall detection ensure jobs are always bounded (closes #28)
 - Time format detection now falls back to `[notify][time]` in `dynamix.cfg` when `[display][time]` is absent, fixing detection on Unraid 7.x where the time format preference is stored in the notification settings section
@@ -80,6 +61,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Container volume backups now skip Unix sockets, character/block devices, and named pipes instead of failing with "sockets not supported" errors; affected containers (e.g. those mounting `/var/run/docker.sock`) will complete successfully with a log entry for each skipped special file (closes #5)
 - Monthly schedule day picker now shows all 31 days instead of only days 1–28; previously `Array(27)` omitted days 29, 30, and 31 (closes #9)
 
+### Changed
+
+- Renamed "Staging Directory" section to "Temporary Work Area" with descriptive subtitle explaining its purpose (closes #13)
+- Replaced "SSD Cache (automatic)" label with "Using SSD cache for fast backup processing" and "Custom override" with "Custom location"
+- Renamed "Custom Path (optional)" to "Custom Location" with description: "Override the automatic location. Use this if you want backups to be assembled on a specific drive."
+- Renamed "Cascade order" to "Fallback locations" with description: "Vault tries each location in order and uses the first available one."
+- Updated Database Location subtitle to explain that Vault's database tracks jobs, schedules, and restore points
+- Replaced "Hybrid (RAM + SSD snapshots)" with "Hybrid — runs in memory for speed, saves to SSD periodically"
+- Renamed "Working" to "Active database" with tooltip explaining hybrid mode operates from RAM
+- Renamed "Snapshot" to "Saved copy", "Last snapshot" to "Last saved", and "Snapshot size" to "Saved copy size"
+- Renamed "Custom Snapshot Path (optional)" to "Custom save location" with description: "Choose where the persistent database copy is stored. Defaults to SSD cache."
+- Enhanced USB warning to suggest adding a cache drive or setting a custom save location
+- Simplified Backup Targets subtitle to "Select what Vault should monitor. Disabled items won't show as unprotected on Dashboard or Recovery."
+- `engine.Handler` interface now accepts `context.Context` as the first parameter for `Backup()` and `Restore()`
+- All engine handlers (Container, VM, Folder, Plugin) updated to accept and propagate context
+- `Runner.backupItem()` now receives and passes context to engine handlers
+
 ### Removed
 
 - API Access feature completely removed from Security settings — API key generation, rotation, revocation, and status endpoints are no longer available
@@ -89,12 +87,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `/auth/status`, `/settings/api-key/generate`, `/settings/api-key/rotate`, `/settings/api-key/revoke`, `/settings/api-key` endpoints removed
 - `api_key` column removed from `replication_sources` database schema
 - `LoginPrompt.svelte` component deleted (unused)
-
-### Changed
-
-- `engine.Handler` interface now accepts `context.Context` as the first parameter for `Backup()` and `Restore()`
-- All engine handlers (Container, VM, Folder, Plugin) updated to accept and propagate context
-- `Runner.backupItem()` now receives and passes context to engine handlers
 
 ## [2026.03.02] - 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- Bind address configuration: replaced free-text input with a dropdown (`127.0.0.1` / `0.0.0.0`) to prevent users from entering invalid IPs that break the daemon
+- PHP proxy now uses the actual bind address instead of hardcoded `127.0.0.1`, fixing the issue where changing the bind address made the Settings page show the daemon as stopped and the Web UI unreachable
+- Default button on the Settings/Vault page now properly resets configuration to defaults (`127.0.0.1:24085`) and restarts the daemon; previously the Unraid `#default` mechanism silently failed
+- Bind address validation added to `rc.vault` and `apply.sh` — invalid addresses (not bound to a local interface) are rejected with a fallback to `127.0.0.1`
+- INI injection prevention in config reset: values read from existing config are sanitized before interpolation
+- Removed obsolete API key warning from bind address help text (API Access feature was previously removed)
 - Database location changes now take effect immediately without requiring a daemon restart; previously, changing or resetting the custom snapshot path required a restart and could be silently reversed by stale data in the old snapshot (Refs #48)
 - Resetting the custom database location back to defaults no longer gets reversed on restart — removed the DB override sync-back that read stale `snapshot_path_override` from cached snapshots and overwrote vault.cfg; `vault.cfg` is now the sole authority for the snapshot path
 - Setting a custom snapshot path to a directory (e.g. `/mnt/garbage`) now automatically appends `/vault.db` instead of rejecting the input, so users can just pick a folder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
-- Bind address configuration: replaced free-text input with a dropdown (`127.0.0.1` / `0.0.0.0`) to prevent users from entering invalid IPs that break the daemon
+- Bind address dropdown now auto-detects the server's network interfaces (NICs) and lists each IPv4 address with its interface name (e.g. `192.168.20.21 (br0)`), allowing users with multiple NICs to bind to a specific interface; duplicate IPs across virtual/shim interfaces are deduplicated
+- Bind address configuration: replaced free-text input with a dropdown (`127.0.0.1` / `0.0.0.0` / detected NICs) to prevent users from entering invalid IPs that break the daemon
 - PHP proxy now uses the actual bind address instead of hardcoded `127.0.0.1`, fixing the issue where changing the bind address made the Settings page show the daemon as stopped and the Web UI unreachable
 - Default button on the Settings/Vault page now properly resets configuration to defaults (`127.0.0.1:24085`) and restarts the daemon; previously the Unraid `#default` mechanism silently failed
 - Bind address validation added to `rc.vault` and `apply.sh` — invalid addresses (not bound to a local interface) are rejected with a fallback to `127.0.0.1`

--- a/internal/api/handlers/browse.go
+++ b/internal/api/handlers/browse.go
@@ -3,10 +3,12 @@ package handlers
 import (
 	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/ruaan-deysel/vault/internal/safepath"
+	"github.com/ruaan-deysel/vault/internal/unraid"
 )
 
 // BrowseHandler serves filesystem directory listings for the path browser UI.
@@ -25,10 +27,11 @@ type dirEntry struct {
 }
 
 // unraidRoots are the well-known Unraid mount points shown as top-level shortcuts.
+// Note: the "Cache" entry is intentionally omitted here — cache pools (including
+// mirrored and custom-named pools) are discovered dynamically below.
 var unraidRoots = []dirEntry{
 	{Name: "Flash Drive", Path: "/boot", IsDir: true},
 	{Name: "User Shares", Path: "/mnt/user", IsDir: true},
-	{Name: "Cache", Path: "/mnt/cache", IsDir: true},
 	{Name: "Unassigned Devices", Path: "/mnt/disks", IsDir: true},
 	{Name: "Remote Mounts", Path: "/mnt/remotes", IsDir: true},
 }
@@ -69,7 +72,7 @@ func (h *BrowseHandler) List(w http.ResponseWriter, r *http.Request) {
 }
 
 // discoverRoots returns Unraid well-known roots plus dynamically discovered
-// array disks (/mnt/disk1, /mnt/disk2, etc.) and cache pools.
+// array disks (/mnt/disk1, /mnt/disk2, etc.) and cache/pool drives.
 func (h *BrowseHandler) discoverRoots() []dirEntry {
 	roots := make([]dirEntry, 0, len(unraidRoots)+8)
 
@@ -77,6 +80,23 @@ func (h *BrowseHandler) discoverRoots() []dirEntry {
 	for _, r := range unraidRoots {
 		if info, err := os.Stat(r.Path); err == nil && info.IsDir() {
 			roots = append(roots, r)
+		}
+	}
+
+	// Discover pool drives via the shared utility.
+	pools := unraid.DiscoverPools()
+	for _, poolPath := range pools {
+		name := filepath.Base(poolPath)
+		label := "Cache"
+		if name != "cache" {
+			label = "Cache Pool (" + name + ")"
+		}
+		if info, err := os.Stat(poolPath); err == nil && info.IsDir() {
+			roots = append(roots, dirEntry{
+				Name:  label,
+				Path:  poolPath,
+				IsDir: true,
+			})
 		}
 	}
 
@@ -107,14 +127,6 @@ func (h *BrowseHandler) discoverRoots() []dirEntry {
 					IsDir: true,
 				})
 			}
-		}
-		// Match additional cache pools (cache2, cache3, etc.).
-		if strings.HasPrefix(name, "cache") && name != "cache" {
-			roots = append(roots, dirEntry{
-				Name:  "Cache Pool (" + name + ")",
-				Path:  "/mnt/" + name,
-				IsDir: true,
-			})
 		}
 	}
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ruaan-deysel/vault/internal/replication"
 	"github.com/ruaan-deysel/vault/internal/scheduler"
 	"github.com/ruaan-deysel/vault/internal/tempdir"
+	"github.com/ruaan-deysel/vault/internal/unraid"
 	"github.com/spf13/cobra"
 )
 
@@ -31,35 +32,39 @@ var daemonCmd = &cobra.Command{
 		tlsCert, _ := cmd.Flags().GetString("tls-cert")
 		tlsKey, _ := cmd.Flags().GetString("tls-key")
 
-		// Hybrid mode detection: if a cache drive is mounted, use a RAM-backed
-		// working database with periodic snapshots to the cache drive. This
+		// Hybrid mode detection: if a pool drive is mounted, use a RAM-backed
+		// working database with periodic snapshots to the pool drive. This
 		// avoids USB flash wear from SQLite WAL writes.
-		const (
-			defaultCachePath = "/mnt/cache"
-			defaultSnapPath  = "/mnt/cache/.vault/vault.db"
-			usbBackupPath    = "/boot/config/plugins/vault/vault.db.backup"
-		)
+		const usbBackupPath = "/boot/config/plugins/vault/vault.db.backup"
 
 		var (
-			hybridMode   bool
-			snapshotPath string
-			snapshotMgr  *db.SnapshotManager
-			actualDBPath = dbPath
+			hybridMode      bool
+			snapshotPath    string
+			snapshotMgr     *db.SnapshotManager
+			actualDBPath    = dbPath
+			detectedPool    string
+			defaultSnapPath string
 		)
 
 		// Determine the vault.cfg path (same directory as the DB flag).
 		cfgPath := filepath.Join(filepath.Dir(dbPath), "vault.cfg")
 
-		cacheState := checkCacheMount(defaultCachePath)
-		switch cacheState {
-		case cacheMounted:
-			hybridMode = true
-			log.Printf("Cache drive detected and mounted at %s", defaultCachePath)
-		case cacheEmptyNotMounted:
-			log.Printf("Warning: %s exists but appears unmounted — the array may not be started yet", defaultCachePath)
-			log.Println("Warning: falling back to USB-direct mode with degraded persistence")
-		case cacheNotExist:
-			log.Println("Warning: no cache drive detected at /mnt/cache — database writes go directly to USB flash (increased wear)")
+		detectedPool = unraid.PreferredPool()
+		if detectedPool != "" {
+			defaultSnapPath = filepath.Join(detectedPool, ".vault", "vault.db")
+			cacheState := checkCacheMount(detectedPool)
+			switch cacheState {
+			case cacheMounted:
+				hybridMode = true
+				log.Printf("Pool drive detected and mounted at %s", detectedPool)
+			case cacheEmptyNotMounted:
+				log.Printf("Warning: %s exists but appears unmounted — the array may not be started yet", detectedPool)
+				log.Println("Warning: falling back to USB-direct mode with degraded persistence")
+			case cacheNotExist:
+				log.Printf("Warning: pool %s not accessible — database writes go directly to USB flash (increased wear)", detectedPool)
+			}
+		} else {
+			log.Println("Warning: no pool drive detected — database writes go directly to USB flash (increased wear)")
 		}
 
 		if hybridMode {

--- a/internal/cli/uninstall_cleanup.go
+++ b/internal/cli/uninstall_cleanup.go
@@ -54,7 +54,9 @@ var cleanupUninstallCmd = &cobra.Command{
 		cfg.LogPath, _ = cmd.Flags().GetString("log-path")
 		cfg.PIDFile, _ = cmd.Flags().GetString("pid-file")
 		cfg.HybridWorkingDir, _ = cmd.Flags().GetString("hybrid-working-dir")
-		cfg.DefaultSnapshotDB, _ = cmd.Flags().GetString("snapshot-path")
+		if cmd.Flags().Changed("snapshot-path") {
+			cfg.DefaultSnapshotDB, _ = cmd.Flags().GetString("snapshot-path")
+		}
 
 		return runUninstallCleanup(cfg)
 	},

--- a/internal/cli/uninstall_cleanup.go
+++ b/internal/cli/uninstall_cleanup.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ruaan-deysel/vault/internal/db"
 	"github.com/ruaan-deysel/vault/internal/tempdir"
+	"github.com/ruaan-deysel/vault/internal/unraid"
 	"github.com/spf13/cobra"
 )
 
@@ -73,8 +74,12 @@ func init() {
 }
 
 func defaultUninstallCleanupConfig() uninstallCleanupConfig {
-	cachePaths := make([]string, len(tempdir.CachePaths))
-	copy(cachePaths, tempdir.CachePaths)
+	paths := tempdir.GetCachePaths()
+
+	snapshotDB := "/mnt/cache/.vault/vault.db"
+	if pool := unraid.PreferredPool(); pool != "" {
+		snapshotDB = filepath.Join(pool, ".vault", "vault.db")
+	}
 
 	return uninstallCleanupConfig{
 		DBPath:            "/boot/config/plugins/vault/vault.db",
@@ -85,8 +90,8 @@ func defaultUninstallCleanupConfig() uninstallCleanupConfig {
 		LogPath:           "/var/log/vault.log",
 		PIDFile:           "/var/run/vault.pid",
 		HybridWorkingDir:  "/var/local/vault",
-		DefaultSnapshotDB: "/mnt/cache/.vault/vault.db",
-		CachePaths:        cachePaths,
+		DefaultSnapshotDB: snapshotDB,
+		CachePaths:        paths,
 	}
 }
 

--- a/internal/db/snapshot.go
+++ b/internal/db/snapshot.go
@@ -96,8 +96,9 @@ func validateSnapshotPath(path string) (string, error) {
 	}
 
 	// Reject ".." components BEFORE cleaning — filepath.Clean would silently
-	// normalise them away, defeating traversal detection.
-	for _, part := range strings.Split(path, string(filepath.Separator)) {
+	// normalise them away, defeating traversal detection.  Use forward-slash
+	// splitting so the check works regardless of OS path separator.
+	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
 		if part == ".." {
 			return "", fmt.Errorf("path traversal not allowed in snapshot path")
 		}

--- a/internal/db/snapshot.go
+++ b/internal/db/snapshot.go
@@ -88,24 +88,24 @@ func (sm *SnapshotManager) DefaultSnapshotPath() string {
 	return sm.defaultSnapshotPath
 }
 
-// validateSnapshotPath normalises and validates a snapshot path to prevent
-// path traversal attacks (CWE-22). Returns the cleaned absolute path.
+// validateSnapshotPath rejects input containing path traversal components and
+// returns the cleaned absolute path.
 func validateSnapshotPath(path string) (string, error) {
 	if path == "" {
 		return "", fmt.Errorf("snapshot path must not be empty")
 	}
 
-	absPath, err := filepath.Abs(filepath.Clean(path))
-	if err != nil {
-		return "", fmt.Errorf("resolve snapshot path: %w", err)
-	}
-
-	// After Clean+Abs, a legitimate absolute path must not contain ".."
-	// path components. Reject any residual traversal.
-	for _, part := range strings.Split(absPath, string(filepath.Separator)) {
+	// Reject ".." components BEFORE cleaning — filepath.Clean would silently
+	// normalise them away, defeating traversal detection.
+	for _, part := range strings.Split(path, string(filepath.Separator)) {
 		if part == ".." {
 			return "", fmt.Errorf("path traversal not allowed in snapshot path")
 		}
+	}
+
+	absPath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", fmt.Errorf("resolve snapshot path: %w", err)
 	}
 
 	return absPath, nil

--- a/internal/db/snapshot.go
+++ b/internal/db/snapshot.go
@@ -366,7 +366,7 @@ func (sm *SnapshotManager) RestoreFromPath(sourcePath string) error {
 		return bck.Finish()
 	})
 	if err != nil {
-		return fmt.Errorf("restore from %s: %w", sourcePath, err)
+		return fmt.Errorf("restore from %s: %w", validPath, err)
 	}
 
 	sm.mu.Lock()

--- a/internal/db/snapshot.go
+++ b/internal/db/snapshot.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -48,6 +49,14 @@ func NewSnapshotManager(database *DB, snapshotPath, defaultPath string) *Snapsho
 
 // SetUSBBackupPath enables the USB shadow backup at the given path.
 func (sm *SnapshotManager) SetUSBBackupPath(path string) {
+	if path != "" {
+		validPath, err := validateSnapshotPath(path)
+		if err != nil {
+			log.Printf("Warning: invalid USB backup path: %v", err)
+			return
+		}
+		path = validPath
+	}
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	sm.usbBackupPath = path
@@ -79,6 +88,29 @@ func (sm *SnapshotManager) DefaultSnapshotPath() string {
 	return sm.defaultSnapshotPath
 }
 
+// validateSnapshotPath normalises and validates a snapshot path to prevent
+// path traversal attacks (CWE-22). Returns the cleaned absolute path.
+func validateSnapshotPath(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("snapshot path must not be empty")
+	}
+
+	absPath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", fmt.Errorf("resolve snapshot path: %w", err)
+	}
+
+	// After Clean+Abs, a legitimate absolute path must not contain ".."
+	// path components. Reject any residual traversal.
+	for _, part := range strings.Split(absPath, string(filepath.Separator)) {
+		if part == ".." {
+			return "", fmt.Errorf("path traversal not allowed in snapshot path")
+		}
+	}
+
+	return absPath, nil
+}
+
 // SetSnapshotPath changes the snapshot path at runtime and immediately saves
 // a fresh snapshot at the new location. If newPath is empty, the default
 // snapshot path is used. This ensures the target location has up-to-date data.
@@ -87,12 +119,17 @@ func (sm *SnapshotManager) SetSnapshotPath(newPath string) error {
 		newPath = sm.defaultSnapshotPath
 	}
 
-	if err := os.MkdirAll(filepath.Dir(newPath), 0o750); err != nil {
+	validPath, err := validateSnapshotPath(newPath)
+	if err != nil {
+		return fmt.Errorf("validating snapshot path: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(validPath), 0o750); err != nil {
 		return fmt.Errorf("creating snapshot directory: %w", err)
 	}
 
 	sm.mu.Lock()
-	sm.snapshotPath = newPath
+	sm.snapshotPath = validPath
 	sm.mu.Unlock()
 
 	// Save a fresh snapshot to the new location so it is never stale.
@@ -112,7 +149,16 @@ func (sm *SnapshotManager) LastSnapshot() time.Time {
 // SaveSnapshot copies the working DB to the snapshot path using the SQLite
 // backup API.
 func (sm *SnapshotManager) SaveSnapshot() error {
-	if err := os.MkdirAll(filepath.Dir(sm.snapshotPath), 0o750); err != nil {
+	sm.mu.Lock()
+	snapshotPath := sm.snapshotPath
+	sm.mu.Unlock()
+
+	validPath, err := validateSnapshotPath(snapshotPath)
+	if err != nil {
+		return fmt.Errorf("validating snapshot path: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(validPath), 0o750); err != nil {
 		return fmt.Errorf("create snapshot directory: %w", err)
 	}
 
@@ -126,7 +172,7 @@ func (sm *SnapshotManager) SaveSnapshot() error {
 		type backuper interface {
 			NewBackup(string) (*sqlite.Backup, error)
 		}
-		bck, err := driverConn.(backuper).NewBackup(sm.snapshotPath)
+		bck, err := driverConn.(backuper).NewBackup(validPath)
 		if err != nil {
 			return err
 		}
@@ -152,8 +198,17 @@ func (sm *SnapshotManager) SaveSnapshot() error {
 // SQLite restore API. If the snapshot file does not exist, it logs a message
 // and returns nil (no-op for first run).
 func (sm *SnapshotManager) RestoreFromSnapshot() error {
-	if _, err := os.Stat(sm.snapshotPath); os.IsNotExist(err) {
-		log.Printf("no snapshot file at %s, skipping restore", sm.snapshotPath)
+	sm.mu.Lock()
+	snapshotPath := sm.snapshotPath
+	sm.mu.Unlock()
+
+	validPath, err := validateSnapshotPath(snapshotPath)
+	if err != nil {
+		return fmt.Errorf("validating snapshot path: %w", err)
+	}
+
+	if _, err := os.Stat(validPath); os.IsNotExist(err) {
+		log.Printf("no snapshot file at %s, skipping restore", validPath)
 		return nil
 	}
 
@@ -167,7 +222,7 @@ func (sm *SnapshotManager) RestoreFromSnapshot() error {
 		type restorer interface {
 			NewRestore(string) (*sqlite.Backup, error)
 		}
-		bck, err := driverConn.(restorer).NewRestore(sm.snapshotPath)
+		bck, err := driverConn.(restorer).NewRestore(validPath)
 		if err != nil {
 			return err
 		}
@@ -227,11 +282,17 @@ func (sm *SnapshotManager) saveUSBBackup(force bool) {
 		return
 	}
 
+	validPath, err := validateSnapshotPath(usbPath)
+	if err != nil {
+		log.Printf("Warning: invalid USB backup path: %v", err)
+		return
+	}
+
 	if !force && !lastBackup.IsZero() && time.Since(lastBackup) < interval {
 		return
 	}
 
-	if err := os.MkdirAll(filepath.Dir(usbPath), 0o750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(validPath), 0o750); err != nil {
 		log.Printf("Warning: failed to create USB backup directory: %v", err)
 		return
 	}
@@ -247,7 +308,7 @@ func (sm *SnapshotManager) saveUSBBackup(force bool) {
 		type backuper interface {
 			NewBackup(string) (*sqlite.Backup, error)
 		}
-		bck, err := driverConn.(backuper).NewBackup(usbPath)
+		bck, err := driverConn.(backuper).NewBackup(validPath)
 		if err != nil {
 			return err
 		}
@@ -267,14 +328,19 @@ func (sm *SnapshotManager) saveUSBBackup(force bool) {
 	sm.mu.Lock()
 	sm.lastUSBBackup = time.Now()
 	sm.mu.Unlock()
-	log.Printf("USB shadow backup saved to %s", usbPath)
+	log.Printf("USB shadow backup saved to %s", validPath)
 }
 
 // RestoreFromPath restores the database from the specified source path.
 // Returns an error if the file doesn't exist or restoration fails.
 func (sm *SnapshotManager) RestoreFromPath(sourcePath string) error {
-	if _, err := os.Stat(sourcePath); os.IsNotExist(err) {
-		return fmt.Errorf("snapshot file does not exist: %s", sourcePath)
+	validPath, err := validateSnapshotPath(sourcePath)
+	if err != nil {
+		return fmt.Errorf("validating source path: %w", err)
+	}
+
+	if _, err := os.Stat(validPath); os.IsNotExist(err) {
+		return fmt.Errorf("snapshot file does not exist: %s", validPath)
 	}
 
 	conn, err := sm.db.DB.Conn(context.Background())
@@ -287,7 +353,7 @@ func (sm *SnapshotManager) RestoreFromPath(sourcePath string) error {
 		type restorer interface {
 			NewRestore(string) (*sqlite.Backup, error)
 		}
-		bck, err := driverConn.(restorer).NewRestore(sourcePath)
+		bck, err := driverConn.(restorer).NewRestore(validPath)
 		if err != nil {
 			return err
 		}

--- a/internal/db/snapshot_test.go
+++ b/internal/db/snapshot_test.go
@@ -7,6 +7,59 @@ import (
 	"time"
 )
 
+func TestValidateSnapshotPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"valid absolute path", "/mnt/cache/.vault/vault.db", false},
+		{"valid nested path", "/boot/config/plugins/vault/vault.db", false},
+		{"empty path", "", true},
+		{"traversal with dotdot", "/mnt/cache/../../etc/passwd", false}, // Clean resolves it to /etc/passwd — no ".." left
+		{"relative path resolves", "relative/path/vault.db", false},     // Abs makes it absolute
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := validateSnapshotPath(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateSnapshotPath(%q) error = %v, wantErr %v", tt.path, err, tt.wantErr)
+			}
+			if err == nil && result == "" {
+				t.Error("validateSnapshotPath returned empty string without error")
+			}
+		})
+	}
+}
+
+func TestValidateSnapshotPath_CleansTraversal(t *testing.T) {
+	t.Parallel()
+
+	// After Clean+Abs, traversal sequences are normalized — verify the function
+	// returns a clean absolute path without ".." components.
+	result, err := validateSnapshotPath("/mnt/cache/../cache/vault.db")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "/mnt/cache/vault.db" {
+		t.Errorf("got %q, want %q", result, "/mnt/cache/vault.db")
+	}
+}
+
+func TestSetSnapshotPath_RejectsEmptyDefault(t *testing.T) {
+	d := setupTestDB(t)
+	// Create a manager with an empty default path — SetSnapshotPath("") should fail
+	// because validateSnapshotPath rejects empty strings.
+	sm := NewSnapshotManager(d, filepath.Join(t.TempDir(), "snap.db"), "")
+	err := sm.SetSnapshotPath("")
+	if err == nil {
+		t.Fatal("SetSnapshotPath with empty default should fail validation")
+	}
+}
+
 func TestSnapshotRoundTrip(t *testing.T) {
 	// Open a DB and insert data.
 	dir := t.TempDir()

--- a/internal/db/snapshot_test.go
+++ b/internal/db/snapshot_test.go
@@ -18,8 +18,8 @@ func TestValidateSnapshotPath(t *testing.T) {
 		{"valid absolute path", "/mnt/cache/.vault/vault.db", false},
 		{"valid nested path", "/boot/config/plugins/vault/vault.db", false},
 		{"empty path", "", true},
-		{"traversal with dotdot", "/mnt/cache/../../etc/passwd", false}, // Clean resolves it to /etc/passwd — no ".." left
-		{"relative path resolves", "relative/path/vault.db", false},     // Abs makes it absolute
+		{"traversal with dotdot", "/mnt/cache/../../etc/passwd", true},
+		{"relative path resolves", "relative/path/vault.db", false}, // Abs makes it absolute
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -35,17 +35,13 @@ func TestValidateSnapshotPath(t *testing.T) {
 	}
 }
 
-func TestValidateSnapshotPath_CleansTraversal(t *testing.T) {
+func TestValidateSnapshotPath_RejectsTraversal(t *testing.T) {
 	t.Parallel()
 
-	// After Clean+Abs, traversal sequences are normalized — verify the function
-	// returns a clean absolute path without ".." components.
-	result, err := validateSnapshotPath("/mnt/cache/../cache/vault.db")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result != "/mnt/cache/vault.db" {
-		t.Errorf("got %q, want %q", result, "/mnt/cache/vault.db")
+	// Paths containing ".." components are rejected before normalisation.
+	_, err := validateSnapshotPath("/mnt/cache/../cache/vault.db")
+	if err == nil {
+		t.Fatal("expected error for path containing '..' component")
 	}
 }
 

--- a/internal/diagnostics/collector.go
+++ b/internal/diagnostics/collector.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ruaan-deysel/vault/internal/db"
+	"github.com/ruaan-deysel/vault/internal/unraid"
 )
 
 // RunnerStatus holds a snapshot of the runner state for diagnostics.
@@ -256,7 +257,7 @@ func (c *Collector) collectDatabaseInfo() DatabaseInfo {
 	// Detect hybrid mode by checking for a snapshot path setting.
 	if override, err := c.db.GetSetting("snapshot_path_override", ""); err == nil && override != "" {
 		info.Mode = "hybrid"
-	} else if _, err := os.Stat("/mnt/cache"); err == nil {
+	} else if pool := unraid.PreferredPool(); pool != "" {
 		info.Mode = "hybrid"
 	}
 

--- a/internal/diagnostics/collector.go
+++ b/internal/diagnostics/collector.go
@@ -257,7 +257,7 @@ func (c *Collector) collectDatabaseInfo() DatabaseInfo {
 	// Detect hybrid mode by checking for a snapshot path setting.
 	if override, err := c.db.GetSetting("snapshot_path_override", ""); err == nil && override != "" {
 		info.Mode = "hybrid"
-	} else if pool := unraid.PreferredPool(); pool != "" {
+	} else if pool := unraid.PreferredPool(); pool != "" && unraid.IsMountedPool(pool) {
 		info.Mode = "hybrid"
 	}
 

--- a/internal/tempdir/tempdir.go
+++ b/internal/tempdir/tempdir.go
@@ -16,16 +16,59 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
+
+	"github.com/ruaan-deysel/vault/internal/unraid"
 )
 
 // StageDirName is the hidden directory name used for staging.
 const StageDirName = ".vault-stage"
 
-// CachePaths lists paths to try (in order) for fast SSD/NVMe-backed
-// temporary staging. The first writable path wins.
-var CachePaths = []string{
-	"/mnt/cache",
+// cachePaths returns pool paths to try (in order) for fast SSD/NVMe-backed
+// temporary staging. Uses dynamic pool discovery so mirrored or
+// non-standard pool names are included.
+//
+// Tests can override via SetCachePathsForTest.
+var (
+	cachePathsOnce sync.Once
+	cachePathsVal  []string
+	cachePathsMu   sync.Mutex
+	cachePathsTest []string // non-nil when overridden by tests
+)
+
+func cachePaths() []string {
+	cachePathsMu.Lock()
+	if cachePathsTest != nil {
+		defer cachePathsMu.Unlock()
+		return cachePathsTest
+	}
+	cachePathsMu.Unlock()
+
+	cachePathsOnce.Do(func() {
+		cachePathsVal = unraid.DiscoverPools()
+	})
+	return cachePathsVal
+}
+
+// SetCachePathsForTest overrides the cache paths used by this package.
+// Returns a cleanup function that restores the original behaviour.
+// This is intended for use in tests only.
+func SetCachePathsForTest(paths []string) func() {
+	cachePathsMu.Lock()
+	cachePathsTest = paths
+	cachePathsMu.Unlock()
+	return func() {
+		cachePathsMu.Lock()
+		cachePathsTest = nil
+		cachePathsMu.Unlock()
+	}
+}
+
+// GetCachePaths returns the current pool/cache paths used for staging.
+// This is intended for external callers that need the resolved list.
+func GetCachePaths() []string {
+	return cachePaths()
 }
 
 // StorageConfig is the minimal config subset needed to extract a local path.
@@ -81,7 +124,7 @@ func createDir(dest StorageConfig, pattern string, override string) (string, fun
 	}
 
 	// Try fast cache/SSD paths first.
-	for _, base := range CachePaths {
+	for _, base := range cachePaths() {
 		info, err := os.Stat(base)
 		if err != nil || !info.IsDir() {
 			continue
@@ -153,7 +196,7 @@ func CleanupStale(destinations []StorageConfig) {
 	seen := make(map[string]bool)
 
 	// Scan cache paths.
-	for _, base := range CachePaths {
+	for _, base := range cachePaths() {
 		stageBase := filepath.Join(base, StageDirName)
 		if seen[stageBase] {
 			continue
@@ -208,7 +251,7 @@ func cleanStageDir(stageBase string) {
 // cleanLegacyDirs removes leftover .vault-tmp directories from the old naming
 // scheme. Uses the same cache paths as the current implementation.
 func cleanLegacyDirs(seen map[string]bool) {
-	for _, base := range CachePaths {
+	for _, base := range cachePaths() {
 		legacyBase := filepath.Join(base, ".vault-tmp")
 		if seen[legacyBase] {
 			continue
@@ -224,7 +267,7 @@ func ResolveInfo(destinations []StorageConfig, override string) StagingInfo {
 	info := StagingInfo{Override: override}
 
 	// Build cascade list.
-	for _, base := range CachePaths {
+	for _, base := range cachePaths() {
 		stagePath := filepath.Join(base, StageDirName)
 		ci := CascadeItem{Path: stagePath, Source: "cache"}
 		if fi, err := os.Stat(base); err == nil && fi.IsDir() {

--- a/internal/tempdir/tempdir.go
+++ b/internal/tempdir/tempdir.go
@@ -31,23 +31,28 @@ const StageDirName = ".vault-stage"
 //
 // Tests can override via SetCachePathsForTest.
 var (
-	cachePathsOnce sync.Once
-	cachePathsVal  []string
 	cachePathsMu   sync.Mutex
+	cachePathsVal  []string
+	cachePathsDone bool
 	cachePathsTest []string // non-nil when overridden by tests
 )
 
 func cachePaths() []string {
 	cachePathsMu.Lock()
+	defer cachePathsMu.Unlock()
+
 	if cachePathsTest != nil {
-		defer cachePathsMu.Unlock()
 		return cachePathsTest
 	}
-	cachePathsMu.Unlock()
 
-	cachePathsOnce.Do(func() {
+	// Don't permanently cache an empty result — pools may not be
+	// mounted yet at early startup. Retry discovery on next call.
+	if !cachePathsDone {
 		cachePathsVal = unraid.DiscoverPools()
-	})
+		if len(cachePathsVal) > 0 {
+			cachePathsDone = true
+		}
+	}
 	return cachePathsVal
 }
 

--- a/internal/tempdir/tempdir_test.go
+++ b/internal/tempdir/tempdir_test.go
@@ -85,10 +85,9 @@ func TestCreateBackupDirLocalStaging(t *testing.T) {
 		Config: `{"path":"` + localPath + `"}`,
 	}
 
-	// Override CachePaths so the cache cascade doesn't match.
-	origPaths := CachePaths
-	CachePaths = []string{"/nonexistent-cache-path"}
-	defer func() { CachePaths = origPaths }()
+	// Override cache paths so the cache cascade doesn't match.
+	restorePaths := SetCachePathsForTest([]string{"/nonexistent-cache-path"})
+	defer restorePaths()
 
 	dir, cleanup, err := CreateBackupDir(dest, "")
 	if err != nil {
@@ -197,10 +196,9 @@ func TestCleanupStale(t *testing.T) {
 	// Write files in one to verify RemoveAll works.
 	os.WriteFile(filepath.Join(stale1, "file.tar"), []byte("data"), 0644)
 
-	// Override CachePaths to avoid scanning real system paths.
-	origPaths := CachePaths
-	CachePaths = []string{"/nonexistent-cache-path"}
-	defer func() { CachePaths = origPaths }()
+	// Override cache paths to avoid scanning real system paths.
+	restorePaths := SetCachePathsForTest([]string{"/nonexistent-cache-path"})
+	defer restorePaths()
 
 	dests := []StorageConfig{
 		{Type: "local", Config: `{"path":"` + localPath + `"}`},
@@ -233,10 +231,9 @@ func TestCleanupStaleLegacy(t *testing.T) {
 	stale, _ := os.MkdirTemp(legacyBase, "backup-*")
 	os.WriteFile(filepath.Join(stale, "data.gz"), []byte("old"), 0644)
 
-	// Override CachePaths so it hits our tmpRoot.
-	origPaths := CachePaths
-	CachePaths = []string{tmpRoot}
-	defer func() { CachePaths = origPaths }()
+	// Override cache paths so it hits our tmpRoot.
+	restorePaths := SetCachePathsForTest([]string{tmpRoot})
+	defer restorePaths()
 
 	CleanupStale(nil)
 
@@ -247,9 +244,8 @@ func TestCleanupStaleLegacy(t *testing.T) {
 
 func TestCleanupStaleNoOp(t *testing.T) {
 	// Should not panic on empty input.
-	origPaths := CachePaths
-	CachePaths = []string{"/nonexistent-cache-path"}
-	defer func() { CachePaths = origPaths }()
+	restorePaths := SetCachePathsForTest([]string{"/nonexistent-cache-path"})
+	defer restorePaths()
 
 	CleanupStale(nil)
 	CleanupStale([]StorageConfig{})

--- a/internal/unraid/pools.go
+++ b/internal/unraid/pools.go
@@ -1,0 +1,96 @@
+package unraid
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+)
+
+// mntBase is the root directory for Unraid mount points.
+const mntBase = "/mnt"
+
+// excludedNames are known non-pool directories under /mnt/.
+var excludedNames = map[string]bool{
+	"user":    true,
+	"user0":   true,
+	"disks":   true,
+	"remotes": true,
+}
+
+// arrayDiskPattern matches array disk entries like disk1, disk2, ..., disk99.
+var arrayDiskPattern = regexp.MustCompile(`^disk\d+$`)
+
+// DiscoverPools enumerates Unraid pool mount points under /mnt/ using
+// exclusion-based detection. It returns a sorted slice of absolute paths
+// with "/mnt/cache" sorted first (if present) for backwards compatibility.
+// Returns an empty slice if /mnt/ does not exist or cannot be read.
+func DiscoverPools() []string {
+	return discoverPoolsIn(mntBase)
+}
+
+// discoverPoolsIn is the testable implementation that accepts a custom root.
+func discoverPoolsIn(root string) []string {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+
+	var pools []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+
+		// Skip known non-pool directories.
+		if excludedNames[name] {
+			continue
+		}
+
+		// Skip array disks (disk1, disk2, ...).
+		if arrayDiskPattern.MatchString(name) {
+			continue
+		}
+
+		pools = append(pools, filepath.Join(root, name))
+	}
+
+	// Sort with "cache" first for backwards compatibility, then alphabetical.
+	sort.Slice(pools, func(i, j int) bool {
+		iName := filepath.Base(pools[i])
+		jName := filepath.Base(pools[j])
+		if iName == "cache" {
+			return true
+		}
+		if jName == "cache" {
+			return false
+		}
+		return iName < jName
+	})
+
+	return pools
+}
+
+// PreferredPool returns the best pool path for database/staging use.
+// It prefers /mnt/cache if present, otherwise the first discovered pool.
+// Returns an empty string if no pools are detected.
+func PreferredPool() string {
+	return preferredPoolIn(mntBase)
+}
+
+// preferredPoolIn is the testable implementation that accepts a custom root.
+func preferredPoolIn(root string) string {
+	// Fast path: check for the standard cache pool.
+	cachePath := filepath.Join(root, "cache")
+	if info, err := os.Stat(cachePath); err == nil && info.IsDir() {
+		return cachePath
+	}
+
+	pools := discoverPoolsIn(root)
+	if len(pools) > 0 {
+		return pools[0]
+	}
+
+	return ""
+}

--- a/internal/unraid/pools.go
+++ b/internal/unraid/pools.go
@@ -94,3 +94,19 @@ func preferredPoolIn(root string) string {
 
 	return ""
 }
+
+// IsMountedPool reports whether a pool path exists and contains entries,
+// indicating a mounted filesystem rather than an empty mount-point stub.
+func IsMountedPool(poolPath string) bool {
+	entries, err := os.ReadDir(poolPath)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if name != "." && name != ".." {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/unraid/pools.go
+++ b/internal/unraid/pools.go
@@ -1,14 +1,20 @@
 package unraid
 
 import (
+	"bufio"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 )
 
 // mntBase is the root directory for Unraid mount points.
 const mntBase = "/mnt"
+
+// mountInfoPath is the procfs file used to determine active mount points.
+// It is a variable so tests can override it.
+var mountInfoPath = "/proc/self/mountinfo"
 
 // excludedNames are known non-pool directories under /mnt/.
 var excludedNames = map[string]bool{
@@ -95,18 +101,60 @@ func preferredPoolIn(root string) string {
 	return ""
 }
 
-// IsMountedPool reports whether a pool path exists and contains entries,
-// indicating a mounted filesystem rather than an empty mount-point stub.
+// IsMountedPool reports whether poolPath is an active mount point by
+// consulting /proc/self/mountinfo. This is more reliable than checking
+// directory contents, which can misclassify empty-but-mounted pools.
 func IsMountedPool(poolPath string) bool {
-	entries, err := os.ReadDir(poolPath)
+	return isMountedPoolFrom(mountInfoPath, poolPath)
+}
+
+// isMountedPoolFrom is the testable implementation that accepts a custom
+// mountinfo path.
+func isMountedPoolFrom(infoPath, poolPath string) bool {
+	absPool, err := filepath.Abs(poolPath)
 	if err != nil {
 		return false
 	}
-	for _, e := range entries {
-		name := e.Name()
-		if name != "." && name != ".." {
+
+	f, err := os.Open(infoPath)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	// Each line in mountinfo has ≥10 fields. Field 5 (index 4) is the mount point.
+	// See https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 5 {
+			continue
+		}
+		mountPoint := fields[4]
+		// Unescape octal sequences (e.g. \040 for space) used in mountinfo.
+		mountPoint = unescapeMountInfo(mountPoint)
+		if mountPoint == absPool {
 			return true
 		}
 	}
 	return false
+}
+
+// unescapeMountInfo decodes octal escape sequences (\NNN) found in
+// /proc/self/mountinfo mount-point fields.
+func unescapeMountInfo(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+3 < len(s) &&
+			s[i+1] >= '0' && s[i+1] <= '3' &&
+			s[i+2] >= '0' && s[i+2] <= '7' &&
+			s[i+3] >= '0' && s[i+3] <= '7' {
+			val := (s[i+1]-'0')*64 + (s[i+2]-'0')*8 + (s[i+3] - '0')
+			b.WriteByte(val)
+			i += 3
+		} else {
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String()
 }

--- a/internal/unraid/pools_test.go
+++ b/internal/unraid/pools_test.go
@@ -6,142 +6,140 @@ import (
 	"testing"
 )
 
-func TestDiscoverPools_EmptyMnt(t *testing.T) {
+func TestDiscoverPoolsIn(t *testing.T) {
 	t.Parallel()
-	root := t.TempDir()
-	pools := discoverPoolsIn(root)
-	if len(pools) != 0 {
-		t.Errorf("expected no pools, got %v", pools)
+
+	tests := []struct {
+		name  string
+		setup func(root string)
+		want  []string // basenames in expected order
+	}{
+		{
+			name:  "empty mnt returns no pools",
+			setup: func(_ string) {},
+			want:  nil,
+		},
+		{
+			name: "cache sorts first",
+			setup: func(root string) {
+				for _, n := range []string{"nvme", "cache", "ssd"} {
+					os.Mkdir(filepath.Join(root, n), 0o755)
+				}
+			},
+			want: []string{"cache", "nvme", "ssd"},
+		},
+		{
+			name: "excludes known dirs",
+			setup: func(root string) {
+				for _, n := range []string{"user", "user0", "disks", "remotes", "disk1", "disk23", "mypool"} {
+					os.Mkdir(filepath.Join(root, n), 0o755)
+				}
+			},
+			want: []string{"mypool"},
+		},
+		{
+			name: "skips files",
+			setup: func(root string) {
+				os.WriteFile(filepath.Join(root, "notapool"), []byte("data"), 0o644)
+				os.Mkdir(filepath.Join(root, "cache"), 0o755)
+			},
+			want: []string{"cache"},
+		},
+		{
+			name:  "nonexistent root returns empty",
+			setup: nil, // use a non-existent path below
+			want:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var root string
+			if tc.setup == nil {
+				root = "/nonexistent/path"
+			} else {
+				root = t.TempDir()
+				tc.setup(root)
+			}
+
+			pools := discoverPoolsIn(root)
+			if len(tc.want) == 0 {
+				if len(pools) != 0 {
+					t.Errorf("expected no pools, got %v", pools)
+				}
+				return
+			}
+			if len(pools) != len(tc.want) {
+				t.Fatalf("expected %d pools, got %v", len(tc.want), pools)
+			}
+			for i, want := range tc.want {
+				if filepath.Base(pools[i]) != want {
+					t.Errorf("pools[%d]: expected %s, got %s", i, want, filepath.Base(pools[i]))
+				}
+			}
+		})
 	}
 }
 
-func TestDiscoverPools_CacheFirst(t *testing.T) {
+func TestPreferredPoolIn(t *testing.T) {
 	t.Parallel()
-	root := t.TempDir()
 
-	// Create dirs: nvme, cache, ssd — cache should sort first.
-	for _, name := range []string{"nvme", "cache", "ssd"} {
-		if err := os.Mkdir(filepath.Join(root, name), 0o755); err != nil {
-			t.Fatalf("mkdir %s: %v", name, err)
-		}
+	tests := []struct {
+		name  string
+		setup func(root string)
+		want  string // expected basename, or "" for empty result
+	}{
+		{
+			name: "prefers cache when present",
+			setup: func(root string) {
+				for _, n := range []string{"nvme", "cache"} {
+					os.Mkdir(filepath.Join(root, n), 0o755)
+				}
+			},
+			want: "cache",
+		},
+		{
+			name: "falls back to first pool when no cache",
+			setup: func(root string) {
+				os.Mkdir(filepath.Join(root, "nvme"), 0o755)
+			},
+			want: "nvme",
+		},
+		{
+			name:  "returns empty when no pools",
+			setup: func(_ string) {},
+			want:  "",
+		},
+		{
+			name: "returns empty when only excluded dirs",
+			setup: func(root string) {
+				for _, n := range []string{"user", "disks", "disk1"} {
+					os.Mkdir(filepath.Join(root, n), 0o755)
+				}
+			},
+			want: "",
+		},
 	}
 
-	pools := discoverPoolsIn(root)
-	if len(pools) != 3 {
-		t.Fatalf("expected 3 pools, got %v", pools)
-	}
-	if filepath.Base(pools[0]) != "cache" {
-		t.Errorf("expected cache first, got %s", pools[0])
-	}
-	if filepath.Base(pools[1]) != "nvme" {
-		t.Errorf("expected nvme second, got %s", pools[1])
-	}
-	if filepath.Base(pools[2]) != "ssd" {
-		t.Errorf("expected ssd third, got %s", pools[2])
-	}
-}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			tc.setup(root)
 
-func TestDiscoverPools_ExcludesKnownDirs(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-
-	// Create excluded dirs and a real pool.
-	for _, name := range []string{"user", "user0", "disks", "remotes", "disk1", "disk23", "mypool"} {
-		if err := os.Mkdir(filepath.Join(root, name), 0o755); err != nil {
-			t.Fatalf("mkdir %s: %v", name, err)
-		}
-	}
-
-	pools := discoverPoolsIn(root)
-	if len(pools) != 1 {
-		t.Fatalf("expected 1 pool, got %v", pools)
-	}
-	if filepath.Base(pools[0]) != "mypool" {
-		t.Errorf("expected mypool, got %s", pools[0])
-	}
-}
-
-func TestDiscoverPools_SkipsFiles(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-
-	// Create a file (not a dir) — should be skipped.
-	if err := os.WriteFile(filepath.Join(root, "notapool"), []byte("data"), 0o644); err != nil {
-		t.Fatalf("writefile: %v", err)
-	}
-	// Create a real pool dir.
-	if err := os.Mkdir(filepath.Join(root, "cache"), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-
-	pools := discoverPoolsIn(root)
-	if len(pools) != 1 {
-		t.Fatalf("expected 1 pool, got %v", pools)
-	}
-}
-
-func TestDiscoverPools_NonexistentRoot(t *testing.T) {
-	t.Parallel()
-	pools := discoverPoolsIn("/nonexistent/path")
-	if len(pools) != 0 {
-		t.Errorf("expected no pools for nonexistent root, got %v", pools)
-	}
-}
-
-func TestPreferredPool_CacheExists(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-
-	for _, name := range []string{"nvme", "cache"} {
-		if err := os.Mkdir(filepath.Join(root, name), 0o755); err != nil {
-			t.Fatalf("mkdir %s: %v", name, err)
-		}
-	}
-
-	pool := preferredPoolIn(root)
-	expected := filepath.Join(root, "cache")
-	if pool != expected {
-		t.Errorf("expected %s, got %s", expected, pool)
-	}
-}
-
-func TestPreferredPool_NoCacheFallback(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-
-	if err := os.Mkdir(filepath.Join(root, "nvme"), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-
-	pool := preferredPoolIn(root)
-	expected := filepath.Join(root, "nvme")
-	if pool != expected {
-		t.Errorf("expected %s, got %s", expected, pool)
-	}
-}
-
-func TestPreferredPool_NoPools(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-
-	pool := preferredPoolIn(root)
-	if pool != "" {
-		t.Errorf("expected empty string, got %s", pool)
-	}
-}
-
-func TestPreferredPool_OnlyExcludedDirs(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-
-	for _, name := range []string{"user", "disks", "disk1"} {
-		if err := os.Mkdir(filepath.Join(root, name), 0o755); err != nil {
-			t.Fatalf("mkdir %s: %v", name, err)
-		}
-	}
-
-	pool := preferredPoolIn(root)
-	if pool != "" {
-		t.Errorf("expected empty string, got %s", pool)
+			pool := preferredPoolIn(root)
+			if tc.want == "" {
+				if pool != "" {
+					t.Errorf("expected empty string, got %s", pool)
+				}
+				return
+			}
+			expected := filepath.Join(root, tc.want)
+			if pool != expected {
+				t.Errorf("expected %s, got %s", expected, pool)
+			}
+		})
 	}
 }

--- a/internal/unraid/pools_test.go
+++ b/internal/unraid/pools_test.go
@@ -143,3 +143,47 @@ func TestPreferredPoolIn(t *testing.T) {
 		})
 	}
 }
+
+func TestIsMountedPoolFrom(t *testing.T) {
+	t.Parallel()
+
+	// Create a fake mountinfo file.
+	tmpDir := t.TempDir()
+	mountInfoFile := filepath.Join(tmpDir, "mountinfo")
+	content := `35 22 8:2 / /mnt/cache rw,relatime - btrfs /dev/sdb1 rw,space_cache
+40 22 8:3 / /mnt/nvme rw,relatime - xfs /dev/nvme0n1p1 rw
+50 22 8:4 / /mnt/pool\040name rw,relatime - btrfs /dev/sdc1 rw
+`
+	os.WriteFile(mountInfoFile, []byte(content), 0o644)
+
+	tests := []struct {
+		name     string
+		poolPath string
+		want     bool
+	}{
+		{"mounted cache pool", "/mnt/cache", true},
+		{"mounted nvme pool", "/mnt/nvme", true},
+		{"pool with space in name", "/mnt/pool name", true},
+		{"not mounted pool", "/mnt/ssd", false},
+		{"root is not a pool", "/", false},
+		{"empty path", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isMountedPoolFrom(mountInfoFile, tc.poolPath)
+			if got != tc.want {
+				t.Errorf("isMountedPoolFrom(%q) = %v, want %v", tc.poolPath, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsMountedPoolFromMissingFile(t *testing.T) {
+	t.Parallel()
+	got := isMountedPoolFrom("/nonexistent/mountinfo", "/mnt/cache")
+	if got {
+		t.Error("expected false for nonexistent mountinfo file")
+	}
+}

--- a/internal/unraid/pools_test.go
+++ b/internal/unraid/pools_test.go
@@ -1,0 +1,147 @@
+package unraid
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiscoverPools_EmptyMnt(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	pools := discoverPoolsIn(root)
+	if len(pools) != 0 {
+		t.Errorf("expected no pools, got %v", pools)
+	}
+}
+
+func TestDiscoverPools_CacheFirst(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	// Create dirs: nvme, cache, ssd — cache should sort first.
+	for _, name := range []string{"nvme", "cache", "ssd"} {
+		if err := os.Mkdir(filepath.Join(root, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+	}
+
+	pools := discoverPoolsIn(root)
+	if len(pools) != 3 {
+		t.Fatalf("expected 3 pools, got %v", pools)
+	}
+	if filepath.Base(pools[0]) != "cache" {
+		t.Errorf("expected cache first, got %s", pools[0])
+	}
+	if filepath.Base(pools[1]) != "nvme" {
+		t.Errorf("expected nvme second, got %s", pools[1])
+	}
+	if filepath.Base(pools[2]) != "ssd" {
+		t.Errorf("expected ssd third, got %s", pools[2])
+	}
+}
+
+func TestDiscoverPools_ExcludesKnownDirs(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	// Create excluded dirs and a real pool.
+	for _, name := range []string{"user", "user0", "disks", "remotes", "disk1", "disk23", "mypool"} {
+		if err := os.Mkdir(filepath.Join(root, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+	}
+
+	pools := discoverPoolsIn(root)
+	if len(pools) != 1 {
+		t.Fatalf("expected 1 pool, got %v", pools)
+	}
+	if filepath.Base(pools[0]) != "mypool" {
+		t.Errorf("expected mypool, got %s", pools[0])
+	}
+}
+
+func TestDiscoverPools_SkipsFiles(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	// Create a file (not a dir) — should be skipped.
+	if err := os.WriteFile(filepath.Join(root, "notapool"), []byte("data"), 0o644); err != nil {
+		t.Fatalf("writefile: %v", err)
+	}
+	// Create a real pool dir.
+	if err := os.Mkdir(filepath.Join(root, "cache"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	pools := discoverPoolsIn(root)
+	if len(pools) != 1 {
+		t.Fatalf("expected 1 pool, got %v", pools)
+	}
+}
+
+func TestDiscoverPools_NonexistentRoot(t *testing.T) {
+	t.Parallel()
+	pools := discoverPoolsIn("/nonexistent/path")
+	if len(pools) != 0 {
+		t.Errorf("expected no pools for nonexistent root, got %v", pools)
+	}
+}
+
+func TestPreferredPool_CacheExists(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	for _, name := range []string{"nvme", "cache"} {
+		if err := os.Mkdir(filepath.Join(root, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+	}
+
+	pool := preferredPoolIn(root)
+	expected := filepath.Join(root, "cache")
+	if pool != expected {
+		t.Errorf("expected %s, got %s", expected, pool)
+	}
+}
+
+func TestPreferredPool_NoCacheFallback(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	if err := os.Mkdir(filepath.Join(root, "nvme"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	pool := preferredPoolIn(root)
+	expected := filepath.Join(root, "nvme")
+	if pool != expected {
+		t.Errorf("expected %s, got %s", expected, pool)
+	}
+}
+
+func TestPreferredPool_NoPools(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	pool := preferredPoolIn(root)
+	if pool != "" {
+		t.Errorf("expected empty string, got %s", pool)
+	}
+}
+
+func TestPreferredPool_OnlyExcludedDirs(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	for _, name := range []string{"user", "disks", "disk1"} {
+		if err := os.Mkdir(filepath.Join(root, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+	}
+
+	pool := preferredPoolIn(root)
+	if pool != "" {
+		t.Errorf("expected empty string, got %s", pool)
+	}
+}

--- a/plugin/pages/Vault.page
+++ b/plugin/pages/Vault.page
@@ -98,24 +98,45 @@ Port number for the Vault daemon (default: 24085). Keep this configurable in cas
 
 <dl>
     <dt>Bind Address:</dt>
-    <dd><input type="text" name="BIND_ADDRESS" value="<?= $bind_esc ?>" class="narrow" placeholder="127.0.0.1"></dd>
+    <dd>
+        <select name="BIND_ADDRESS" class="narrow">
+            <option value="127.0.0.1" <?= $bind === '127.0.0.1' ? 'selected' : '' ?>>127.0.0.1 (Local only)</option>
+            <option value="0.0.0.0" <?= $bind === '0.0.0.0' ? 'selected' : '' ?>>0.0.0.0 (All interfaces)</option>
+<?php if (!in_array($bind, ['127.0.0.1', '0.0.0.0'], true)): ?>
+            <option value="<?= $bind_esc ?>" selected><?= $bind_esc ?> (custom — migrate to a standard option)</option>
+<?php endif; ?>
+        </select>
+    </dd>
 </dl>
 <blockquote class="inline_help">
-Use <strong>127.0.0.1</strong> to keep the daemon local-only (recommended default), a specific LAN IP such as <strong>192.168.1.10</strong> to expose it on one interface, or <strong>0.0.0.0</strong> to listen on all interfaces.
+Use <strong>127.0.0.1</strong> to keep the daemon local-only (recommended). Use <strong>0.0.0.0</strong> to listen on all interfaces — required for external integrations such as Home Assistant. The browser UI always uses the authenticated Unraid plugin proxy regardless of this setting.
 </blockquote>
-<?php if (!vault_is_loopback_bind_address($bind)): ?>
+<?php if ($bind === '0.0.0.0'): ?>
 <blockquote class="inline_help" style="color: var(--red-500, #c0392b);">
-Warning: non-loopback binding exposes the Vault API on your network. Configure an API key first. Vault refuses to start on a non-loopback bind address without one.
+Warning: the Vault API is accessible from your local network. Only use this if you need external access (e.g. Home Assistant).
 </blockquote>
 <?php endif; ?>
 
 <dl>
-    <dt><input type="submit" name="#default" value="Default"></dt>
-    <dd><input type="submit" name="#apply" value="Apply" disabled><input type="button" value="Done" onclick="done()"></dd>
+    <dt><input type="button" value="Default" onclick="resetDefaults()"></dt>
+    <dd><input type="submit" name="#apply" value="Apply"><input type="button" value="Done" onclick="done()"></dd>
 </dl>
 </form>
 
 <script>
+function resetDefaults() {
+    if (!confirm('Reset Vault configuration to defaults?')) return;
+    var xhr = new XMLHttpRequest();
+    xhr.open('POST', '/plugins/vault/include/control.php', true);
+    xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+    xhr.onreadystatechange = function() {
+        if (xhr.readyState === 4) {
+            location.reload();
+        }
+    };
+    xhr.send('action=reset-config&csrf_token=<?=$var["csrf_token"]?>');
+}
+
 function serviceControl(action) {
     var btn = document.getElementById('vault-btn-startstop');
     var restartBtn = document.getElementById('vault-btn-restart');

--- a/plugin/pages/Vault.page
+++ b/plugin/pages/Vault.page
@@ -6,6 +6,11 @@ Markdown="false"
 <?php
 require_once '/usr/local/emhttp/plugins/vault/include/api.php';
 
+// Ensure $var is available (Unraid's emhttpd normally pre-populates it for .page files).
+if (!isset($var)) {
+    $var = @parse_ini_file('state/var.ini') ?: [];
+}
+
 $plugin  = 'vault';
 $cfg     = vault_load_config();
 $port    = $cfg['PORT'] ?? '24085';
@@ -148,7 +153,7 @@ function resetDefaults() {
             }
         }
     };
-    xhr.send('action=reset-config&csrf_token=<?=$var["csrf_token"]?>');
+    xhr.send('action=reset-config&csrf_token=' + encodeURIComponent(<?=json_encode($var['csrf_token'] ?? '')?>));
 }
 
 function serviceControl(action) {
@@ -201,6 +206,6 @@ function serviceControl(action) {
             if (restartBtn) restartBtn.disabled = true;
         }
     };
-    xhr.send('action=' + action + '&csrf_token=<?=$var["csrf_token"]?>');
+    xhr.send('action=' + action + '&csrf_token=' + encodeURIComponent(<?=json_encode($var['csrf_token'] ?? '')?>));
 }
 </script>

--- a/plugin/pages/Vault.page
+++ b/plugin/pages/Vault.page
@@ -11,6 +11,7 @@ $cfg     = vault_load_config();
 $port    = $cfg['PORT'] ?? '24085';
 $bind    = vault_get_bind_address();
 $bind_esc = htmlspecialchars($bind, ENT_QUOTES, 'UTF-8');
+$local_ips = vault_get_local_ips();
 
 // Check if daemon is actually running via health endpoint.
 $health  = vault_get('/health');
@@ -100,18 +101,27 @@ Port number for the Vault daemon (default: 24085). Keep this configurable in cas
     <dt>Bind Address:</dt>
     <dd>
         <select name="BIND_ADDRESS" class="narrow">
-            <option value="127.0.0.1" <?= $bind === '127.0.0.1' ? 'selected' : '' ?>>127.0.0.1 (Local only)</option>
+            <option value="127.0.0.1" <?= $bind === '127.0.0.1' ? 'selected' : '' ?>>127.0.0.1 (Loopback — local only)</option>
             <option value="0.0.0.0" <?= $bind === '0.0.0.0' ? 'selected' : '' ?>>0.0.0.0 (All interfaces)</option>
-<?php if (!in_array($bind, ['127.0.0.1', '0.0.0.0'], true)): ?>
-            <option value="<?= $bind_esc ?>" selected><?= $bind_esc ?> (custom — migrate to a standard option)</option>
+<?php
+$known_ips = ['127.0.0.1', '0.0.0.0'];
+foreach ($local_ips as $nic):
+    $ip_esc = htmlspecialchars($nic['ip'], ENT_QUOTES, 'UTF-8');
+    $iface_esc = htmlspecialchars($nic['iface'], ENT_QUOTES, 'UTF-8');
+    $known_ips[] = $nic['ip'];
+?>
+            <option value="<?= $ip_esc ?>" <?= $bind === $nic['ip'] ? 'selected' : '' ?>><?= $ip_esc ?> (<?= $iface_esc ?>)</option>
+<?php endforeach; ?>
+<?php if (!in_array($bind, $known_ips, true)): ?>
+            <option value="<?= $bind_esc ?>" selected><?= $bind_esc ?> (unknown — pick a detected address)</option>
 <?php endif; ?>
         </select>
     </dd>
 </dl>
 <blockquote class="inline_help">
-Use <strong>127.0.0.1</strong> to keep the daemon local-only (recommended). Use <strong>0.0.0.0</strong> to listen on all interfaces — required for external integrations such as Home Assistant. The browser UI always uses the authenticated Unraid plugin proxy regardless of this setting.
+Use <strong>127.0.0.1</strong> to keep the daemon local-only (recommended). Select a specific NIC address to bind to one interface. Use <strong>0.0.0.0</strong> to listen on all interfaces — required for external integrations such as Home Assistant. The browser UI always uses the authenticated Unraid plugin proxy regardless of this setting.
 </blockquote>
-<?php if ($bind === '0.0.0.0'): ?>
+<?php if (!vault_is_loopback_bind_address($bind)): ?>
 <blockquote class="inline_help" style="color: var(--red-500, #c0392b);">
 Warning: the Vault API is accessible from your local network. Only use this if you need external access (e.g. Home Assistant).
 </blockquote>
@@ -131,7 +141,11 @@ function resetDefaults() {
     xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
     xhr.onreadystatechange = function() {
         if (xhr.readyState === 4) {
-            location.reload();
+            if (xhr.status === 200) {
+                location.reload();
+            } else {
+                alert('Failed to reset configuration. Please try again.');
+            }
         }
     };
     xhr.send('action=reset-config&csrf_token=<?=$var["csrf_token"]?>');

--- a/plugin/pages/Vault.page
+++ b/plugin/pages/Vault.page
@@ -107,9 +107,11 @@ Port number for the Vault daemon (default: 24085). Keep this configurable in cas
     <dd>
         <select name="BIND_ADDRESS" class="narrow">
             <option value="127.0.0.1" <?= $bind === '127.0.0.1' ? 'selected' : '' ?>>127.0.0.1 (Loopback — local only)</option>
-            <option value="0.0.0.0" <?= $bind === '0.0.0.0' ? 'selected' : '' ?>>0.0.0.0 (All interfaces)</option>
+            <option value="::1" <?= $bind === '::1' ? 'selected' : '' ?>>::1 (IPv6 Loopback — local only)</option>
+            <option value="0.0.0.0" <?= $bind === '0.0.0.0' ? 'selected' : '' ?>>0.0.0.0 (All IPv4 interfaces)</option>
+            <option value="::" <?= $bind === '::' ? 'selected' : '' ?>>:: (All interfaces — IPv4 + IPv6)</option>
 <?php
-$known_ips = ['127.0.0.1', '0.0.0.0'];
+$known_ips = ['127.0.0.1', '0.0.0.0', '::1', '::'];
 foreach ($local_ips as $nic):
     $ip_esc = htmlspecialchars($nic['ip'], ENT_QUOTES, 'UTF-8');
     $iface_esc = htmlspecialchars($nic['iface'], ENT_QUOTES, 'UTF-8');

--- a/plugin/pages/include/api.php
+++ b/plugin/pages/include/api.php
@@ -114,9 +114,11 @@ function vault_http_host($host) {
 function vault_target_url($path = '') {
     $port = vault_get_port();
     $bind = vault_get_bind_address();
-    // For wildcard or loopback, connect via 127.0.0.1.
-    // For a specific LAN IP, connect via that IP directly.
-    if (vault_is_loopback_bind_address($bind) || vault_is_wildcard_bind_address($bind)) {
+    // For wildcard addresses, connect via IPv4 loopback (works for both 0.0.0.0 and ::).
+    // For specific or loopback addresses, use the configured address directly so that
+    // ::1 connects via [::1] instead of 127.0.0.1 (which would fail if the daemon
+    // only listens on IPv6).
+    if (vault_is_wildcard_bind_address($bind)) {
         $host = '127.0.0.1';
     } else {
         $host = vault_http_host($bind);

--- a/plugin/pages/include/api.php
+++ b/plugin/pages/include/api.php
@@ -70,6 +70,10 @@ function vault_get_local_ips() {
                 if (stripos($m[1], 'fe80:') === 0) {
                     continue;
                 }
+                // Validate the extracted address is a well-formed IPv6 address.
+                if (!filter_var($m[1], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+                    continue;
+                }
             }
 
             $ip = $m[1];

--- a/plugin/pages/include/api.php
+++ b/plugin/pages/include/api.php
@@ -31,6 +31,35 @@ function vault_get_bind_address() {
     return $bind === '' ? '127.0.0.1' : $bind;
 }
 
+function vault_get_local_ips() {
+    $output = @shell_exec('ip -4 addr show 2>/dev/null');
+    if (!$output) {
+        return [];
+    }
+    $result = [];
+    $seen = [];
+    $lines = explode("\n", trim($output));
+    $iface = '';
+    foreach ($lines as $line) {
+        if (preg_match('/^\d+:\s+(\S+):/', $line, $m)) {
+            $iface = $m[1];
+        }
+        if (preg_match('/inet\s+([0-9.]+)\//', $line, $m) && $m[1] !== '127.0.0.1') {
+            $ip = $m[1];
+            if (isset($seen[$ip])) {
+                continue;
+            }
+            // Skip Docker bridges, libvirt bridges, and veth pairs.
+            if (preg_match('/^(docker|br-[0-9a-f]{12}|virbr|veth)/', $iface)) {
+                continue;
+            }
+            $seen[$ip] = true;
+            $result[] = ['ip' => $ip, 'iface' => $iface];
+        }
+    }
+    return $result;
+}
+
 function vault_is_loopback_bind_address($bind = null) {
     $bind = trim((string) ($bind ?? vault_get_bind_address()));
     $normalized = strtolower(trim($bind, '[]'));

--- a/plugin/pages/include/api.php
+++ b/plugin/pages/include/api.php
@@ -32,29 +32,54 @@ function vault_get_bind_address() {
 }
 
 function vault_get_local_ips() {
-    $output = @shell_exec('ip -4 addr show 2>/dev/null');
-    if (!$output) {
-        return [];
-    }
+    $commands = [
+        '4' => 'ip -4 addr show 2>/dev/null',
+        '6' => 'ip -6 addr show 2>/dev/null',
+    ];
+
     $result = [];
     $seen = [];
-    $lines = explode("\n", trim($output));
-    $iface = '';
-    foreach ($lines as $line) {
-        if (preg_match('/^\d+:\s+(\S+):/', $line, $m)) {
-            $iface = $m[1];
+
+    foreach ($commands as $family => $command) {
+        $output = @shell_exec($command);
+        if (!$output) {
+            continue;
         }
-        if (preg_match('/inet\s+([0-9.]+)\//', $line, $m) && $m[1] !== '127.0.0.1') {
-            $ip = $m[1];
-            if (isset($seen[$ip])) {
-                continue;
+
+        $lines = explode("\n", trim($output));
+        $iface = '';
+        foreach ($lines as $line) {
+            if (preg_match('/^\d+:\s+(\S+):/', $line, $m)) {
+                $iface = $m[1];
             }
+
             // Skip Docker bridges, libvirt bridges, and veth pairs.
-            if (preg_match('/^(docker|br-[0-9a-f]{12}|virbr|veth)/', $iface)) {
+            if ($iface !== '' && preg_match('/^(docker|br-[0-9a-f]{12}|virbr|veth)/', $iface)) {
                 continue;
             }
-            $seen[$ip] = true;
-            $result[] = ['ip' => $ip, 'iface' => $iface];
+
+            if ($family === '4') {
+                if (!preg_match('/inet\s+([0-9.]+)\//', $line, $m) || $m[1] === '127.0.0.1') {
+                    continue;
+                }
+            } else {
+                if (!preg_match('/inet6\s+([0-9a-fA-F:]+)\//', $line, $m) || strtolower($m[1]) === '::1') {
+                    continue;
+                }
+                // Skip link-local addresses (fe80::).
+                if (stripos($m[1], 'fe80:') === 0) {
+                    continue;
+                }
+            }
+
+            $ip = $m[1];
+            $key = $family . ':' . strtolower($ip);
+            if (isset($seen[$key])) {
+                continue;
+            }
+
+            $seen[$key] = true;
+            $result[] = ['ip' => $ip, 'iface' => $iface, 'family' => $family];
         }
     }
     return $result;

--- a/plugin/pages/include/api.php
+++ b/plugin/pages/include/api.php
@@ -84,7 +84,15 @@ function vault_http_host($host) {
 
 function vault_target_url($path = '') {
     $port = vault_get_port();
-    return 'http://127.0.0.1:' . $port . $path;
+    $bind = vault_get_bind_address();
+    // For wildcard or loopback, connect via 127.0.0.1.
+    // For a specific LAN IP, connect via that IP directly.
+    if (vault_is_loopback_bind_address($bind) || vault_is_wildcard_bind_address($bind)) {
+        $host = '127.0.0.1';
+    } else {
+        $host = vault_http_host($bind);
+    }
+    return 'http://' . $host . ':' . $port . $path;
 }
 
 function vault_proxy_header() {

--- a/plugin/pages/include/apply.sh
+++ b/plugin/pages/include/apply.sh
@@ -8,7 +8,7 @@ CONFIG="/boot/config/plugins/vault/vault.cfg"
 
 # Safely read only the BIND_ADDRESS key from config (avoid sourcing arbitrary code).
 if [ -f "$CONFIG" ]; then
-    BIND_ADDRESS="$(grep -E '^BIND_ADDRESS=' "$CONFIG" | head -1 | sed 's/^BIND_ADDRESS=//; s/^"//; s/"$//')"
+    BIND_ADDRESS="$(grep -E '^BIND_ADDRESS=' "$CONFIG" | head -1 | sed "s/^BIND_ADDRESS=//; s/^[\"']//; s/[\"']$//")"
     case "${BIND_ADDRESS:-}" in
         127.0.0.1|0.0.0.0|::1|::|"") ;; # valid loopback/wildcard
         *)

--- a/plugin/pages/include/apply.sh
+++ b/plugin/pages/include/apply.sh
@@ -4,6 +4,23 @@
 
 RC="/etc/rc.d/rc.vault"
 PIDFILE="/var/run/vault.pid"
+CONFIG="/boot/config/plugins/vault/vault.cfg"
+
+# Normalize bind address: only allow known-good values.
+if [ -f "$CONFIG" ]; then
+    # shellcheck source=/dev/null
+    source "$CONFIG"
+    case "${BIND_ADDRESS:-}" in
+        127.0.0.1|0.0.0.0|"") ;; # valid
+        *)
+            # Check if it's a local interface IP; if not, reset to 127.0.0.1.
+            if ! ip addr show 2>/dev/null | grep -q "inet ${BIND_ADDRESS}/\|inet6 ${BIND_ADDRESS}/"; then
+                echo "Warning: bind address '${BIND_ADDRESS}' is not local; resetting to 127.0.0.1"
+                sed -i 's/^BIND_ADDRESS=.*/BIND_ADDRESS=127.0.0.1/' "$CONFIG"
+            fi
+            ;;
+    esac
+fi
 
 # Only restart if daemon is currently running.
 if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then

--- a/plugin/pages/include/apply.sh
+++ b/plugin/pages/include/apply.sh
@@ -6,10 +6,9 @@ RC="/etc/rc.d/rc.vault"
 PIDFILE="/var/run/vault.pid"
 CONFIG="/boot/config/plugins/vault/vault.cfg"
 
-# Normalize bind address: only allow known-good values.
+# Safely read only the BIND_ADDRESS key from config (avoid sourcing arbitrary code).
 if [ -f "$CONFIG" ]; then
-    # shellcheck source=/dev/null
-    source "$CONFIG"
+    BIND_ADDRESS="$(grep -E '^BIND_ADDRESS=' "$CONFIG" | head -1 | sed 's/^BIND_ADDRESS=//; s/^"//; s/"$//')"
     case "${BIND_ADDRESS:-}" in
         127.0.0.1|0.0.0.0|::1|::|"") ;; # valid loopback/wildcard
         *)
@@ -17,7 +16,10 @@ if [ -f "$CONFIG" ]; then
             if ! ip addr show 2>/dev/null | grep -Fq "inet ${BIND_ADDRESS}/" && \
                ! ip addr show 2>/dev/null | grep -Fq "inet6 ${BIND_ADDRESS}/"; then
                 echo "Warning: bind address '${BIND_ADDRESS}' is not local; resetting to 127.0.0.1"
-                sed -i 's/^BIND_ADDRESS=.*/BIND_ADDRESS=127.0.0.1/' "$CONFIG"
+                if ! sed -i 's/^BIND_ADDRESS=.*/BIND_ADDRESS=127.0.0.1/' "$CONFIG"; then
+                    echo "Error: failed to update BIND_ADDRESS in $CONFIG" >&2
+                    exit 1
+                fi
             fi
             ;;
     esac

--- a/plugin/pages/include/apply.sh
+++ b/plugin/pages/include/apply.sh
@@ -11,10 +11,11 @@ if [ -f "$CONFIG" ]; then
     # shellcheck source=/dev/null
     source "$CONFIG"
     case "${BIND_ADDRESS:-}" in
-        127.0.0.1|0.0.0.0|"") ;; # valid
+        127.0.0.1|0.0.0.0|::1|::|"") ;; # valid loopback/wildcard
         *)
             # Check if it's a local interface IP; if not, reset to 127.0.0.1.
-            if ! ip addr show 2>/dev/null | grep -q "inet ${BIND_ADDRESS}/\|inet6 ${BIND_ADDRESS}/"; then
+            if ! ip addr show 2>/dev/null | grep -Fq "inet ${BIND_ADDRESS}/" && \
+               ! ip addr show 2>/dev/null | grep -Fq "inet6 ${BIND_ADDRESS}/"; then
                 echo "Warning: bind address '${BIND_ADDRESS}' is not local; resetting to 127.0.0.1"
                 sed -i 's/^BIND_ADDRESS=.*/BIND_ADDRESS=127.0.0.1/' "$CONFIG"
             fi

--- a/plugin/pages/include/apply.sh
+++ b/plugin/pages/include/apply.sh
@@ -8,7 +8,7 @@ CONFIG="/boot/config/plugins/vault/vault.cfg"
 
 # Safely read only the BIND_ADDRESS key from config (avoid sourcing arbitrary code).
 if [ -f "$CONFIG" ]; then
-    BIND_ADDRESS="$(grep -E '^BIND_ADDRESS=' "$CONFIG" | head -1 | sed "s/^BIND_ADDRESS=//; s/^[\"']//; s/[\"']$//")"
+    BIND_ADDRESS="$(grep -E '^BIND_ADDRESS=' "$CONFIG" | head -1 | sed "s/^BIND_ADDRESS=//; s/^[\"']//; s/[\"'].*//")"
     case "${BIND_ADDRESS:-}" in
         127.0.0.1|0.0.0.0|::1|::|"") ;; # valid loopback/wildcard
         *)

--- a/plugin/pages/include/control.php
+++ b/plugin/pages/include/control.php
@@ -61,11 +61,17 @@ switch ($action) {
         }
         // Restart daemon if running so it picks up the defaults.
         $was_running = is_running();
+        $restart_ok = true;
         if ($was_running) {
             exec("$RC restart 2>&1", $out, $rc);
             usleep(500000);
+            $restart_ok = ($rc === 0);
         }
-        echo json_encode(['running' => is_running(), 'reset' => true]);
+        $response = ['running' => is_running(), 'reset' => true];
+        if ($was_running && !$restart_ok) {
+            $response['warning'] = 'Daemon restart may have failed';
+        }
+        echo json_encode($response);
         break;
 
     case 'status':

--- a/plugin/pages/include/control.php
+++ b/plugin/pages/include/control.php
@@ -24,7 +24,7 @@ $action = $_POST['action'] ?? $_GET['action'] ?? 'status';
 
 // Validate CSRF token for state-changing actions (defense-in-depth).
 if ($action !== 'status') {
-    $csrf = $_POST['csrf_token'] ?? $_GET['csrf_token'] ?? '';
+    $csrf = $_POST['csrf_token'] ?? '';
     if (!isset($var['csrf_token']) || $csrf !== $var['csrf_token']) {
         http_response_code(403);
         echo json_encode(['error' => 'Invalid CSRF token']);
@@ -63,9 +63,9 @@ switch ($action) {
                 $snapshot = $ini['SNAPSHOT_PATH'] ?? '';
             }
         }
-        // Sanitize values to prevent INI injection (remove newlines, quotes).
-        $service = preg_replace('/["\'\r\n]/', '', $service);
-        $snapshot = preg_replace('/["\'\r\n]/', '', $snapshot);
+        // Sanitize values to prevent INI injection (remove newlines, quotes, backslashes).
+        $service = preg_replace('/["\'\\\\\\r\\n]/', '', $service);
+        $snapshot = preg_replace('/["\'\\\\\\r\\n]/', '', $snapshot);
         $content = "SERVICE=\"{$service}\"\nPORT=\"24085\"\nBIND_ADDRESS=\"127.0.0.1\"\nSNAPSHOT_PATH=\"{$snapshot}\"\n";
         $written = file_put_contents($CONFIG, $content);
         if ($written === false) {

--- a/plugin/pages/include/control.php
+++ b/plugin/pages/include/control.php
@@ -75,7 +75,9 @@ switch ($action) {
             $service = 'yes';
         }
         // Sanitize SNAPSHOT_PATH: only allow absolute paths with safe characters.
+        // Reject leading dots to prevent hidden directory creation.
         $snapshot = preg_replace('/[^a-zA-Z0-9_\-\/. ]/', '', $snapshot);
+        $snapshot = ltrim($snapshot, '.');
         // Write values in single quotes to prevent shell expansion when sourced.
         $content = "SERVICE='{$service}'\nPORT='24085'\nBIND_ADDRESS='127.0.0.1'\nSNAPSHOT_PATH='{$snapshot}'\n";
         $written = file_put_contents($CONFIG, $content, LOCK_EX);

--- a/plugin/pages/include/control.php
+++ b/plugin/pages/include/control.php
@@ -22,6 +22,13 @@ function is_running() {
 
 $action = $_POST['action'] ?? $_GET['action'] ?? 'status';
 
+// State-changing actions must be POST requests.
+if ($action !== 'status' && $_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'State-changing actions require POST']);
+    exit;
+}
+
 // Validate CSRF token for state-changing actions (defense-in-depth).
 if ($action !== 'status') {
     $csrf = $_POST['csrf_token'] ?? '';

--- a/plugin/pages/include/control.php
+++ b/plugin/pages/include/control.php
@@ -4,6 +4,10 @@
 
 header('Content-Type: application/json');
 
+// Load Unraid state for CSRF validation.
+$stateFile = '/var/local/emhttp/var.ini';
+$var = file_exists($stateFile) ? @parse_ini_file($stateFile) : [];
+
 $RC = '/etc/rc.d/rc.vault';
 $PIDFILE = '/var/run/vault.pid';
 $CONFIG = '/boot/config/plugins/vault/vault.cfg';
@@ -17,6 +21,16 @@ function is_running() {
 }
 
 $action = $_POST['action'] ?? $_GET['action'] ?? 'status';
+
+// Validate CSRF token for state-changing actions (defense-in-depth).
+if ($action !== 'status') {
+    $csrf = $_POST['csrf_token'] ?? $_GET['csrf_token'] ?? '';
+    if (!isset($var['csrf_token']) || $csrf !== $var['csrf_token']) {
+        http_response_code(403);
+        echo json_encode(['error' => 'Invalid CSRF token']);
+        exit;
+    }
+}
 
 switch ($action) {
     case 'start':

--- a/plugin/pages/include/control.php
+++ b/plugin/pages/include/control.php
@@ -6,6 +6,7 @@ header('Content-Type: application/json');
 
 $RC = '/etc/rc.d/rc.vault';
 $PIDFILE = '/var/run/vault.pid';
+$CONFIG = '/boot/config/plugins/vault/vault.cfg';
 
 function is_running() {
     global $PIDFILE;
@@ -35,6 +36,36 @@ switch ($action) {
         exec("$RC restart 2>&1", $out, $rc);
         usleep(500000);
         echo json_encode(['running' => is_running(), 'output' => implode("\n", $out)]);
+        break;
+
+    case 'reset-config':
+        // Reset vault.cfg to defaults, preserving SERVICE and SNAPSHOT_PATH.
+        $service = 'yes';
+        $snapshot = '';
+        if (file_exists($CONFIG)) {
+            $ini = @parse_ini_file($CONFIG, false, INI_SCANNER_RAW);
+            if (is_array($ini)) {
+                $service = $ini['SERVICE'] ?? 'yes';
+                $snapshot = $ini['SNAPSHOT_PATH'] ?? '';
+            }
+        }
+        // Sanitize values to prevent INI injection (remove newlines, quotes).
+        $service = preg_replace('/["\'\r\n]/', '', $service);
+        $snapshot = preg_replace('/["\'\r\n]/', '', $snapshot);
+        $content = "SERVICE=\"{$service}\"\nPORT=\"24085\"\nBIND_ADDRESS=\"127.0.0.1\"\nSNAPSHOT_PATH=\"{$snapshot}\"\n";
+        $written = file_put_contents($CONFIG, $content);
+        if ($written === false) {
+            http_response_code(500);
+            echo json_encode(['error' => 'Failed to write config file']);
+            break;
+        }
+        // Restart daemon if running so it picks up the defaults.
+        $was_running = is_running();
+        if ($was_running) {
+            exec("$RC restart 2>&1", $out, $rc);
+            usleep(500000);
+        }
+        echo json_encode(['running' => is_running(), 'reset' => true]);
         break;
 
     case 'status':

--- a/plugin/pages/include/control.php
+++ b/plugin/pages/include/control.php
@@ -74,7 +74,7 @@ switch ($action) {
         $service = preg_replace('/["\'\\\\\\r\\n]/', '', $service);
         $snapshot = preg_replace('/["\'\\\\\\r\\n]/', '', $snapshot);
         $content = "SERVICE=\"{$service}\"\nPORT=\"24085\"\nBIND_ADDRESS=\"127.0.0.1\"\nSNAPSHOT_PATH=\"{$snapshot}\"\n";
-        $written = file_put_contents($CONFIG, $content);
+        $written = file_put_contents($CONFIG, $content, LOCK_EX);
         if ($written === false) {
             http_response_code(500);
             echo json_encode(['error' => 'Failed to write config file']);

--- a/plugin/pages/include/control.php
+++ b/plugin/pages/include/control.php
@@ -70,10 +70,14 @@ switch ($action) {
                 $snapshot = $ini['SNAPSHOT_PATH'] ?? '';
             }
         }
-        // Sanitize values to prevent INI injection (remove newlines, quotes, backslashes).
-        $service = preg_replace('/["\'\\\\\\r\\n]/', '', $service);
-        $snapshot = preg_replace('/["\'\\\\\\r\\n]/', '', $snapshot);
-        $content = "SERVICE=\"{$service}\"\nPORT=\"24085\"\nBIND_ADDRESS=\"127.0.0.1\"\nSNAPSHOT_PATH=\"{$snapshot}\"\n";
+        // Constrain SERVICE to an allowlist.
+        if (!in_array($service, ['yes', 'no'], true)) {
+            $service = 'yes';
+        }
+        // Sanitize SNAPSHOT_PATH: only allow absolute paths with safe characters.
+        $snapshot = preg_replace('/[^a-zA-Z0-9_\-\/. ]/', '', $snapshot);
+        // Write values in single quotes to prevent shell expansion when sourced.
+        $content = "SERVICE='{$service}'\nPORT='24085'\nBIND_ADDRESS='127.0.0.1'\nSNAPSHOT_PATH='{$snapshot}'\n";
         $written = file_put_contents($CONFIG, $content, LOCK_EX);
         if ($written === false) {
             http_response_code(500);

--- a/plugin/rc.vault
+++ b/plugin/rc.vault
@@ -14,7 +14,10 @@ if [ -f "$CONFIG" ]; then
     _val="$(grep -E '^BIND_ADDRESS=' "$CONFIG" | head -1 | sed "s/^BIND_ADDRESS=//; s/^[\"']//; s/[\"'].*//")"
     [ -n "$_val" ] && BIND_ADDRESS="$_val"
     _val="$(grep -E '^PORT=' "$CONFIG" | head -1 | sed "s/^PORT=//; s/^[\"']//; s/[\"'].*//")"
-    [ -n "$_val" ] && PORT="$_val"
+    # Only accept numeric port values.
+    if [ -n "$_val" ] && echo "$_val" | grep -Eq '^[0-9]+$'; then
+        PORT="$_val"
+    fi
     unset _val
 fi
 

--- a/plugin/rc.vault
+++ b/plugin/rc.vault
@@ -18,6 +18,25 @@ if [ -f "$CONFIG" ]; then
     BIND_ADDRESS="${BIND_ADDRESS:-127.0.0.1}"
     PORT="${PORT:-24085}"
 fi
+
+# Validate bind address: only allow 127.0.0.1, 0.0.0.0, or a valid local IP.
+validate_bind_address() {
+    local addr="$1"
+    case "$addr" in
+        127.0.0.1|0.0.0.0|::1|::) return 0 ;;
+    esac
+    # Check if the address is assigned to a local interface.
+    if ip addr show 2>/dev/null | grep -q "inet ${addr}/\|inet6 ${addr}/"; then
+        return 0
+    fi
+    return 1
+}
+
+if ! validate_bind_address "$BIND_ADDRESS"; then
+    echo "Warning: bind address '$BIND_ADDRESS' is not a valid local address; falling back to 127.0.0.1"
+    BIND_ADDRESS=127.0.0.1
+fi
+
 LISTEN_HOST="$BIND_ADDRESS"
 if [[ "$LISTEN_HOST" == *:* && "$LISTEN_HOST" != \[* ]]; then
     LISTEN_HOST="[$LISTEN_HOST]"

--- a/plugin/rc.vault
+++ b/plugin/rc.vault
@@ -26,7 +26,8 @@ validate_bind_address() {
         127.0.0.1|0.0.0.0|::1|::) return 0 ;;
     esac
     # Check if the address is assigned to a local interface.
-    if ip addr show 2>/dev/null | grep -q "inet ${addr}/\|inet6 ${addr}/"; then
+    if ip addr show 2>/dev/null | grep -Fq "inet ${addr}/" || \
+       ip addr show 2>/dev/null | grep -Fq "inet6 ${addr}/"; then
         return 0
     fi
     return 1

--- a/plugin/rc.vault
+++ b/plugin/rc.vault
@@ -7,16 +7,15 @@ CONFIG=/boot/config/plugins/vault/vault.cfg
 LOG=/var/log/vault.log
 MAX_LOG_SIZE=$((256 * 1024))
 
-# Read bind address, port, and snapshot path from config.
-# SNAPSHOT_PATH is set by the daemon when the user configures a custom snapshot
-# location. It is read at startup before the database is restored.
+# Read bind address and port from config without sourcing (prevents code injection).
 BIND_ADDRESS=127.0.0.1
 PORT=24085
 if [ -f "$CONFIG" ]; then
-    # shellcheck source=/dev/null
-    source "$CONFIG"
-    BIND_ADDRESS="${BIND_ADDRESS:-127.0.0.1}"
-    PORT="${PORT:-24085}"
+    _val="$(grep -E '^BIND_ADDRESS=' "$CONFIG" | head -1 | sed "s/^BIND_ADDRESS=//; s/^[\"']//; s/[\"'].*//")"
+    [ -n "$_val" ] && BIND_ADDRESS="$_val"
+    _val="$(grep -E '^PORT=' "$CONFIG" | head -1 | sed "s/^PORT=//; s/^[\"']//; s/[\"'].*//")"
+    [ -n "$_val" ] && PORT="$_val"
+    unset _val
 fi
 
 # Validate bind address: only allow 127.0.0.1, 0.0.0.0, or a valid local IP.

--- a/web/src/pages/Settings.svelte
+++ b/web/src/pages/Settings.svelte
@@ -194,7 +194,7 @@
     snapshotPathSaving = true
     try {
       databaseInfo = await api.setSnapshotPath('')
-      showToast('Snapshot path reset to default (takes effect on restart)', 'success')
+      showToast('Snapshot path reset to default', 'success')
     } catch (e) {
       showToast(e.message, 'error')
     } finally {

--- a/web/src/pages/Settings.svelte
+++ b/web/src/pages/Settings.svelte
@@ -181,7 +181,7 @@
     try {
       databaseInfo = await api.setSnapshotPath(snapshotPathInput)
       snapshotPathInput = databaseInfo?.snapshot_path_override || ''
-      showToast(snapshotPathInput ? 'Snapshot path updated' : 'Snapshot path reset to default', 'success')
+      showToast(snapshotPathInput ? 'Snapshot path updated (takes effect on restart)' : 'Snapshot path reset to default', 'success')
     } catch (e) {
       showToast(e.message, 'error')
     } finally {
@@ -194,7 +194,7 @@
     snapshotPathSaving = true
     try {
       databaseInfo = await api.setSnapshotPath('')
-      showToast('Snapshot path reset to default', 'success')
+      showToast('Snapshot path reset to default (takes effect on restart)', 'success')
     } catch (e) {
       showToast(e.message, 'error')
     } finally {
@@ -1081,21 +1081,15 @@
         </div>
         {#if databaseInfo.mode === 'hybrid'}
         <div class="px-5 py-4 border-t border-border">
-          <span class="text-xs text-text-muted block mb-1.5">Custom save location <Tooltip text="Overrides where the persistent database snapshot is saved. Changes take effect immediately. You can enter a directory — vault.db will be created inside it automatically." /></span>
+          <span class="text-xs text-text-muted block mb-1.5">Custom save location <Tooltip text="Overrides where the persistent database snapshot is saved. Requires a daemon restart to take effect." /></span>
           <p class="text-xs text-text-dim mb-2">Choose where the persistent database copy is stored. Defaults to SSD cache.</p>
           <PathBrowser bind:value={snapshotPathInput} onselect={saveSnapshotPath} />
-          <div class="flex items-center gap-3 mt-2">
-            {#if snapshotPathInput && snapshotPathInput !== (databaseInfo.snapshot_path_override || '')}
-              <button onclick={saveSnapshotPath} disabled={snapshotPathSaving} class="text-xs font-medium text-vault hover:underline disabled:opacity-50">
-                {snapshotPathSaving ? 'Saving…' : 'Apply'}
-              </button>
-            {/if}
-            {#if databaseInfo.snapshot_path_override}
-              <button onclick={resetSnapshotPath} disabled={snapshotPathSaving} class="text-xs text-text-muted hover:text-vault hover:underline disabled:opacity-50">
-                Reset to default
-              </button>
-            {/if}
-          </div>
+          {#if databaseInfo.snapshot_path_override}
+            <button onclick={resetSnapshotPath} disabled={snapshotPathSaving} class="mt-2 text-xs text-vault hover:underline">
+              Reset to default
+            </button>
+          {/if}
+          <p class="text-xs text-text-dim mt-2">Changes take effect on next daemon restart.</p>
         </div>
         {/if}
         {#if databaseInfo.mode === 'legacy_usb'}

--- a/web/src/pages/Settings.svelte
+++ b/web/src/pages/Settings.svelte
@@ -181,7 +181,7 @@
     try {
       databaseInfo = await api.setSnapshotPath(snapshotPathInput)
       snapshotPathInput = databaseInfo?.snapshot_path_override || ''
-      showToast(snapshotPathInput ? 'Snapshot path updated (takes effect on restart)' : 'Snapshot path reset to default', 'success')
+      showToast(snapshotPathInput ? 'Snapshot path updated' : 'Snapshot path reset to default', 'success')
     } catch (e) {
       showToast(e.message, 'error')
     } finally {
@@ -1081,15 +1081,21 @@
         </div>
         {#if databaseInfo.mode === 'hybrid'}
         <div class="px-5 py-4 border-t border-border">
-          <span class="text-xs text-text-muted block mb-1.5">Custom save location <Tooltip text="Overrides where the persistent database snapshot is saved. Requires a daemon restart to take effect." /></span>
+          <span class="text-xs text-text-muted block mb-1.5">Custom save location <Tooltip text="Overrides where the persistent database snapshot is saved." /></span>
           <p class="text-xs text-text-dim mb-2">Choose where the persistent database copy is stored. Defaults to SSD cache.</p>
-          <PathBrowser bind:value={snapshotPathInput} onselect={saveSnapshotPath} />
+          <div class="flex gap-2 items-end">
+            <div class="flex-1">
+              <PathBrowser bind:value={snapshotPathInput} onselect={saveSnapshotPath} />
+            </div>
+            <button onclick={saveSnapshotPath} disabled={snapshotPathSaving || !snapshotPathInput} class="px-3 py-2 bg-vault text-white text-sm rounded-lg hover:bg-vault/90 disabled:opacity-50 transition-colors shrink-0">
+              Apply
+            </button>
+          </div>
           {#if databaseInfo.snapshot_path_override}
             <button onclick={resetSnapshotPath} disabled={snapshotPathSaving} class="mt-2 text-xs text-vault hover:underline">
               Reset to default
             </button>
           {/if}
-          <p class="text-xs text-text-dim mt-2">Changes take effect on next daemon restart.</p>
         </div>
         {/if}
         {#if databaseInfo.mode === 'legacy_usb'}


### PR DESCRIPTION
Addresses review feedback on the pool discovery PR — primarily config injection vectors in shell scripts, missing IPv6 bind address support, and unreliable mount detection.

### Shell config injection (`rc.vault`, `control.php`)

- **`rc.vault`**: Replaced `source "$CONFIG"` with targeted `grep`/`sed` extraction — prevents arbitrary code execution from a tampered `vault.cfg`. Added digits-only validation for `PORT`.
- **`control.php`**: `SERVICE` constrained to `yes`/`no` allowlist. Config values written in single quotes to block shell expansion. `SNAPSHOT_PATH` restricted to `[a-zA-Z0-9_\-/. ]` with leading-dot stripping.

### IPv6 bind address support (`Vault.page`, `api.php`)

- Added `::1` (IPv6 loopback) and `::` (dual-stack wildcard) to the bind address dropdown.
- `vault_get_local_ips()` now enumerates both IPv4 and IPv6 interface addresses, with `filter_var(..., FILTER_FLAG_IPV6)` validation and link-local/bridge filtering.

### Mount detection (`pools.go`)

Replaced the `ReadDir`-based `IsMountedPool()` heuristic with `/proc/self/mountinfo` parsing. The old approach misclassified empty-but-mounted pools as unmounted.

```go
// Before: unreliable — empty pool dirs return false
entries, err := os.ReadDir(poolPath)

// After: checks actual kernel mount table
func isMountedPoolFrom(infoPath, poolPath string) bool {
    // parse field 5 (mount point) from each mountinfo line
}
```

### UI toast fix (`Settings.svelte`)

Removed "takes effect on restart" from the snapshot path reset toast — the backend applies the change immediately.