### PR TITLE
feat(engine,api): add ZFS zpool support for database location and staging area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- ZFS zpool support for database location: the path browser now includes ZFS pool mountpoints when browsing for custom database snapshot locations via `include_zfs` query parameter (closes #50)
+- ZFS zpool support for temporary work area: NVMe-backed ZFS zpools are automatically detected at daemon startup and prepended to the staging cascade, giving them highest priority for backup assembly (closes #51)
+- `ListNVMePools()` method on `ZFSHandler` to discover zpools composed entirely of NVMe devices
+- `ListZFSMountpoints()` method on `ZFSHandler` to enumerate all accessible ZFS dataset mountpoints
+- `PrependCachePaths()` function in `tempdir` package to inject high-priority staging paths at runtime
+- `BrowseHandler.SetZFSLister()` for pluggable ZFS mountpoint discovery in the browse API
+- Updated Settings page text to mention ZFS zpools as available locations for database and staging
 - `internal/unraid` package with `DiscoverPools()`, `PreferredPool()`, and `IsMountedPool()` for dynamic Unraid pool detection — replaces hardcoded `/mnt/cache` references across the codebase (closes #49)
 - Contextual tooltips across Settings, Jobs, Storage, and Replication pages — reusable `Tooltip.svelte` component with hover/click-to-toggle, viewport-aware positioning, keyboard dismissal, and full ARIA accessibility (closes #34)
 - Enriched activity logs with contextual details for troubleshooting: backup started/completed and restore completed entries now include job name, backup type, storage destination, duration, and size; per-item container health check results are logged individually under a new "health" category; stop_all health check summary includes aggregate counts (containers checked/healthy/unhealthy) (closes #30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 
 - ZFS zpool support for database location: the path browser now includes ZFS pool mountpoints when browsing for custom database snapshot locations via `include_zfs` query parameter (closes #50)
-- ZFS zpool support for temporary work area: NVMe-backed ZFS zpools are automatically detected at daemon startup and prepended to the staging cascade, giving them highest priority for backup assembly (closes #51)
+- ZFS zpool support for temporary work area: NVMe-backed ZFS zpools are automatically detected at daemon startup and prepended to the staging cascade, giving them the highest priority for backup assembly (closes #51)
 - `ListNVMePools()` method on `ZFSHandler` to discover zpools composed entirely of NVMe devices
 - `ListZFSMountpoints()` method on `ZFSHandler` to enumerate all accessible ZFS dataset mountpoints
 - `PrependCachePaths()` function in `tempdir` package to inject high-priority staging paths at runtime

--- a/internal/api/handlers/browse.go
+++ b/internal/api/handlers/browse.go
@@ -37,16 +37,40 @@ func NewBrowseHandler() *BrowseHandler {
 // It also pre-populates extra allowed roots from ZFS mountpoints so path
 // validation accepts ZFS locations that may fall outside /mnt and /boot.
 func (h *BrowseHandler) SetZFSLister(lister ZFSMountpointLister) {
+	if lister == nil {
+		return
+	}
 	h.zfsLister = lister
-	if mounts, err := lister.ListZFSMountpoints(); err == nil {
-		for _, m := range mounts {
-			h.extraAllowedRoots = append(h.extraAllowedRoots, m.Mountpoint)
+
+	mounts, err := lister.ListZFSMountpoints()
+	if err != nil {
+		return
+	}
+
+	seen := make(map[string]struct{}, len(h.extraAllowedRoots))
+	for _, root := range h.extraAllowedRoots {
+		seen[filepath.Clean(root)] = struct{}{}
+	}
+
+	for _, m := range mounts {
+		mp := filepath.Clean(m.Mountpoint)
+		if mp == "" || !filepath.IsAbs(mp) || mp == "/" {
+			continue
 		}
+		if _, ok := seen[mp]; ok {
+			continue
+		}
+		h.extraAllowedRoots = append(h.extraAllowedRoots, mp)
+		seen[mp] = struct{}{}
 	}
 }
 
 // normalizePath validates a browse path against the static allowed roots
-// plus any ZFS mountpoints discovered at startup.
+// plus any ZFS mountpoints discovered at startup. ZFS roots are always
+// included in path validation (not gated by include_zfs) because they are
+// legitimate filesystem locations used for database and staging configuration.
+// The include_zfs query parameter only controls whether ZFS roots appear in the
+// top-level root listing.
 func (h *BrowseHandler) normalizePath(path string) (string, error) {
 	roots := browseAllowedRoots
 	if len(h.extraAllowedRoots) > 0 {
@@ -75,8 +99,9 @@ var unraidRoots = []dirEntry{
 	{Name: "Remote Mounts", Path: "/mnt/remotes", IsDir: true},
 }
 
-// List returns subdirectories of a given path. Only paths under /mnt/ are allowed.
-// When no path query param is provided, it returns Unraid well-known roots.
+// List returns subdirectories of a given path. Paths must be under allowed roots
+// (/mnt, /boot, or discovered ZFS mountpoints). When no path query param is
+// provided, it returns Unraid well-known roots plus optional ZFS pools.
 //
 //	GET /api/v1/browse?path=/mnt/user
 func (h *BrowseHandler) List(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/browse.go
+++ b/internal/api/handlers/browse.go
@@ -36,17 +36,28 @@ func NewBrowseHandler() *BrowseHandler {
 // SetZFSLister sets the ZFS mountpoint lister for ZFS-aware browsing.
 // It also pre-populates extra allowed roots from ZFS mountpoints so path
 // validation accepts ZFS locations that may fall outside /mnt and /boot.
+// The lister is only stored when mountpoints are successfully fetched so
+// that discoverRoots and normalizePath stay consistent.
 func (h *BrowseHandler) SetZFSLister(lister ZFSMountpointLister) {
 	if lister == nil {
 		return
 	}
-	h.zfsLister = lister
 
 	mounts, err := lister.ListZFSMountpoints()
 	if err != nil {
 		return
 	}
 
+	// Lister is only assigned after a successful fetch so discoverRoots
+	// and normalizePath stay in sync with extraAllowedRoots.
+	h.zfsLister = lister
+
+	h.mergeExtraRoots(mounts)
+}
+
+// mergeExtraRoots adds cleaned, deduplicated ZFS mountpoints to
+// extraAllowedRoots. It skips empty, non-absolute, and root ("/") paths.
+func (h *BrowseHandler) mergeExtraRoots(mounts []ZFSMountInfo) {
 	seen := make(map[string]struct{}, len(h.extraAllowedRoots))
 	for _, root := range h.extraAllowedRoots {
 		seen[filepath.Clean(root)] = struct{}{}

--- a/internal/api/handlers/browse.go
+++ b/internal/api/handlers/browse.go
@@ -12,11 +12,29 @@ import (
 )
 
 // BrowseHandler serves filesystem directory listings for the path browser UI.
-type BrowseHandler struct{}
+type BrowseHandler struct {
+	zfsLister ZFSMountpointLister
+}
+
+// ZFSMountpointLister enumerates ZFS dataset mountpoints for browse discovery.
+type ZFSMountpointLister interface {
+	ListZFSMountpoints() ([]ZFSMountInfo, error)
+}
+
+// ZFSMountInfo describes a ZFS pool mountpoint for browse discovery.
+type ZFSMountInfo struct {
+	Name       string
+	Mountpoint string
+}
 
 // NewBrowseHandler creates a new BrowseHandler.
 func NewBrowseHandler() *BrowseHandler {
 	return &BrowseHandler{}
+}
+
+// SetZFSLister sets the ZFS mountpoint lister for ZFS-aware browsing.
+func (h *BrowseHandler) SetZFSLister(lister ZFSMountpointLister) {
+	h.zfsLister = lister
 }
 
 // dirEntry represents a single directory in the browse response.
@@ -45,7 +63,8 @@ func (h *BrowseHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	// No path — return well-known Unraid roots plus any array disks found.
 	if qpath == "" {
-		roots := h.discoverRoots()
+		includeZFS := r.URL.Query().Get("include_zfs") == "true"
+		roots := h.discoverRoots(includeZFS)
 		respondJSON(w, http.StatusOK, map[string]any{
 			"path":    "/mnt",
 			"entries": roots,
@@ -73,7 +92,8 @@ func (h *BrowseHandler) List(w http.ResponseWriter, r *http.Request) {
 
 // discoverRoots returns Unraid well-known roots plus dynamically discovered
 // array disks (/mnt/disk1, /mnt/disk2, etc.) and cache/pool drives.
-func (h *BrowseHandler) discoverRoots() []dirEntry {
+// When includeZFS is true, ZFS dataset mountpoints are also included.
+func (h *BrowseHandler) discoverRoots(includeZFS bool) []dirEntry {
 	roots := make([]dirEntry, 0, len(unraidRoots)+8)
 
 	// Add well-known roots that actually exist on this system.
@@ -126,6 +146,28 @@ func (h *BrowseHandler) discoverRoots() []dirEntry {
 					Path:  "/mnt/" + name,
 					IsDir: true,
 				})
+			}
+		}
+	}
+
+	// Append ZFS pool mountpoints when requested.
+	if includeZFS && h.zfsLister != nil {
+		seen := make(map[string]bool, len(roots))
+		for _, r := range roots {
+			seen[r.Path] = true
+		}
+		zfsMounts, zfsErr := h.zfsLister.ListZFSMountpoints()
+		if zfsErr == nil {
+			for _, m := range zfsMounts {
+				if seen[m.Mountpoint] {
+					continue
+				}
+				roots = append(roots, dirEntry{
+					Name:  "ZFS Pool: " + m.Name,
+					Path:  m.Mountpoint,
+					IsDir: true,
+				})
+				seen[m.Mountpoint] = true
 			}
 		}
 	}

--- a/internal/api/handlers/browse.go
+++ b/internal/api/handlers/browse.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -45,6 +46,7 @@ func (h *BrowseHandler) SetZFSLister(lister ZFSMountpointLister) {
 
 	mounts, err := lister.ListZFSMountpoints()
 	if err != nil {
+		log.Printf("browse: failed to list ZFS mountpoints: %v", err)
 		return
 	}
 

--- a/internal/api/handlers/browse.go
+++ b/internal/api/handlers/browse.go
@@ -13,7 +13,8 @@ import (
 
 // BrowseHandler serves filesystem directory listings for the path browser UI.
 type BrowseHandler struct {
-	zfsLister ZFSMountpointLister
+	zfsLister         ZFSMountpointLister
+	extraAllowedRoots []string
 }
 
 // ZFSMountpointLister enumerates ZFS dataset mountpoints for browse discovery.
@@ -33,8 +34,28 @@ func NewBrowseHandler() *BrowseHandler {
 }
 
 // SetZFSLister sets the ZFS mountpoint lister for ZFS-aware browsing.
+// It also pre-populates extra allowed roots from ZFS mountpoints so path
+// validation accepts ZFS locations that may fall outside /mnt and /boot.
 func (h *BrowseHandler) SetZFSLister(lister ZFSMountpointLister) {
 	h.zfsLister = lister
+	if mounts, err := lister.ListZFSMountpoints(); err == nil {
+		for _, m := range mounts {
+			h.extraAllowedRoots = append(h.extraAllowedRoots, m.Mountpoint)
+		}
+	}
+}
+
+// normalizePath validates a browse path against the static allowed roots
+// plus any ZFS mountpoints discovered at startup.
+func (h *BrowseHandler) normalizePath(path string) (string, error) {
+	roots := browseAllowedRoots
+	if len(h.extraAllowedRoots) > 0 {
+		combined := make([]string, 0, len(browseAllowedRoots)+len(h.extraAllowedRoots))
+		combined = append(combined, browseAllowedRoots...)
+		combined = append(combined, h.extraAllowedRoots...)
+		roots = combined
+	}
+	return safepath.NormalizeAbsoluteUnderRoots(path, roots)
 }
 
 // dirEntry represents a single directory in the browse response.
@@ -72,9 +93,9 @@ func (h *BrowseHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	normalizedPath, err := normalizeBrowsePath(qpath)
+	normalizedPath, err := h.normalizePath(qpath)
 	if err != nil {
-		respondError(w, http.StatusForbidden, "browsing is restricted to /mnt/ and /boot/")
+		respondError(w, http.StatusForbidden, "path is outside allowed roots")
 		return
 	}
 

--- a/internal/api/handlers/path_validation.go
+++ b/internal/api/handlers/path_validation.go
@@ -6,10 +6,6 @@ var browseAllowedRoots = []string{"/mnt", "/boot"}
 
 var configurablePathRoots = []string{"/mnt", "/boot", "/tmp"}
 
-func normalizeBrowsePath(path string) (string, error) {
-	return safepath.NormalizeAbsoluteUnderRoots(path, browseAllowedRoots)
-}
-
 func normalizeConfigurablePath(path string) (string, error) {
 	return safepath.NormalizeAbsoluteUnderRoots(path, configurablePathRoots)
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -111,6 +111,7 @@ func (s *Server) setupRoutes() *chi.Mux {
 		})
 
 		browseH := handlers.NewBrowseHandler()
+		s.browseHandler = browseH
 		r.Get("/browse", browseH.List)
 
 		activityH := handlers.NewActivityHandler(s.db)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -38,6 +38,7 @@ type Server struct {
 	nextRunResolver func(jobID int64) (string, bool)
 
 	settingsHandler *handlers.SettingsHandler
+	browseHandler   *handlers.BrowseHandler
 
 	// configChangeHook is called after any handler mutates persistent
 	// configuration. It flushed the DB to USB flash.
@@ -100,6 +101,11 @@ func (s *Server) Syncer() *replication.Syncer {
 // SettingsHandler returns the settings handler for external configuration.
 func (s *Server) SettingsHandler() *handlers.SettingsHandler {
 	return s.settingsHandler
+}
+
+// BrowseHandler returns the browse handler for external configuration.
+func (s *Server) BrowseHandler() *handlers.BrowseHandler {
+	return s.browseHandler
 }
 
 func (s *Server) Start() error {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -12,10 +12,12 @@ import (
 	"syscall"
 
 	"github.com/ruaan-deysel/vault/internal/api"
+	"github.com/ruaan-deysel/vault/internal/api/handlers"
 	"github.com/ruaan-deysel/vault/internal/config"
 	"github.com/ruaan-deysel/vault/internal/crypto"
 	"github.com/ruaan-deysel/vault/internal/db"
 	"github.com/ruaan-deysel/vault/internal/diagnostics"
+	"github.com/ruaan-deysel/vault/internal/engine"
 	"github.com/ruaan-deysel/vault/internal/replication"
 	"github.com/ruaan-deysel/vault/internal/scheduler"
 	"github.com/ruaan-deysel/vault/internal/tempdir"
@@ -211,6 +213,26 @@ var daemonCmd = &cobra.Command{
 		}
 		srv := api.NewServer(database, cfg)
 
+		// Discover NVMe-backed ZFS pools and wire them into the staging
+		// cascade and browse handler for ZFS-aware path browsing.
+		zfsH, zfsErr := engine.NewZFSHandler()
+		if zfsErr == nil {
+			// Prepend NVMe pool mountpoints to the staging cascade so they
+			// are preferred over conventional Unraid pools.
+			if nvmePools, err := zfsH.ListNVMePools(); err == nil && len(nvmePools) > 0 {
+				var paths []string
+				for _, p := range nvmePools {
+					stagingPath := filepath.Join(p.Mountpoint, ".vault-staging")
+					paths = append(paths, stagingPath)
+					log.Printf("NVMe ZFS pool detected: %s → staging at %s", p.Name, stagingPath)
+				}
+				tempdir.PrependCachePaths(paths)
+			}
+
+			// Wire ZFS mountpoint discovery into the browse handler.
+			srv.BrowseHandler().SetZFSLister(&zfsBrowseAdapter{handler: zfsH})
+		}
+
 		// Register the snapshot manager with the runner so it can save
 		// snapshots after each backup/restore operation.
 		if hybridMode && snapshotMgr != nil {
@@ -297,4 +319,22 @@ func init() {
 	daemonCmd.Flags().String("tls-cert", "", "Path to TLS certificate file")
 	daemonCmd.Flags().String("tls-key", "", "Path to TLS private key file")
 	rootCmd.AddCommand(daemonCmd)
+}
+
+// zfsBrowseAdapter bridges engine.ZFSHandler to the browse handler's
+// ZFSMountpointLister interface.
+type zfsBrowseAdapter struct {
+	handler *engine.ZFSHandler
+}
+
+func (a *zfsBrowseAdapter) ListZFSMountpoints() ([]handlers.ZFSMountInfo, error) {
+	pools, err := a.handler.ListZFSMountpoints()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]handlers.ZFSMountInfo, len(pools))
+	for i, p := range pools {
+		result[i] = handlers.ZFSMountInfo{Name: p.Name, Mountpoint: p.Mountpoint}
+	}
+	return result, nil
 }

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -226,10 +226,14 @@ var daemonCmd = &cobra.Command{
 					log.Printf("NVMe ZFS pool detected: %s → cache base %s", p.Name, p.Mountpoint)
 				}
 				tempdir.PrependCachePaths(paths)
+			} else if err != nil {
+				log.Printf("Warning: failed to discover NVMe ZFS pools: %v", err)
 			}
 
 			// Wire ZFS mountpoint discovery into the browse handler.
 			srv.BrowseHandler().SetZFSLister(&zfsBrowseAdapter{handler: zfsH})
+		} else {
+			log.Printf("Warning: ZFS support disabled: %v", zfsErr)
 		}
 
 		// Register the snapshot manager with the runner so it can save
@@ -329,7 +333,7 @@ type zfsBrowseAdapter struct {
 func (a *zfsBrowseAdapter) ListZFSMountpoints() ([]handlers.ZFSMountInfo, error) {
 	pools, err := a.handler.ListZFSMountpoints()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listing ZFS mountpoints for browse: %w", err)
 	}
 	result := make([]handlers.ZFSMountInfo, len(pools))
 	for i, p := range pools {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -222,9 +222,8 @@ var daemonCmd = &cobra.Command{
 			if nvmePools, err := zfsH.ListNVMePools(); err == nil && len(nvmePools) > 0 {
 				var paths []string
 				for _, p := range nvmePools {
-					stagingPath := filepath.Join(p.Mountpoint, ".vault-staging")
-					paths = append(paths, stagingPath)
-					log.Printf("NVMe ZFS pool detected: %s → staging at %s", p.Name, stagingPath)
+					paths = append(paths, p.Mountpoint)
+					log.Printf("NVMe ZFS pool detected: %s → cache base %s", p.Name, p.Mountpoint)
 				}
 				tempdir.PrependCachePaths(paths)
 			}

--- a/internal/engine/zfs.go
+++ b/internal/engine/zfs.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -377,4 +378,133 @@ func (cr *countingReader) Read(p []byte) (int, error) {
 		cr.progress(cr.name, pct, fmt.Sprintf("receiving: %d MB read", mb))
 	}
 	return n, err
+}
+
+// NVMePoolInfo describes a ZFS zpool composed entirely of NVMe devices.
+type NVMePoolInfo struct {
+	Name       string `json:"name"`
+	Mountpoint string `json:"mountpoint"`
+}
+
+// ListNVMePools discovers ZFS zpools where every data vdev is backed by NVMe
+// devices. It returns only pools with valid, accessible mountpoints.
+func (h *ZFSHandler) ListNVMePools() ([]NVMePoolInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	pools, err := h.client.Zpool.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing zpools: %w", err)
+	}
+
+	var result []NVMePoolInfo
+	for _, pool := range pools {
+		leaves := collectLeafVdevPaths(pool.Vdevs)
+		if len(leaves) == 0 {
+			continue
+		}
+		if !allNVMe(leaves) {
+			continue
+		}
+
+		mountpoint, err := h.poolMountpoint(ctx, pool.Name)
+		if err != nil {
+			log.Printf("zfs: skipping pool %s: %v", pool.Name, err)
+			continue
+		}
+		if !isValidMountpoint(mountpoint) {
+			continue
+		}
+		if _, statErr := os.Stat(mountpoint); statErr != nil {
+			continue
+		}
+
+		result = append(result, NVMePoolInfo{
+			Name:       pool.Name,
+			Mountpoint: mountpoint,
+		})
+	}
+
+	return result, nil
+}
+
+// ListZFSMountpoints returns mountpoints for all accessible ZFS filesystem
+// datasets. Used by the browse API to discover ZFS locations for database or
+// staging configuration.
+func (h *ZFSHandler) ListZFSMountpoints() ([]NVMePoolInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	pools, err := h.client.Zpool.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing zpools: %w", err)
+	}
+
+	var result []NVMePoolInfo
+	for _, pool := range pools {
+		mountpoint, err := h.poolMountpoint(ctx, pool.Name)
+		if err != nil {
+			continue
+		}
+		if !isValidMountpoint(mountpoint) {
+			continue
+		}
+		if _, statErr := os.Stat(mountpoint); statErr != nil {
+			continue
+		}
+
+		result = append(result, NVMePoolInfo{
+			Name:       pool.Name,
+			Mountpoint: mountpoint,
+		})
+	}
+
+	return result, nil
+}
+
+// poolMountpoint retrieves the mountpoint of a pool's root dataset.
+func (h *ZFSHandler) poolMountpoint(ctx context.Context, poolName string) (string, error) {
+	datasets, err := h.client.ZFS.ListByType(ctx, gzfs.DatasetTypeFilesystem, false, poolName)
+	if err != nil {
+		return "", fmt.Errorf("listing datasets for pool %s: %w", poolName, err)
+	}
+	for _, ds := range datasets {
+		if ds.Name == poolName {
+			return ds.Mountpoint, nil
+		}
+	}
+	return "", fmt.Errorf("root dataset for pool %s not found", poolName)
+}
+
+// collectLeafVdevPaths recursively traverses vdev trees and returns device
+// paths of leaf vdevs (those with no children).
+func collectLeafVdevPaths(vdevs map[string]*gzfs.ZPoolVDEV) []string {
+	var paths []string
+	for _, v := range vdevs {
+		if len(v.Vdevs) > 0 {
+			paths = append(paths, collectLeafVdevPaths(v.Vdevs)...)
+		} else if v.Path != "" {
+			paths = append(paths, v.Path)
+		}
+	}
+	return paths
+}
+
+// allNVMe returns true if every path contains "nvme" (case-insensitive).
+func allNVMe(paths []string) bool {
+	for _, p := range paths {
+		if !strings.Contains(strings.ToLower(p), "nvme") {
+			return false
+		}
+	}
+	return true
+}
+
+// isValidMountpoint returns true if the mountpoint is a usable filesystem path.
+func isValidMountpoint(mp string) bool {
+	switch mp {
+	case "", "none", "-", "legacy":
+		return false
+	}
+	return filepath.IsAbs(mp)
 }

--- a/internal/engine/zfs.go
+++ b/internal/engine/zfs.go
@@ -501,10 +501,16 @@ func allNVMe(paths []string) bool {
 }
 
 // isValidMountpoint returns true if the mountpoint is a usable filesystem path.
+// The root filesystem ("/") is explicitly rejected to prevent broadening browse
+// access to the entire host.
 func isValidMountpoint(mp string) bool {
 	switch mp {
 	case "", "none", "-", "legacy":
 		return false
 	}
-	return filepath.IsAbs(mp)
+	cleaned := filepath.Clean(mp)
+	if !filepath.IsAbs(cleaned) {
+		return false
+	}
+	return cleaned != string(filepath.Separator)
 }

--- a/internal/engine/zfs.go
+++ b/internal/engine/zfs.go
@@ -380,15 +380,15 @@ func (cr *countingReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-// NVMePoolInfo describes a ZFS zpool composed entirely of NVMe devices.
-type NVMePoolInfo struct {
+// ZFSPoolInfo describes a ZFS zpool with its root dataset mountpoint.
+type ZFSPoolInfo struct {
 	Name       string `json:"name"`
 	Mountpoint string `json:"mountpoint"`
 }
 
 // ListNVMePools discovers ZFS zpools where every data vdev is backed by NVMe
 // devices. It returns only pools with valid, accessible mountpoints.
-func (h *ZFSHandler) ListNVMePools() ([]NVMePoolInfo, error) {
+func (h *ZFSHandler) ListNVMePools() ([]ZFSPoolInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -397,7 +397,7 @@ func (h *ZFSHandler) ListNVMePools() ([]NVMePoolInfo, error) {
 		return nil, fmt.Errorf("listing zpools: %w", err)
 	}
 
-	var result []NVMePoolInfo
+	var result []ZFSPoolInfo
 	for _, pool := range pools {
 		leaves := collectLeafVdevPaths(pool.Vdevs)
 		if len(leaves) == 0 {
@@ -419,7 +419,7 @@ func (h *ZFSHandler) ListNVMePools() ([]NVMePoolInfo, error) {
 			continue
 		}
 
-		result = append(result, NVMePoolInfo{
+		result = append(result, ZFSPoolInfo{
 			Name:       pool.Name,
 			Mountpoint: mountpoint,
 		})
@@ -428,10 +428,10 @@ func (h *ZFSHandler) ListNVMePools() ([]NVMePoolInfo, error) {
 	return result, nil
 }
 
-// ListZFSMountpoints returns mountpoints for all accessible ZFS filesystem
+// ListZFSMountpoints returns mountpoints for all accessible ZFS pool root
 // datasets. Used by the browse API to discover ZFS locations for database or
 // staging configuration.
-func (h *ZFSHandler) ListZFSMountpoints() ([]NVMePoolInfo, error) {
+func (h *ZFSHandler) ListZFSMountpoints() ([]ZFSPoolInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -440,7 +440,7 @@ func (h *ZFSHandler) ListZFSMountpoints() ([]NVMePoolInfo, error) {
 		return nil, fmt.Errorf("listing zpools: %w", err)
 	}
 
-	var result []NVMePoolInfo
+	var result []ZFSPoolInfo
 	for _, pool := range pools {
 		mountpoint, err := h.poolMountpoint(ctx, pool.Name)
 		if err != nil {
@@ -453,7 +453,7 @@ func (h *ZFSHandler) ListZFSMountpoints() ([]NVMePoolInfo, error) {
 			continue
 		}
 
-		result = append(result, NVMePoolInfo{
+		result = append(result, ZFSPoolInfo{
 			Name:       pool.Name,
 			Mountpoint: mountpoint,
 		})

--- a/internal/engine/zfs.go
+++ b/internal/engine/zfs.go
@@ -412,6 +412,7 @@ func (h *ZFSHandler) ListNVMePools() ([]ZFSPoolInfo, error) {
 			log.Printf("zfs: skipping pool %s: %v", pool.Name, err)
 			continue
 		}
+		mountpoint = filepath.Clean(mountpoint)
 		if !isValidMountpoint(mountpoint) {
 			continue
 		}
@@ -446,6 +447,7 @@ func (h *ZFSHandler) ListZFSMountpoints() ([]ZFSPoolInfo, error) {
 		if err != nil {
 			continue
 		}
+		mountpoint = filepath.Clean(mountpoint)
 		if !isValidMountpoint(mountpoint) {
 			continue
 		}

--- a/internal/engine/zfs_stub.go
+++ b/internal/engine/zfs_stub.go
@@ -10,8 +10,8 @@ import (
 // ZFSHandler is a stub for non-Linux platforms where ZFS is not available.
 type ZFSHandler struct{}
 
-// NVMePoolInfo describes a ZFS zpool composed entirely of NVMe devices.
-type NVMePoolInfo struct {
+// ZFSPoolInfo describes a ZFS zpool with its root dataset mountpoint.
+type ZFSPoolInfo struct {
 	Name       string `json:"name"`
 	Mountpoint string `json:"mountpoint"`
 }
@@ -37,11 +37,11 @@ func (h *ZFSHandler) Restore(_ context.Context, _ BackupItem, _ string, _ Progre
 }
 
 // ListNVMePools returns an empty slice on non-Linux platforms.
-func (h *ZFSHandler) ListNVMePools() ([]NVMePoolInfo, error) {
+func (h *ZFSHandler) ListNVMePools() ([]ZFSPoolInfo, error) {
 	return nil, nil
 }
 
 // ListZFSMountpoints returns an empty slice on non-Linux platforms.
-func (h *ZFSHandler) ListZFSMountpoints() ([]NVMePoolInfo, error) {
+func (h *ZFSHandler) ListZFSMountpoints() ([]ZFSPoolInfo, error) {
 	return nil, nil
 }

--- a/internal/engine/zfs_stub.go
+++ b/internal/engine/zfs_stub.go
@@ -10,6 +10,12 @@ import (
 // ZFSHandler is a stub for non-Linux platforms where ZFS is not available.
 type ZFSHandler struct{}
 
+// NVMePoolInfo describes a ZFS zpool composed entirely of NVMe devices.
+type NVMePoolInfo struct {
+	Name       string `json:"name"`
+	Mountpoint string `json:"mountpoint"`
+}
+
 // NewZFSHandler returns an error on non-Linux platforms.
 func NewZFSHandler() (*ZFSHandler, error) {
 	return nil, fmt.Errorf("ZFS backup handler is not supported on this platform (requires Linux)")
@@ -28,4 +34,14 @@ func (h *ZFSHandler) Backup(_ context.Context, _ BackupItem, _ string, _ Progres
 // Restore is not supported on this platform.
 func (h *ZFSHandler) Restore(_ context.Context, _ BackupItem, _ string, _ ProgressFunc) error {
 	return fmt.Errorf("ZFS backup handler is not supported on this platform")
+}
+
+// ListNVMePools returns an empty slice on non-Linux platforms.
+func (h *ZFSHandler) ListNVMePools() ([]NVMePoolInfo, error) {
+	return nil, nil
+}
+
+// ListZFSMountpoints returns an empty slice on non-Linux platforms.
+func (h *ZFSHandler) ListZFSMountpoints() ([]NVMePoolInfo, error) {
+	return nil, nil
 }

--- a/internal/engine/zfs_stub.go
+++ b/internal/engine/zfs_stub.go
@@ -38,10 +38,10 @@ func (h *ZFSHandler) Restore(_ context.Context, _ BackupItem, _ string, _ Progre
 
 // ListNVMePools returns an empty slice on non-Linux platforms.
 func (h *ZFSHandler) ListNVMePools() ([]ZFSPoolInfo, error) {
-	return nil, nil
+	return []ZFSPoolInfo{}, nil
 }
 
 // ListZFSMountpoints returns an empty slice on non-Linux platforms.
 func (h *ZFSHandler) ListZFSMountpoints() ([]ZFSPoolInfo, error) {
-	return nil, nil
+	return []ZFSPoolInfo{}, nil
 }

--- a/internal/tempdir/tempdir.go
+++ b/internal/tempdir/tempdir.go
@@ -78,8 +78,11 @@ func GetCachePaths() []string {
 
 // PrependCachePaths adds paths to the front of the cache paths list so they
 // are tried first in the staging cascade. Duplicate paths are skipped.
+// Paths are normalized with filepath.Clean; "/" is rejected.
 // Discovery is triggered first (if not already completed) so the normal
 // pool cascade is preserved rather than being shadowed.
+// If test overrides are active (via SetCachePathsForTest), the prepend
+// targets the test slice so callers see the prepended paths.
 func PrependCachePaths(paths []string) {
 	if len(paths) == 0 {
 		return
@@ -87,9 +90,13 @@ func PrependCachePaths(paths []string) {
 	cachePathsMu.Lock()
 	defer cachePathsMu.Unlock()
 
-	// Run discovery first so we merge with (not replace) the
-	// conventional Unraid pool cascade.
-	if !cachePathsDone {
+	// Determine the target slice: test override or production.
+	target := &cachePathsVal
+	if cachePathsTest != nil {
+		target = &cachePathsTest
+	} else if !cachePathsDone {
+		// Run discovery first so we merge with (not replace) the
+		// conventional Unraid pool cascade.
 		discovered := unraid.DiscoverPools()
 		if len(discovered) > 0 {
 			cachePathsVal = discovered
@@ -97,21 +104,25 @@ func PrependCachePaths(paths []string) {
 		}
 	}
 
-	existing := make(map[string]bool, len(cachePathsVal))
-	for _, p := range cachePathsVal {
-		existing[p] = true
+	existing := make(map[string]bool, len(*target))
+	for _, p := range *target {
+		existing[filepath.Clean(p)] = true
 	}
 
 	var toAdd []string
 	for _, p := range paths {
-		if !existing[p] {
-			toAdd = append(toAdd, p)
-			existing[p] = true
+		cleaned := filepath.Clean(p)
+		if cleaned == "/" || cleaned == "" {
+			continue
+		}
+		if !existing[cleaned] {
+			toAdd = append(toAdd, cleaned)
+			existing[cleaned] = true
 		}
 	}
 
 	if len(toAdd) > 0 {
-		cachePathsVal = append(toAdd, cachePathsVal...)
+		*target = append(toAdd, *target...)
 	}
 }
 

--- a/internal/tempdir/tempdir.go
+++ b/internal/tempdir/tempdir.go
@@ -112,7 +112,7 @@ func PrependCachePaths(paths []string) {
 	var toAdd []string
 	for _, p := range paths {
 		cleaned := filepath.Clean(p)
-		if cleaned == "/" || cleaned == "" {
+		if cleaned == "/" {
 			continue
 		}
 		if !existing[cleaned] {

--- a/internal/tempdir/tempdir.go
+++ b/internal/tempdir/tempdir.go
@@ -90,7 +90,11 @@ func PrependCachePaths(paths []string) {
 	// Run discovery first so we merge with (not replace) the
 	// conventional Unraid pool cascade.
 	if !cachePathsDone {
-		cachePathsVal = unraid.DiscoverPools()
+		discovered := unraid.DiscoverPools()
+		if len(discovered) > 0 {
+			cachePathsVal = discovered
+			cachePathsDone = true
+		}
 	}
 
 	existing := make(map[string]bool, len(cachePathsVal))
@@ -109,7 +113,6 @@ func PrependCachePaths(paths []string) {
 	if len(toAdd) > 0 {
 		cachePathsVal = append(toAdd, cachePathsVal...)
 	}
-	cachePathsDone = true
 }
 
 // StorageConfig is the minimal config subset needed to extract a local path.

--- a/internal/tempdir/tempdir.go
+++ b/internal/tempdir/tempdir.go
@@ -78,12 +78,20 @@ func GetCachePaths() []string {
 
 // PrependCachePaths adds paths to the front of the cache paths list so they
 // are tried first in the staging cascade. Duplicate paths are skipped.
+// Discovery is triggered first (if not already completed) so the normal
+// pool cascade is preserved rather than being shadowed.
 func PrependCachePaths(paths []string) {
 	if len(paths) == 0 {
 		return
 	}
 	cachePathsMu.Lock()
 	defer cachePathsMu.Unlock()
+
+	// Run discovery first so we merge with (not replace) the
+	// conventional Unraid pool cascade.
+	if !cachePathsDone {
+		cachePathsVal = unraid.DiscoverPools()
+	}
 
 	existing := make(map[string]bool, len(cachePathsVal))
 	for _, p := range cachePathsVal {
@@ -100,8 +108,8 @@ func PrependCachePaths(paths []string) {
 
 	if len(toAdd) > 0 {
 		cachePathsVal = append(toAdd, cachePathsVal...)
-		cachePathsDone = true
 	}
+	cachePathsDone = true
 }
 
 // StorageConfig is the minimal config subset needed to extract a local path.

--- a/internal/tempdir/tempdir.go
+++ b/internal/tempdir/tempdir.go
@@ -76,6 +76,34 @@ func GetCachePaths() []string {
 	return cachePaths()
 }
 
+// PrependCachePaths adds paths to the front of the cache paths list so they
+// are tried first in the staging cascade. Duplicate paths are skipped.
+func PrependCachePaths(paths []string) {
+	if len(paths) == 0 {
+		return
+	}
+	cachePathsMu.Lock()
+	defer cachePathsMu.Unlock()
+
+	existing := make(map[string]bool, len(cachePathsVal))
+	for _, p := range cachePathsVal {
+		existing[p] = true
+	}
+
+	var toAdd []string
+	for _, p := range paths {
+		if !existing[p] {
+			toAdd = append(toAdd, p)
+			existing[p] = true
+		}
+	}
+
+	if len(toAdd) > 0 {
+		cachePathsVal = append(toAdd, cachePathsVal...)
+		cachePathsDone = true
+	}
+}
+
 // StorageConfig is the minimal config subset needed to extract a local path.
 type StorageConfig struct {
 	Type   string

--- a/web/src/components/PathBrowser.svelte
+++ b/web/src/components/PathBrowser.svelte
@@ -10,10 +10,9 @@
   let breadcrumbs = $derived(
     currentPath
       ? currentPath.split('/').filter(Boolean)
-          .slice(1) // skip 'mnt' — already shown as the root breadcrumb
           .map((seg, i, arr) => ({
             name: seg,
-            path: '/mnt/' + arr.slice(0, i + 1).join('/'),
+            path: '/' + arr.slice(0, i + 1).join('/'),
           }))
       : []
   )
@@ -81,7 +80,7 @@
 
         <!-- Breadcrumbs -->
         <div class="px-5 py-2 border-b border-border/50 flex items-center gap-1 text-xs text-text-muted overflow-x-auto">
-          <button onclick={() => goTo('')} class="hover:text-vault shrink-0">/mnt</button>
+          <button onclick={() => goTo('')} class="hover:text-vault shrink-0">/</button>
           {#each breadcrumbs as crumb (crumb.path)}
             <span class="text-text-dim">/</span>
             <button onclick={() => goTo(crumb.path)} class="hover:text-vault shrink-0">{crumb.name}</button>
@@ -91,7 +90,7 @@
         <!-- Current path -->
         <div class="px-5 py-2 bg-surface-3/50">
           <div class="text-xs text-text-dim">Selected path</div>
-          <div class="text-sm font-mono text-vault">{currentPath || '/mnt'}</div>
+          <div class="text-sm font-mono text-vault">{currentPath || '/'}</div>
         </div>
 
         <!-- Directory listing -->

--- a/web/src/components/PathBrowser.svelte
+++ b/web/src/components/PathBrowser.svelte
@@ -1,7 +1,7 @@
 <script>
   import { api } from '../lib/api.js'
 
-  let { value = $bindable(''), onselect = () => {} } = $props()
+  let { value = $bindable(''), onselect = () => {}, includeZfs = false } = $props()
 
   let open = $state(false)
   let entries = $state([])
@@ -21,7 +21,7 @@
   async function browse(path = '') {
     loading = true
     try {
-      const res = await api.browse(path)
+      const res = await api.browse(path, { includeZfs })
       entries = res.entries || []
       currentPath = res.path || ''
     } catch {

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -58,7 +58,13 @@ export const api = {
   getRunnerStatus: () => request('GET', '/runner/status'),
 
   // Discovery
-  browse: (path = '') => request('GET', `/browse${path ? '?path=' + encodeURIComponent(path) : ''}`),
+  browse: (path = '', { includeZfs = false } = {}) => {
+    const params = new URLSearchParams()
+    if (path) params.set('path', path)
+    if (includeZfs) params.set('include_zfs', 'true')
+    const qs = params.toString()
+    return request('GET', `/browse${qs ? '?' + qs : ''}`)
+  },
   browseFiles: (path = '') => request('GET', `/browse?files=true${path ? '&path=' + encodeURIComponent(path) : ''}`),
   listContainers: () => request('GET', '/containers'),
   listVMs: () => request('GET', '/vms'),

--- a/web/src/pages/Settings.svelte
+++ b/web/src/pages/Settings.svelte
@@ -784,8 +784,8 @@
 
           <div>
             <span class="text-xs text-text-muted block mb-1.5">Custom Location</span>
-            <p class="text-xs text-text-dim mb-2">Override the automatic location. Use this if you want backups to be assembled on a specific drive.</p>
-            <PathBrowser bind:value={stagingOverrideInput} onselect={saveStagingOverride} />
+            <p class="text-xs text-text-dim mb-2">Override the automatic location. Use this if you want backups to be assembled on a specific drive. NVMe-backed ZFS pools are automatically prioritized when detected.</p>
+            <PathBrowser bind:value={stagingOverrideInput} onselect={saveStagingOverride} includeZfs={true} />
             {#if stagingInfo.override}
               <button onclick={resetStagingOverride} disabled={stagingSaving} class="mt-2 text-xs text-vault hover:underline">
                 Reset to automatic
@@ -1082,10 +1082,10 @@
         {#if databaseInfo.mode === 'hybrid'}
         <div class="px-5 py-4 border-t border-border">
           <span class="text-xs text-text-muted block mb-1.5">Custom save location <Tooltip text="Overrides where the persistent database snapshot is saved." /></span>
-          <p class="text-xs text-text-dim mb-2">Choose where the persistent database copy is stored. Defaults to SSD cache.</p>
+          <p class="text-xs text-text-dim mb-2">Choose where the persistent database copy is stored. Defaults to SSD cache. ZFS zpools are also available as high-performance locations.</p>
           <div class="flex gap-2 items-end">
             <div class="flex-1">
-              <PathBrowser bind:value={snapshotPathInput} onselect={saveSnapshotPath} />
+              <PathBrowser bind:value={snapshotPathInput} onselect={saveSnapshotPath} includeZfs={true} />
             </div>
             <button onclick={saveSnapshotPath} disabled={snapshotPathSaving || !snapshotPathInput} class="px-3 py-2 bg-vault text-white text-sm rounded-lg hover:bg-vault/90 disabled:opacity-50 transition-colors shrink-0">
               Apply


### PR DESCRIPTION
## Summary

Add support for ZFS zpools with all-NVMe drives as both database snapshot locations and temporary work area locations.

Closes #50, closes #51

## Changes

### Backend (7 files)

- **`internal/engine/zfs.go`**: Added `NVMePoolInfo` type, `ListNVMePools()` (detects all-NVMe zpools via vdev path inspection), `ListZFSMountpoints()` (all accessible ZFS pools), `poolMountpoint()`, and helpers (`collectLeafVdevPaths`, `allNVMe`, `isValidMountpoint`)
- **`internal/engine/zfs_stub.go`**: Added no-op stubs for `ListNVMePools()` and `ListZFSMountpoints()` on non-Linux platforms
- **`internal/tempdir/tempdir.go`**: Added `PrependCachePaths()` to inject NVMe pool staging paths at highest priority in the cascade
- **`internal/api/handlers/browse.go`**: Added `ZFSMountpointLister` interface, `include_zfs` query parameter support, and ZFS pool entries in `discoverRoots()`
- **`internal/api/server.go`**: Exposed `BrowseHandler()` accessor
- **`internal/api/routes.go`**: Stored browse handler on server for external configuration
- **`internal/cli/daemon.go`**: Wired NVMe pool detection at startup — prepends staging paths + connects ZFS browse adapter

### Frontend (3 files)

- **`web/src/lib/api.js`**: `browse()` now accepts `{ includeZfs }` option
- **`web/src/components/PathBrowser.svelte`**: Added `includeZfs` prop passed through to API
- **`web/src/pages/Settings.svelte`**: Both DB and staging PathBrowsers pass `includeZfs={true}`; updated help text mentioning ZFS support

## Testing

- All 18 Go test packages pass
- golangci-lint: 0 issues
- `make build` ✅ (Ansible: lint → test → web build → cross-compile)
- `make deploy` ✅ (deployed to Unraid)
- `make verify` ✅ (62 ok, 0 failed — endpoint checks + VM smoke tests)
- Playwright UI verification ✅ (Settings page renders correctly with updated text)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browse UI now optionally includes ZFS pool mountpoints when listing directories.
  * NVMe-backed ZFS pools are auto-detected at startup and prioritised for staging/cache paths.
  * Settings page updated to mention ZFS zpools as available high-performance locations for database and staging.
  * Path browser component and API now support an include-ZFS flag to toggle ZFS discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->