### PR TITLE
fix(security): harden API error responses, storage adapters, and OAuth callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ coverage.html
 # Dependencies
 vendor/
 
-# Python bytecode
+# Python bytecode (from .claude skills)
 __pycache__/
 *.pyc
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ coverage.html
 # Dependencies
 vendor/
 
+# Python bytecode
+__pycache__/
+*.pyc
+
 # Ansible secrets (inventory contains server credentials)
 ansible/inventory.yml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
-### Security
+### Fixed
 
 - API key authentication middleware with loopback exemption: non-localhost requests require a valid `X-API-Key` header when an API key is configured; localhost and Unraid PHP proxy connections are always exempt
 - API error responses no longer leak internal error details to clients; all 500 responses now return a generic "internal server error" message while the real error is logged server-side (OWASP A09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - API key authentication middleware with loopback exemption: non-localhost requests require a valid `X-API-Key` header when an API key is configured; localhost and Unraid PHP proxy connections are always exempt
+- API key middleware now fails closed on database errors instead of allowing unauthenticated access
+- OAuth callback routes (`/gdrive/callback`, `/onedrive/callback`) are exempt from API key authentication since browser redirects cannot carry custom headers
+- `ReplicationSource.APIKey` is no longer exposed in JSON API responses (`json:"-"`)
+- API key sealed value is written before the hash to prevent partial-failure lockout; hash write failure triggers rollback of the sealed value
+- `api_key_hash` and `api_key_sealed` are redacted from `GET /settings` responses alongside encryption settings
+- `GET /settings/api-key/reveal` response includes `Cache-Control: no-store` to prevent sensitive key caching
+- "Server key not configured" error responses on API key handlers now use generic 500 via `respondInternalError` instead of leaking internal state
+- Fixed `sync.Mutex` deadlock in runner: `RunJob` already holds `r.mu`, removed redundant lock around `snapshotManager` access in snapshot save
+- Clipboard copy in Settings UI now handles errors with an error toast instead of silently failing
+- Middleware test `SetSetting` calls now check for errors to prevent misleading test results
 - API error responses no longer leak internal error details to clients; all 500 responses now return a generic "internal server error" message while the real error is logged server-side (OWASP A09)
 - SMB storage adapter now enforces a 30-second dial timeout via `context.WithTimeout` to prevent indefinite connection hangs
 - SFTP adapter logs a warning when falling back to `InsecureIgnoreHostKey` due to missing host key verification configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Security
+
+- API error responses no longer leak internal error details to clients; all 500 responses now return a generic "internal server error" message while the real error is logged server-side (OWASP A09)
+- SMB storage adapter now enforces a 30-second dial timeout via `context.WithTimeout` to prevent indefinite connection hangs
+- SFTP adapter logs a warning when falling back to `InsecureIgnoreHostKey` due to missing host key verification configuration
+- OAuth callback templates (Google Drive, OneDrive) restrict `postMessage` target origin from wildcard `*` to `window.location.origin`
+- Runner `SetSnapshotManager` write is now protected by mutex to prevent a data race with concurrent job execution
+- SMB `smbReadCloser.Close()` now uses `errors.Join` to surface file/share/session close failures instead of silently discarding them
+- NFS adapter `unmount()` now logs errors from `umount` and temp directory removal instead of silently discarding them
+
 ### Added
 
 - ZFS zpool support for database location: the path browser now includes ZFS pool mountpoints when browsing for custom database snapshot locations via `include_zfs` query parameter (closes #50)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Security
 
+- API key authentication middleware with loopback exemption: non-localhost requests require a valid `X-API-Key` header when an API key is configured; localhost and Unraid PHP proxy connections are always exempt
 - API error responses no longer leak internal error details to clients; all 500 responses now return a generic "internal server error" message while the real error is logged server-side (OWASP A09)
 - SMB storage adapter now enforces a 30-second dial timeout via `context.WithTimeout` to prevent indefinite connection hangs
 - SFTP adapter logs a warning when falling back to `InsecureIgnoreHostKey` due to missing host key verification configuration
@@ -18,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- API key management: generate, reveal, rotate, copy, and revoke a shared API key from Settings > Security for authenticating external integrations (Home Assistant, replication) — key is stored sealed (AES-256-GCM) and verified via bcrypt
+- Settings > Security > API Access card showing key status, reveal/copy, rotate, and revoke controls with confirmation dialog
+- `X-API-Key` header support in the replication client for authenticated cross-server sync
+- `api_key` column on `replication_sources` table for storing per-source API keys
 - ZFS zpool support for database location: the path browser now includes ZFS pool mountpoints when browsing for custom database snapshot locations via `include_zfs` query parameter (closes #50)
 - ZFS zpool support for temporary work area: NVMe-backed ZFS zpools are automatically detected at daemon startup and prepended to the staging cascade, giving them the highest priority for backup assembly (closes #51)
 - `ListNVMePools()` method on `ZFSHandler` to discover zpools composed entirely of NVMe devices

--- a/internal/api/handlers/activity.go
+++ b/internal/api/handlers/activity.go
@@ -31,7 +31,7 @@ func (h *ActivityHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	entries, err := h.db.ListActivityLogs(limit, category)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	if entries == nil {
@@ -45,7 +45,7 @@ func (h *ActivityHandler) List(w http.ResponseWriter, r *http.Request) {
 //	DELETE /api/v1/activity
 func (h *ActivityHandler) Purge(w http.ResponseWriter, _ *http.Request) {
 	if err := h.db.DeleteOldActivityLogs(0); err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/handlers/gdrive_oauth.go
+++ b/internal/api/handlers/gdrive_oauth.go
@@ -199,12 +199,12 @@ var gdriveCallbackTmpl = template.Must(template.New("gdrive-callback").Parse(`<!
 (function(){
 {{if .Success}}
   if(window.opener){
-    window.opener.postMessage({type:'gdrive-auth-code',code:{{.Code}}},'*');
+    window.opener.postMessage({type:'gdrive-auth-code',code:{{.Code}}},window.location.origin);
     setTimeout(function(){window.close()},2000);
   }
 {{else}}
   if(window.opener){
-    window.opener.postMessage({type:'gdrive-auth-error',error:{{.Error}}},'*');
+    window.opener.postMessage({type:'gdrive-auth-error',error:{{.Error}}},window.location.origin);
   }
   setTimeout(function(){window.close()},3000);
 {{end}}

--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -21,7 +21,7 @@ func NewHealthHandler(database *db.DB) *HealthHandler {
 func (h *HealthHandler) Summary(w http.ResponseWriter, r *http.Request) {
 	jobs, err := h.db.ListJobs()
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 

--- a/internal/api/handlers/jobs.go
+++ b/internal/api/handlers/jobs.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -293,7 +294,7 @@ func (h *JobHandler) Restore(w http.ResponseWriter, r *http.Request) {
 		// Look up job items to resolve types.
 		jobItems, itemsErr := h.db.GetJobItems(id)
 		if itemsErr != nil {
-			respondError(w, http.StatusInternalServerError, itemsErr.Error())
+			respondInternalError(w, fmt.Errorf("fetching job items: %w", itemsErr))
 			return
 		}
 		itemTypeMap := make(map[string]string, len(jobItems))

--- a/internal/api/handlers/jobs.go
+++ b/internal/api/handlers/jobs.go
@@ -60,7 +60,7 @@ func (h *JobHandler) reloadScheduler() {
 func (h *JobHandler) List(w http.ResponseWriter, r *http.Request) {
 	jobs, err := h.db.ListJobs()
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	respondJSON(w, http.StatusOK, jobs)
@@ -77,13 +77,13 @@ func (h *JobHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	id, err := h.db.CreateJob(req.Job)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	for _, item := range req.Items {
 		item.JobID = id
 		if _, err := h.db.AddJobItem(item); err != nil {
-			respondError(w, http.StatusInternalServerError, err.Error())
+			respondInternalError(w, err)
 			return
 		}
 	}
@@ -116,18 +116,18 @@ func (h *JobHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	req.Job.ID = id
 	if err := h.db.UpdateJob(req.Job); err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	if req.Items != nil {
 		if err := h.db.DeleteJobItems(id); err != nil {
-			respondError(w, http.StatusInternalServerError, err.Error())
+			respondInternalError(w, err)
 			return
 		}
 		for _, item := range req.Items {
 			item.JobID = id
 			if _, err := h.db.AddJobItem(item); err != nil {
-				respondError(w, http.StatusInternalServerError, err.Error())
+				respondInternalError(w, err)
 				return
 			}
 		}
@@ -149,7 +149,7 @@ func (h *JobHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.db.DeleteJob(id); err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -167,7 +167,7 @@ func (h *JobHandler) GetHistory(w http.ResponseWriter, r *http.Request) {
 	}
 	runs, err := h.db.GetJobRuns(id, limit)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	respondJSON(w, http.StatusOK, runs)
@@ -181,12 +181,12 @@ func (h *JobHandler) GetRestorePoints(w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusNotFound, "not found")
 			return
 		}
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	rps, err := h.db.ListRestorePoints(id)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	respondJSON(w, http.StatusOK, runner.AnnotateRestorePoints(job, rps))
@@ -259,7 +259,7 @@ func (h *JobHandler) Restore(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
 	rps, err := h.db.ListRestorePoints(id)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 
@@ -362,7 +362,7 @@ func (h *JobHandler) NextRun(w http.ResponseWriter, r *http.Request) {
 func (h *JobHandler) AllNextRuns(w http.ResponseWriter, r *http.Request) {
 	jobs, err := h.db.ListJobs()
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	result := make(map[string]any)

--- a/internal/api/handlers/onedrive_oauth.go
+++ b/internal/api/handlers/onedrive_oauth.go
@@ -195,12 +195,12 @@ var onedriveCallbackTmpl = template.Must(template.New("onedrive-callback").Parse
 (function(){
 {{if .Success}}
   if(window.opener){
-    window.opener.postMessage({type:'onedrive-auth-code',code:{{.Code}}},'*');
+    window.opener.postMessage({type:'onedrive-auth-code',code:{{.Code}}},window.location.origin);
     setTimeout(function(){window.close()},2000);
   }
 {{else}}
   if(window.opener){
-    window.opener.postMessage({type:'onedrive-auth-error',error:{{.Error}}},'*');
+    window.opener.postMessage({type:'onedrive-auth-error',error:{{.Error}}},window.location.origin);
   }
   setTimeout(function(){window.close()},3000);
 {{end}}

--- a/internal/api/handlers/recovery.go
+++ b/internal/api/handlers/recovery.go
@@ -25,13 +25,13 @@ func NewRecoveryHandler(database *db.DB, version string) *RecoveryHandler {
 func (h *RecoveryHandler) GetPlan(w http.ResponseWriter, r *http.Request) {
 	jobs, err := h.db.ListJobs()
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 
 	storageDests, err := h.db.ListStorageDestinations()
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 

--- a/internal/api/handlers/replication.go
+++ b/internal/api/handlers/replication.go
@@ -15,6 +15,35 @@ import (
 // SyncerProvider returns the replication syncer (resolved lazily).
 type SyncerProvider = func() *replication.Syncer
 
+// replicationSourceRequest is the write-side DTO for creating/updating
+// replication sources. It mirrors db.ReplicationSource but includes
+// api_key so clients can supply it (the model uses json:"-" to prevent
+// the key from leaking in responses).
+type replicationSourceRequest struct {
+	Name          string `json:"name"`
+	Type          string `json:"type"`
+	URL           string `json:"url"`
+	Config        string `json:"config"`
+	APIKey        string `json:"api_key"`
+	StorageDestID int64  `json:"storage_dest_id"`
+	Schedule      string `json:"schedule"`
+	Enabled       bool   `json:"enabled"`
+}
+
+// toModel converts the request DTO to a db.ReplicationSource.
+func (r *replicationSourceRequest) toModel() db.ReplicationSource {
+	return db.ReplicationSource{
+		Name:          r.Name,
+		Type:          r.Type,
+		URL:           r.URL,
+		Config:        r.Config,
+		APIKey:        r.APIKey,
+		StorageDestID: r.StorageDestID,
+		Schedule:      r.Schedule,
+		Enabled:       r.Enabled,
+	}
+}
+
 // ReplicationHandler handles CRUD and sync operations for replication sources.
 type ReplicationHandler struct {
 	db             *db.DB
@@ -68,11 +97,13 @@ func (h *ReplicationHandler) List(w http.ResponseWriter, r *http.Request) {
 
 // Create adds a new replication source.
 func (h *ReplicationHandler) Create(w http.ResponseWriter, r *http.Request) {
-	var src db.ReplicationSource
-	if err := json.NewDecoder(r.Body).Decode(&src); err != nil {
+	var req replicationSourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		respondError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
+	src := req.toModel()
+
 	if src.Name == "" {
 		respondError(w, http.StatusBadRequest, "name is required")
 		return
@@ -132,11 +163,12 @@ func (h *ReplicationHandler) Get(w http.ResponseWriter, r *http.Request) {
 func (h *ReplicationHandler) Update(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
 
-	var src db.ReplicationSource
-	if err := json.NewDecoder(r.Body).Decode(&src); err != nil {
+	var req replicationSourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		respondError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
+	src := req.toModel()
 	src.ID = id
 
 	if src.Type == "" {

--- a/internal/api/handlers/replication.go
+++ b/internal/api/handlers/replication.go
@@ -208,7 +208,13 @@ func (h *ReplicationHandler) TestConnection(w http.ResponseWriter, r *http.Reque
 		}
 		respondJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 	default: // remote_vault
-		client, clientErr := replication.NewClient(src.URL)
+		var client *replication.Client
+		var clientErr error
+		if src.APIKey != "" {
+			client, clientErr = replication.NewClientWithAPIKey(src.URL, src.APIKey)
+		} else {
+			client, clientErr = replication.NewClient(src.URL)
+		}
 		if clientErr != nil {
 			respondError(w, http.StatusBadRequest, "invalid url: "+clientErr.Error())
 			return

--- a/internal/api/handlers/replication.go
+++ b/internal/api/handlers/replication.go
@@ -60,7 +60,7 @@ func (h *ReplicationHandler) notifyConfigChange() {
 func (h *ReplicationHandler) List(w http.ResponseWriter, r *http.Request) {
 	sources, err := h.db.ListReplicationSources()
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	respondJSON(w, http.StatusOK, sources)
@@ -107,7 +107,7 @@ func (h *ReplicationHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	id, err := h.db.CreateReplicationSource(src)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	src.ID = id
@@ -158,7 +158,7 @@ func (h *ReplicationHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.db.UpdateReplicationSource(src); err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 
@@ -177,7 +177,7 @@ func (h *ReplicationHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.db.DeleteReplicationSource(id); err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 
@@ -272,7 +272,7 @@ func (h *ReplicationHandler) ListReplicatedJobs(w http.ResponseWriter, r *http.R
 	id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
 	jobs, err := h.db.ListReplicatedJobs(id)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	respondJSON(w, http.StatusOK, jobs)

--- a/internal/api/handlers/respond.go
+++ b/internal/api/handlers/respond.go
@@ -20,6 +20,13 @@ func respondError(w http.ResponseWriter, status int, msg string) {
 	respondJSON(w, status, map[string]string{"error": msg})
 }
 
+// respondInternalError logs the real error server-side and returns a generic
+// message to the client, preventing internal details from leaking in responses.
+func respondInternalError(w http.ResponseWriter, err error) {
+	log.Printf("internal error: %v", err)
+	respondError(w, http.StatusInternalServerError, "internal server error")
+}
+
 // ConfigChangeHook is called after a handler mutates persistent configuration
 // (jobs, storage destinations, settings). It triggers an immediate USB flash
 // backup so the flash copy always has fresh data.

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -306,7 +306,7 @@ func (h *SettingsHandler) SetEncryption(w http.ResponseWriter, r *http.Request) 
 	if len(h.serverKey) > 0 {
 		sealed, sealErr := crypto.Seal(h.serverKey, req.Passphrase)
 		if sealErr != nil {
-			respondError(w, http.StatusInternalServerError, "sealing passphrase: "+sealErr.Error())
+			respondInternalError(w, fmt.Errorf("sealing passphrase: %w", sealErr))
 			return
 		}
 		if err := h.db.SetSetting("encryption_passphrase_sealed", sealed); err != nil {
@@ -381,7 +381,7 @@ func (h *SettingsHandler) GetEncryptionPassphrase(w http.ResponseWriter, _ *http
 
 		passphrase, err := crypto.Unseal(h.serverKey, sealed)
 		if err != nil {
-			respondError(w, http.StatusInternalServerError, "unsealing passphrase: "+err.Error())
+			respondInternalError(w, fmt.Errorf("unsealing passphrase: %w", err))
 			return
 		}
 

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -244,6 +244,8 @@ var sensitiveSettingKeys = []string{
 	"encryption_passphrase",
 	"encryption_passphrase_hash",
 	"encryption_passphrase_sealed",
+	"api_key_hash",
+	"api_key_sealed",
 }
 
 // Update accepts a JSON object of key-value pairs and upserts them.
@@ -375,7 +377,7 @@ func (h *SettingsHandler) GetEncryptionPassphrase(w http.ResponseWriter, _ *http
 	sealed, _ := h.db.GetSetting("encryption_passphrase_sealed", "")
 	if sealed != "" {
 		if len(h.serverKey) == 0 {
-			respondError(w, http.StatusInternalServerError, "server key is not configured")
+			respondInternalError(w, fmt.Errorf("server key is not configured"))
 			return
 		}
 
@@ -506,7 +508,7 @@ func (h *SettingsHandler) GenerateAPIKey(w http.ResponseWriter, _ *http.Request)
 	}
 
 	if len(h.serverKey) == 0 {
-		respondError(w, http.StatusInternalServerError, "server key is not configured")
+		respondInternalError(w, fmt.Errorf("server key is not configured"))
 		return
 	}
 
@@ -516,19 +518,23 @@ func (h *SettingsHandler) GenerateAPIKey(w http.ResponseWriter, _ *http.Request)
 		return
 	}
 
-	if err := h.db.SetSetting("api_key_hash", hash); err != nil {
-		respondInternalError(w, fmt.Errorf("storing API key hash: %w", err))
-		return
-	}
+	// Write sealed key first so that if the hash write fails no auth is
+	// enabled yet, avoiding a state where remote clients get locked out.
 	if err := h.db.SetSetting("api_key_sealed", sealed); err != nil {
 		respondInternalError(w, fmt.Errorf("storing sealed API key: %w", err))
+		return
+	}
+	if err := h.db.SetSetting("api_key_hash", hash); err != nil {
+		// Roll back the sealed value to avoid a dangling sealed key.
+		_ = h.db.SetSetting("api_key_sealed", "")
+		respondInternalError(w, fmt.Errorf("storing API key hash: %w", err))
 		return
 	}
 
 	h.notifyConfigChange()
 	respondJSON(w, http.StatusCreated, map[string]string{
 		"api_key": key,
-		"message": "API key generated — copy it now, it will not be shown in full again",
+		"message": "API key generated — you can reveal it later from Settings › Security",
 	})
 }
 
@@ -544,7 +550,7 @@ func (h *SettingsHandler) GetAPIKey(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	if len(h.serverKey) == 0 {
-		respondError(w, http.StatusInternalServerError, "server key is not configured")
+		respondInternalError(w, fmt.Errorf("server key is not configured"))
 		return
 	}
 
@@ -554,6 +560,7 @@ func (h *SettingsHandler) GetAPIKey(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
+	w.Header().Set("Cache-Control", "no-store")
 	respondJSON(w, http.StatusOK, map[string]string{"api_key": key})
 }
 

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -86,13 +86,13 @@ func (h *SettingsHandler) GetDiagnostics(w http.ResponseWriter, _ *http.Request)
 
 	bundle, err := h.diagnosticsCollector.Collect()
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, fmt.Sprintf("collecting diagnostics: %v", err))
+		respondInternalError(w, fmt.Errorf("collecting diagnostics: %w", err))
 		return
 	}
 
 	zipReader, err := diagnostics.PackageAsZip(bundle)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, fmt.Sprintf("packaging diagnostics: %v", err))
+		respondInternalError(w, fmt.Errorf("packaging diagnostics: %w", err))
 		return
 	}
 	if closer, ok := zipReader.(io.Closer); ok {

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -185,7 +185,7 @@ func (h *SettingsHandler) SetSnapshotPath(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := h.db.SetSetting("snapshot_path_override", req.SnapshotPath); err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 
@@ -213,7 +213,7 @@ func (h *SettingsHandler) SetSnapshotPath(w http.ResponseWriter, r *http.Request
 func (h *SettingsHandler) List(w http.ResponseWriter, r *http.Request) {
 	settings, err := h.db.GetAllSettings()
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 
@@ -256,7 +256,7 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	for k, v := range incoming {
 		if err := h.db.SetSetting(k, v); err != nil {
-			respondError(w, http.StatusInternalServerError, err.Error())
+			respondInternalError(w, err)
 			return
 		}
 	}
@@ -293,12 +293,12 @@ func (h *SettingsHandler) SetEncryption(w http.ResponseWriter, r *http.Request) 
 
 	hash, err := crypto.HashPassphrase(req.Passphrase)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 
 	if err := h.db.SetSetting("encryption_passphrase_hash", hash); err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 
@@ -310,7 +310,7 @@ func (h *SettingsHandler) SetEncryption(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		if err := h.db.SetSetting("encryption_passphrase_sealed", sealed); err != nil {
-			respondError(w, http.StatusInternalServerError, err.Error())
+			respondInternalError(w, err)
 			return
 		}
 	}
@@ -403,7 +403,7 @@ func (h *SettingsHandler) GetStagingInfo(w http.ResponseWriter, r *http.Request)
 	override, _ := h.db.GetSetting("staging_dir_override", "")
 	dests, err := h.db.ListStorageDestinations()
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	configs := make([]tempdir.StorageConfig, len(dests))
@@ -438,7 +438,7 @@ func (h *SettingsHandler) SetStagingOverride(w http.ResponseWriter, r *http.Requ
 	}
 
 	if err := h.db.SetSetting("staging_dir_override", req.Override); err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -477,3 +477,116 @@ func (h *SettingsHandler) TestDiscordWebhook(w http.ResponseWriter, r *http.Requ
 	}
 	respondJSON(w, http.StatusOK, map[string]string{"message": "Test notification sent"})
 }
+
+// GetAPIKeyStatus returns whether an API key has been configured.
+//
+//	GET /api/v1/settings/api-key
+func (h *SettingsHandler) GetAPIKeyStatus(w http.ResponseWriter, _ *http.Request) {
+	hash, _ := h.db.GetSetting("api_key_hash", "")
+	respondJSON(w, http.StatusOK, map[string]any{
+		"enabled": hash != "",
+	})
+}
+
+// GenerateAPIKey creates a new API key, stores it sealed + hashed, and
+// returns the plaintext key once. Subsequent reads use GetAPIKey.
+//
+//	POST /api/v1/settings/api-key/generate
+func (h *SettingsHandler) GenerateAPIKey(w http.ResponseWriter, _ *http.Request) {
+	key, err := crypto.GenerateAPIKey()
+	if err != nil {
+		respondInternalError(w, fmt.Errorf("generating API key: %w", err))
+		return
+	}
+
+	hash, err := crypto.HashPassphrase(key)
+	if err != nil {
+		respondInternalError(w, fmt.Errorf("hashing API key: %w", err))
+		return
+	}
+
+	if len(h.serverKey) == 0 {
+		respondError(w, http.StatusInternalServerError, "server key is not configured")
+		return
+	}
+
+	sealed, err := crypto.Seal(h.serverKey, key)
+	if err != nil {
+		respondInternalError(w, fmt.Errorf("sealing API key: %w", err))
+		return
+	}
+
+	if err := h.db.SetSetting("api_key_hash", hash); err != nil {
+		respondInternalError(w, fmt.Errorf("storing API key hash: %w", err))
+		return
+	}
+	if err := h.db.SetSetting("api_key_sealed", sealed); err != nil {
+		respondInternalError(w, fmt.Errorf("storing sealed API key: %w", err))
+		return
+	}
+
+	h.notifyConfigChange()
+	respondJSON(w, http.StatusCreated, map[string]string{
+		"api_key": key,
+		"message": "API key generated — copy it now, it will not be shown in full again",
+	})
+}
+
+// GetAPIKey returns the stored API key by unsealing it. This allows the
+// user to view/copy the key from the Settings UI.
+//
+//	GET /api/v1/settings/api-key/reveal
+func (h *SettingsHandler) GetAPIKey(w http.ResponseWriter, _ *http.Request) {
+	sealed, _ := h.db.GetSetting("api_key_sealed", "")
+	if sealed == "" {
+		respondError(w, http.StatusNotFound, "no API key configured")
+		return
+	}
+
+	if len(h.serverKey) == 0 {
+		respondError(w, http.StatusInternalServerError, "server key is not configured")
+		return
+	}
+
+	key, err := crypto.Unseal(h.serverKey, sealed)
+	if err != nil {
+		respondInternalError(w, fmt.Errorf("unsealing API key: %w", err))
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]string{"api_key": key})
+}
+
+// RotateAPIKey replaces the existing API key with a new random one.
+//
+//	POST /api/v1/settings/api-key/rotate
+func (h *SettingsHandler) RotateAPIKey(w http.ResponseWriter, r *http.Request) {
+	// Verify an existing key is set.
+	hash, _ := h.db.GetSetting("api_key_hash", "")
+	if hash == "" {
+		respondError(w, http.StatusBadRequest, "no existing API key to rotate — generate one first")
+		return
+	}
+
+	// Generate handles all storage — reuse the handler.
+	h.GenerateAPIKey(w, r)
+}
+
+// RevokeAPIKey removes the stored API key, disabling authentication.
+//
+//	DELETE /api/v1/settings/api-key
+func (h *SettingsHandler) RevokeAPIKey(w http.ResponseWriter, _ *http.Request) {
+	if err := h.db.SetSetting("api_key_hash", ""); err != nil {
+		respondInternalError(w, fmt.Errorf("clearing API key hash: %w", err))
+		return
+	}
+	if err := h.db.SetSetting("api_key_sealed", ""); err != nil {
+		respondInternalError(w, fmt.Errorf("clearing sealed API key: %w", err))
+		return
+	}
+
+	h.notifyConfigChange()
+	respondJSON(w, http.StatusOK, map[string]string{
+		"message": "API key revoked — authentication disabled",
+	})
+}

--- a/internal/api/handlers/storage.go
+++ b/internal/api/handlers/storage.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -239,7 +240,7 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 
 	adapter, err := storage.NewAdapter(dest.Type, dest.Config)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to create storage adapter: "+err.Error())
+		respondInternalError(w, fmt.Errorf("creating storage adapter: %w", err))
 		return
 	}
 
@@ -254,7 +255,7 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 	// Write to a temporary file first.
 	tmpFile, err := os.CreateTemp("", "vault-restore-*.db")
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to create temp file: "+err.Error())
+		respondInternalError(w, fmt.Errorf("creating temp file: %w", err))
 		return
 	}
 	tmpPath := tmpFile.Name()
@@ -262,7 +263,7 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 	if _, err := io.Copy(tmpFile, rc); err != nil {
 		_ = tmpFile.Close()
 		_ = os.Remove(tmpPath)
-		respondError(w, http.StatusInternalServerError, "failed to download database: "+err.Error())
+		respondInternalError(w, fmt.Errorf("downloading database: %w", err))
 		return
 	}
 	_ = tmpFile.Close()
@@ -290,7 +291,7 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 	srcFile, err := os.Open(tmpPath)
 	if err != nil {
 		_ = os.Remove(tmpPath)
-		respondError(w, http.StatusInternalServerError, "failed to open restored database: "+err.Error())
+		respondInternalError(w, fmt.Errorf("opening restored database: %w", err))
 		return
 	}
 
@@ -298,7 +299,7 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		_ = srcFile.Close()
 		_ = os.Remove(tmpPath)
-		respondError(w, http.StatusInternalServerError, "failed to replace database: "+err.Error())
+		respondInternalError(w, fmt.Errorf("replacing database: %w", err))
 		return
 	}
 
@@ -306,7 +307,7 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 		_ = srcFile.Close()
 		_ = dstFile.Close()
 		_ = os.Remove(tmpPath)
-		respondError(w, http.StatusInternalServerError, "failed to write database: "+err.Error())
+		respondInternalError(w, fmt.Errorf("writing database: %w", err))
 		return
 	}
 	_ = srcFile.Close()
@@ -348,14 +349,14 @@ func (h *StorageHandler) ListFiles(w http.ResponseWriter, r *http.Request) {
 
 	adapter, err := storage.NewAdapter(dest.Type, dest.Config)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, "open storage: "+err.Error())
+		respondInternalError(w, fmt.Errorf("open storage: %w", err))
 		return
 	}
 
 	prefix := r.URL.Query().Get("prefix")
 	files, err := adapter.List(prefix)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, "list files: "+err.Error())
+		respondInternalError(w, fmt.Errorf("list files: %w", err))
 		return
 	}
 	respondJSON(w, http.StatusOK, files)
@@ -380,7 +381,7 @@ func (h *StorageHandler) DownloadFile(w http.ResponseWriter, r *http.Request) {
 
 	adapter, err := storage.NewAdapter(dest.Type, dest.Config)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, "open storage: "+err.Error())
+		respondInternalError(w, fmt.Errorf("open storage: %w", err))
 		return
 	}
 

--- a/internal/api/handlers/storage.go
+++ b/internal/api/handlers/storage.go
@@ -40,7 +40,7 @@ func (h *StorageHandler) notifyConfigChange() {
 func (h *StorageHandler) List(w http.ResponseWriter, r *http.Request) {
 	dests, err := h.db.ListStorageDestinations()
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	for i := range dests {
@@ -57,7 +57,7 @@ func (h *StorageHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	id, err := h.db.CreateStorageDestination(dest)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	dest.ID = id
@@ -85,7 +85,7 @@ func (h *StorageHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	dest.ID = id
 	if err := h.db.UpdateStorageDestination(dest); err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	respondJSON(w, http.StatusOK, dest)
@@ -98,7 +98,7 @@ func (h *StorageHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	// Check for dependent jobs.
 	jobCount, err := h.db.CountJobsByStorageDestID(id)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	if jobCount > 0 && r.URL.Query().Get("force") != "true" {
@@ -120,7 +120,7 @@ func (h *StorageHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.db.DeleteStorageDestination(id); err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -160,7 +160,7 @@ func (h *StorageHandler) Scan(w http.ResponseWriter, r *http.Request) {
 
 	manifests, err := h.runner.ScanStorageManifests(dest)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 
@@ -203,7 +203,7 @@ func (h *StorageHandler) Import(w http.ResponseWriter, r *http.Request) {
 
 	imported, err := h.runner.ImportBackups(id, req.Backups)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 
@@ -329,7 +329,7 @@ func (h *StorageHandler) DependentJobs(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
 	count, err := h.db.CountJobsByStorageDestID(id)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondInternalError(w, err)
 		return
 	}
 	respondJSON(w, http.StatusOK, map[string]any{"job_count": count})

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -8,6 +8,9 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/ruaan-deysel/vault/internal/crypto"
+	"github.com/ruaan-deysel/vault/internal/db"
 )
 
 const (
@@ -108,4 +111,67 @@ func BodySizeLimit(maxBytes int64) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// APIKeyAuth returns middleware that enforces API key authentication for
+// non-loopback requests. Loopback connections (127.0.0.1, ::1) and the
+// Unraid PHP proxy are always exempt — authentication only applies when
+// the daemon is exposed on a LAN address (bind != 127.0.0.1).
+//
+// The middleware checks the X-API-Key header against the bcrypt hash stored
+// in the settings table. If no API key has been generated, all requests pass.
+func APIKeyAuth(database *db.DB) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Loopback connections are always exempt.
+			if isLoopback(r.RemoteAddr) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Check if an API key has been configured.
+			hash, err := database.GetSetting("api_key_hash", "")
+			if err != nil || hash == "" {
+				// No API key set — all requests pass.
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Extract key from X-API-Key header.
+			key := r.Header.Get("X-API-Key")
+			if key == "" {
+				respondUnauthorized(w)
+				return
+			}
+
+			// Constant-time comparison via bcrypt.
+			if err := crypto.VerifyPassphrase(key, hash); err != nil {
+				respondUnauthorized(w)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// isLoopback returns true if the remote address is a loopback address
+// (127.0.0.0/8 or ::1). This exempts local UI and Unraid PHP proxy requests.
+func isLoopback(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr
+	}
+	host = strings.Trim(host, "[]")
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
+}
+
+func respondUnauthorized(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+	_, _ = w.Write([]byte(`{"error":"valid API key required"}`))
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -129,9 +129,21 @@ func APIKeyAuth(database *db.DB) func(http.Handler) http.Handler {
 				return
 			}
 
+			// OAuth callback routes cannot carry API keys because the
+			// browser is redirected by the provider. Exempt them.
+			if isOAuthCallback(r.URL.Path) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			// Check if an API key has been configured.
 			hash, err := database.GetSetting("api_key_hash", "")
-			if err != nil || hash == "" {
+			if err != nil {
+				// Fail closed: DB errors must not allow unauthenticated access.
+				respondUnauthorized(w)
+				return
+			}
+			if hash == "" {
 				// No API key set — all requests pass.
 				next.ServeHTTP(w, r)
 				return
@@ -168,6 +180,24 @@ func isLoopback(remoteAddr string) bool {
 		return false
 	}
 	return ip.IsLoopback()
+}
+
+// oauthCallbackSuffixes are URL path suffixes that indicate an OAuth provider
+// redirect. These cannot carry API keys, so they must be exempt.
+var oauthCallbackSuffixes = []string{
+	"/gdrive/callback",
+	"/onedrive/callback",
+}
+
+// isOAuthCallback returns true when the request path ends with a known
+// OAuth callback suffix.
+func isOAuthCallback(path string) bool {
+	for _, suffix := range oauthCallbackSuffixes {
+		if strings.HasSuffix(path, suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 func respondUnauthorized(w http.ResponseWriter) {

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -201,7 +201,5 @@ func isOAuthCallback(path string) bool {
 }
 
 func respondUnauthorized(w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusUnauthorized)
-	_, _ = w.Write([]byte(`{"error":"valid API key required"}`))
+	respondJSON(w, http.StatusUnauthorized, map[string]string{"error": "valid API key required"})
 }

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -179,9 +179,13 @@ func TestAPIKeyAuth(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Reset api_key_hash setting for each subtest.
-			database.SetSetting("api_key_hash", "")
+			if err := database.SetSetting("api_key_hash", ""); err != nil {
+				t.Fatalf("resetting api_key_hash: %v", err)
+			}
 			if tt.setupKey {
-				database.SetSetting("api_key_hash", hash)
+				if err := database.SetSetting("api_key_hash", hash); err != nil {
+					t.Fatalf("setting api_key_hash: %v", err)
+				}
 			}
 
 			req := httptest.NewRequest("GET", "/", nil)

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -5,9 +5,13 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ruaan-deysel/vault/internal/crypto"
+	"github.com/ruaan-deysel/vault/internal/db"
 )
 
 func TestQuietRequestLogger(t *testing.T) {
@@ -95,6 +99,99 @@ func TestReadOnlyGuard(t *testing.T) {
 			req := httptest.NewRequest(tt.method, "/", nil)
 			w := httptest.NewRecorder()
 			handler.ServeHTTP(w, req)
+			if w.Code != tt.wantStatus {
+				t.Errorf("got status %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestAPIKeyAuth(t *testing.T) {
+	t.Parallel()
+
+	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+	middleware := APIKeyAuth(database)
+	handler := middleware(okHandler)
+
+	apiKey := "vault_testkey_abc123"
+	hash, err := crypto.HashPassphrase(apiKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		header     string
+		setupKey   bool
+		wantStatus int
+	}{
+		{
+			name:       "loopback exempt ipv4",
+			remoteAddr: "127.0.0.1:12345",
+			setupKey:   true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "loopback exempt ipv6",
+			remoteAddr: "[::1]:12345",
+			setupKey:   true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "no key configured passes through",
+			remoteAddr: "192.168.1.50:12345",
+			setupKey:   false,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "valid key from remote",
+			remoteAddr: "192.168.1.50:12345",
+			header:     apiKey,
+			setupKey:   true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "invalid key from remote",
+			remoteAddr: "192.168.1.50:12345",
+			header:     "vault_wrong_key",
+			setupKey:   true,
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "missing key from remote",
+			remoteAddr: "192.168.1.50:12345",
+			header:     "",
+			setupKey:   true,
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset api_key_hash setting for each subtest.
+			database.SetSetting("api_key_hash", "")
+			if tt.setupKey {
+				database.SetSetting("api_key_hash", hash)
+			}
+
+			req := httptest.NewRequest("GET", "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.header != "" {
+				req.Header.Set("X-API-Key", tt.header)
+			}
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
 			if w.Code != tt.wantStatus {
 				t.Errorf("got status %d, want %d", w.Code, tt.wantStatus)
 			}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -24,6 +24,9 @@ func (s *Server) setupRoutes() *chi.Mux {
 	r.Use(BodySizeLimit(maxRequestBodySize))
 
 	r.Route("/api/v1", func(r chi.Router) {
+		// API key auth — only affects non-loopback requests when an API key
+		// has been configured. Loopback/Unraid PHP proxy is always exempt.
+		r.Use(APIKeyAuth(s.db))
 		// Wrap the config change hook to run asynchronously so it doesn't
 		// block HTTP responses. The hook flushes the DB to USB flash.
 		asyncHook := handlers.ConfigChangeHook(func() {
@@ -108,6 +111,11 @@ func (s *Server) setupRoutes() *chi.Mux {
 			r.Get("/database", settingsH.GetDatabaseInfo)
 			r.Put("/database", settingsH.SetSnapshotPath)
 			r.Get("/diagnostics", settingsH.GetDiagnostics)
+			r.Get("/api-key", settingsH.GetAPIKeyStatus)
+			r.Get("/api-key/reveal", settingsH.GetAPIKey)
+			r.Post("/api-key/generate", settingsH.GenerateAPIKey)
+			r.Post("/api-key/rotate", settingsH.RotateAPIKey)
+			r.Delete("/api-key", settingsH.RevokeAPIKey)
 		})
 
 		browseH := handlers.NewBrowseHandler()

--- a/internal/crypto/apikey.go
+++ b/internal/crypto/apikey.go
@@ -1,0 +1,23 @@
+package crypto
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+)
+
+const (
+	// apiKeyPrefix is prepended to generated API keys for identification.
+	apiKeyPrefix = "vault_"
+	// apiKeyRandomBytes is the number of random bytes in an API key.
+	apiKeyRandomBytes = 32
+)
+
+// GenerateAPIKey creates a new random API key with the "vault_" prefix.
+func GenerateAPIKey() (string, error) {
+	b := make([]byte, apiKeyRandomBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating random bytes: %w", err)
+	}
+	return apiKeyPrefix + base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/internal/crypto/apikey_test.go
+++ b/internal/crypto/apikey_test.go
@@ -1,0 +1,28 @@
+package crypto
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateAPIKey(t *testing.T) {
+	t.Parallel()
+
+	key, err := GenerateAPIKey()
+	if err != nil {
+		t.Fatalf("GenerateAPIKey() error = %v", err)
+	}
+
+	if !strings.HasPrefix(key, "vault_") {
+		t.Errorf("expected prefix vault_, got %q", key)
+	}
+
+	// Verify uniqueness (sanity check).
+	key2, err := GenerateAPIKey()
+	if err != nil {
+		t.Fatalf("GenerateAPIKey() second call error = %v", err)
+	}
+	if key == key2 {
+		t.Error("two generated keys should not be identical")
+	}
+}

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -111,4 +111,5 @@ var alterMigrations = []string{
 	"ALTER TABLE job_runs ADD COLUMN run_type TEXT DEFAULT 'backup'",
 	"ALTER TABLE replication_sources ADD COLUMN type TEXT DEFAULT 'remote_vault'",
 	"ALTER TABLE replication_sources ADD COLUMN config TEXT DEFAULT '{}'",
+	"ALTER TABLE replication_sources ADD COLUMN api_key TEXT DEFAULT ''",
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -90,6 +90,7 @@ type ReplicationSource struct {
 	Type           string     `json:"type"`
 	URL            string     `json:"url"`
 	Config         string     `json:"config"`
+	APIKey         string     `json:"api_key,omitempty"`
 	StorageDestID  int64      `json:"storage_dest_id"`
 	Schedule       string     `json:"schedule"`
 	Enabled        bool       `json:"enabled"`

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -90,7 +90,7 @@ type ReplicationSource struct {
 	Type           string     `json:"type"`
 	URL            string     `json:"url"`
 	Config         string     `json:"config"`
-	APIKey         string     `json:"api_key,omitempty"`
+	APIKey         string     `json:"-"`
 	StorageDestID  int64      `json:"storage_dest_id"`
 	Schedule       string     `json:"schedule"`
 	Enabled        bool       `json:"enabled"`

--- a/internal/db/replication_repo.go
+++ b/internal/db/replication_repo.go
@@ -18,9 +18,9 @@ func (d *DB) CreateReplicationSource(src ReplicationSource) (int64, error) {
 		cfg = "{}"
 	}
 	res, err := d.Exec(
-		`INSERT INTO replication_sources (name, type, url, config, storage_dest_id, schedule, enabled)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		src.Name, typ, src.URL, cfg, destID, src.Schedule, src.Enabled,
+		`INSERT INTO replication_sources (name, type, url, config, api_key, storage_dest_id, schedule, enabled)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		src.Name, typ, src.URL, cfg, src.APIKey, destID, src.Schedule, src.Enabled,
 	)
 	if err != nil {
 		return 0, err
@@ -33,10 +33,10 @@ func (d *DB) GetReplicationSource(id int64) (ReplicationSource, error) {
 	var src ReplicationSource
 	err := d.QueryRow(
 		`SELECT id, name, COALESCE(type, 'remote_vault'), url, COALESCE(config, '{}'),
-			COALESCE(storage_dest_id, 0), schedule, enabled,
+			COALESCE(api_key, ''), COALESCE(storage_dest_id, 0), schedule, enabled,
 			last_sync_at, last_sync_status, last_sync_error, created_at, updated_at
 		FROM replication_sources WHERE id = ?`, id,
-	).Scan(&src.ID, &src.Name, &src.Type, &src.URL, &src.Config, &src.StorageDestID,
+	).Scan(&src.ID, &src.Name, &src.Type, &src.URL, &src.Config, &src.APIKey, &src.StorageDestID,
 		&src.Schedule, &src.Enabled, &src.LastSyncAt, &src.LastSyncStatus,
 		&src.LastSyncError, &src.CreatedAt, &src.UpdatedAt)
 	if err == sql.ErrNoRows {
@@ -49,7 +49,7 @@ func (d *DB) GetReplicationSource(id int64) (ReplicationSource, error) {
 func (d *DB) ListReplicationSources() ([]ReplicationSource, error) {
 	rows, err := d.Query(
 		`SELECT id, name, COALESCE(type, 'remote_vault'), url, COALESCE(config, '{}'),
-			COALESCE(storage_dest_id, 0), schedule, enabled,
+			COALESCE(api_key, ''), COALESCE(storage_dest_id, 0), schedule, enabled,
 			last_sync_at, last_sync_status, last_sync_error, created_at, updated_at
 		FROM replication_sources ORDER BY name`)
 	if err != nil {
@@ -59,7 +59,7 @@ func (d *DB) ListReplicationSources() ([]ReplicationSource, error) {
 	var sources []ReplicationSource
 	for rows.Next() {
 		var src ReplicationSource
-		if err := rows.Scan(&src.ID, &src.Name, &src.Type, &src.URL, &src.Config, &src.StorageDestID,
+		if err := rows.Scan(&src.ID, &src.Name, &src.Type, &src.URL, &src.Config, &src.APIKey, &src.StorageDestID,
 			&src.Schedule, &src.Enabled, &src.LastSyncAt, &src.LastSyncStatus,
 			&src.LastSyncError, &src.CreatedAt, &src.UpdatedAt); err != nil {
 			return nil, err
@@ -76,9 +76,9 @@ func (d *DB) UpdateReplicationSource(src ReplicationSource) error {
 		destID = src.StorageDestID
 	}
 	_, err := d.Exec(
-		`UPDATE replication_sources SET name=?, type=?, url=?, config=?, storage_dest_id=?,
+		`UPDATE replication_sources SET name=?, type=?, url=?, config=?, api_key=?, storage_dest_id=?,
 		schedule=?, enabled=?, updated_at=CURRENT_TIMESTAMP WHERE id=?`,
-		src.Name, src.Type, src.URL, src.Config, destID,
+		src.Name, src.Type, src.URL, src.Config, src.APIKey, destID,
 		src.Schedule, src.Enabled, src.ID,
 	)
 	return err

--- a/internal/db/settings_repo.go
+++ b/internal/db/settings_repo.go
@@ -1,6 +1,9 @@
 package db
 
-import "database/sql"
+import (
+	"database/sql"
+	"errors"
+)
 
 // GetSetting retrieves a setting value by key. Returns the default if not found.
 // Real database errors are propagated to the caller.
@@ -8,7 +11,7 @@ func (d *DB) GetSetting(key, defaultVal string) (string, error) {
 	var val string
 	err := d.QueryRow("SELECT value FROM settings WHERE key = ?", key).Scan(&val)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return defaultVal, nil
 		}
 		return defaultVal, err

--- a/internal/db/settings_repo.go
+++ b/internal/db/settings_repo.go
@@ -1,11 +1,17 @@
 package db
 
+import "database/sql"
+
 // GetSetting retrieves a setting value by key. Returns the default if not found.
+// Real database errors are propagated to the caller.
 func (d *DB) GetSetting(key, defaultVal string) (string, error) {
 	var val string
 	err := d.QueryRow("SELECT value FROM settings WHERE key = ?", key).Scan(&val)
 	if err != nil {
-		return defaultVal, nil //nolint:nilerr // missing key is not an error
+		if err == sql.ErrNoRows {
+			return defaultVal, nil
+		}
+		return defaultVal, err
 	}
 	return val, nil
 }

--- a/internal/db/snapshot.go
+++ b/internal/db/snapshot.go
@@ -110,10 +110,13 @@ func validateSnapshotPath(path string) (string, error) {
 	}
 
 	// Defence-in-depth: verify the normalised absolute path contains no
-	// traversal components. This also serves as a CodeQL-recognised
-	// sanitiser barrier for go/path-injection.
-	if strings.Contains(absPath, "..") {
-		return "", fmt.Errorf("path traversal not allowed in snapshot path")
+	// traversal components by checking path elements, not substrings, so
+	// legitimate names like "backups..2026" are not rejected. This also
+	// serves as a CodeQL-recognised sanitiser barrier for go/path-injection.
+	for _, part := range strings.Split(filepath.ToSlash(absPath), "/") {
+		if part == ".." {
+			return "", fmt.Errorf("path traversal not allowed in snapshot path")
+		}
 	}
 
 	return absPath, nil

--- a/internal/db/snapshot.go
+++ b/internal/db/snapshot.go
@@ -109,6 +109,13 @@ func validateSnapshotPath(path string) (string, error) {
 		return "", fmt.Errorf("resolve snapshot path: %w", err)
 	}
 
+	// Defence-in-depth: verify the normalised absolute path contains no
+	// traversal components. This also serves as a CodeQL-recognised
+	// sanitiser barrier for go/path-injection.
+	if strings.Contains(absPath, "..") {
+		return "", fmt.Errorf("path traversal not allowed in snapshot path")
+	}
+
 	return absPath, nil
 }
 

--- a/internal/replication/client.go
+++ b/internal/replication/client.go
@@ -13,6 +13,7 @@ import (
 // Client talks to a remote Vault API server.
 type Client struct {
 	baseURL    string
+	apiKey     string
 	httpClient *http.Client
 }
 
@@ -29,6 +30,17 @@ func NewClient(baseURL string) (*Client, error) {
 			Timeout: 10 * time.Minute,
 		},
 	}, nil
+}
+
+// NewClientWithAPIKey creates a replication client that authenticates using
+// the given API key via the X-API-Key header.
+func NewClientWithAPIKey(baseURL, apiKey string) (*Client, error) {
+	c, err := NewClient(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	c.apiKey = apiKey
+	return c, nil
 }
 
 // NormalizeBaseURL validates and canonicalizes a remote Vault base URL.
@@ -209,6 +221,9 @@ func (c *Client) doRequestWithParams(method, path string, params map[string]stri
 	req, err := http.NewRequest(method, u, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
+	}
+	if c.apiKey != "" {
+		req.Header.Set("X-API-Key", c.apiKey)
 	}
 	return c.httpClient.Do(req)
 }

--- a/internal/replication/sync.go
+++ b/internal/replication/sync.go
@@ -79,7 +79,13 @@ func (s *Syncer) syncRemoteVault(src db.ReplicationSource, progress ProgressFunc
 	sourceID := src.ID
 
 	// Build the remote client.
-	client, err := NewClient(src.URL)
+	var client *Client
+	var err error
+	if src.APIKey != "" {
+		client, err = NewClientWithAPIKey(src.URL, src.APIKey)
+	} else {
+		client, err = NewClient(src.URL)
+	}
 	if err != nil {
 		errMsg := fmt.Sprintf("normalize source url %q: %v", src.Name, err)
 		s.updateSyncStatus(sourceID, "failed", err.Error())

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -888,8 +888,11 @@ func (r *Runner) RunJob(jobID int64) {
 		r.backupDatabase(dest, basePath)
 
 		// Persist database to cache drive and USB backup after successful backup.
-		if r.snapshotManager != nil {
-			if err := r.snapshotManager.SaveSnapshotAndUSBBackup(); err != nil {
+		r.mu.Lock()
+		sm := r.snapshotManager
+		r.mu.Unlock()
+		if sm != nil {
+			if err := sm.SaveSnapshotAndUSBBackup(); err != nil {
 				log.Printf("runner: snapshot save error: %v", err)
 			}
 		}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -888,9 +888,9 @@ func (r *Runner) RunJob(jobID int64) {
 		r.backupDatabase(dest, basePath)
 
 		// Persist database to cache drive and USB backup after successful backup.
-		r.mu.Lock()
+		// r.mu is already held by RunJob (line 289), so access snapshotManager
+		// directly without re-locking.
 		sm := r.snapshotManager
-		r.mu.Unlock()
 		if sm != nil {
 			if err := sm.SaveSnapshotAndUSBBackup(); err != nil {
 				log.Printf("runner: snapshot save error: %v", err)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -260,6 +260,8 @@ func (r *countingReader) Read(p []byte) (int, error) {
 // SetSnapshotManager sets the snapshot manager used to persist the database
 // to the cache drive after successful backup jobs.
 func (r *Runner) SetSnapshotManager(sm *db.SnapshotManager) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.snapshotManager = sm
 }
 

--- a/internal/storage/nfs.go
+++ b/internal/storage/nfs.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -105,8 +106,12 @@ func (n *NFSAdapter) unmount() {
 	if !n.mounted {
 		return
 	}
-	_ = exec.Command("umount", n.mountDir).Run() //nolint:gosec // mountDir is vault-controlled temp dir
-	_ = os.Remove(n.mountDir)
+	if err := exec.Command("umount", n.mountDir).Run(); err != nil { //nolint:gosec // mountDir is vault-controlled temp dir
+		log.Printf("Warning: nfs unmount %s failed: %v", n.mountDir, err)
+	}
+	if err := os.Remove(n.mountDir); err != nil && !os.IsNotExist(err) {
+		log.Printf("Warning: nfs cleanup %s failed: %v", n.mountDir, err)
+	}
 	n.mounted = false
 	n.local = nil
 }

--- a/internal/storage/sftp.go
+++ b/internal/storage/sftp.go
@@ -99,7 +99,10 @@ func (s *SFTPAdapter) hostKeyCallback() ssh.HostKeyCallback {
 		if err == nil {
 			return cb
 		}
-		// Fall through on error.
+		// Log the load error and fall through to the next option.
+		log.Printf("Warning: SFTP could not load known_hosts_file %q for host %s: %v. "+
+			"Falling back to insecure host key acceptance — configure a valid known_hosts_file or host_key to prevent MITM attacks.",
+			s.config.KnownHostsFile, s.config.Host, err)
 	}
 
 	// Option 2: Verify against a SHA-256 fingerprint of the host key.

--- a/internal/storage/sftp.go
+++ b/internal/storage/sftp.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -115,6 +116,8 @@ func (s *SFTPAdapter) hostKeyCallback() ssh.HostKeyCallback {
 	}
 
 	// Fallback: accept any key (backward compatibility with existing configs).
+	log.Printf("Warning: SFTP connection to %s has no host key verification configured. "+
+		"Set host_key or known_hosts_file in storage config to prevent MITM attacks.", s.config.Host)
 	return ssh.InsecureIgnoreHostKey() //nolint:gosec // user chose not to configure host key
 }
 

--- a/internal/storage/smb.go
+++ b/internal/storage/smb.go
@@ -2,9 +2,11 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
+	"time"
 
 	"github.com/cloudsoda/go-smb2"
 	"github.com/ruaan-deysel/vault/internal/safepath"
@@ -35,6 +37,9 @@ func NewSMBAdapter(config SMBConfig) (*SMBAdapter, error) {
 	return &SMBAdapter{config: config}, nil
 }
 
+// smbDialTimeout is the maximum time allowed for dialling and mounting an SMB share.
+const smbDialTimeout = 30 * time.Second
+
 func (s *SMBAdapter) connect() (*smb2.Share, *smb2.Session, error) {
 	addr := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)
 
@@ -45,7 +50,10 @@ func (s *SMBAdapter) connect() (*smb2.Share, *smb2.Session, error) {
 		},
 	}
 
-	session, err := d.Dial(context.Background(), addr)
+	ctx, cancel := context.WithTimeout(context.Background(), smbDialTimeout)
+	defer cancel()
+
+	session, err := d.Dial(ctx, addr)
 	if err != nil {
 		return nil, nil, fmt.Errorf("smb dial: %w", err)
 	}
@@ -122,9 +130,11 @@ type smbReadCloser struct {
 
 func (r *smbReadCloser) Read(p []byte) (int, error) { return r.file.Read(p) }
 func (r *smbReadCloser) Close() error {
-	_ = r.file.Close()
-	_ = r.share.Umount()
-	return r.session.Logoff()
+	return errors.Join(
+		r.file.Close(),
+		r.share.Umount(),
+		r.session.Logoff(),
+	)
 }
 
 func (s *SMBAdapter) Delete(path string) error {

--- a/internal/storage/smb.go
+++ b/internal/storage/smb.go
@@ -130,11 +130,17 @@ type smbReadCloser struct {
 
 func (r *smbReadCloser) Read(p []byte) (int, error) { return r.file.Read(p) }
 func (r *smbReadCloser) Close() error {
-	return errors.Join(
-		r.file.Close(),
-		r.share.Umount(),
-		r.session.Logoff(),
-	)
+	var errs []error
+	if err := r.file.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("close smb file: %w", err))
+	}
+	if err := r.share.Umount(); err != nil {
+		errs = append(errs, fmt.Errorf("umount smb share: %w", err))
+	}
+	if err := r.session.Logoff(); err != nil {
+		errs = append(errs, fmt.Errorf("logoff smb session: %w", err))
+	}
+	return errors.Join(errs...)
 }
 
 func (s *SMBAdapter) Delete(path string) error {

--- a/internal/storage/smb.go
+++ b/internal/storage/smb.go
@@ -37,7 +37,7 @@ func NewSMBAdapter(config SMBConfig) (*SMBAdapter, error) {
 	return &SMBAdapter{config: config}, nil
 }
 
-// smbDialTimeout is the maximum time allowed for dialling and mounting an SMB share.
+// smbDialTimeout is the maximum time allowed for dialling the SMB session.
 const smbDialTimeout = 30 * time.Second
 
 func (s *SMBAdapter) connect() (*smb2.Share, *smb2.Session, error) {

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -89,6 +89,13 @@ export const api = {
   // Discord
   testDiscordWebhook: (webhookUrl) => request('POST', '/settings/discord/test', { webhook_url: webhookUrl }),
 
+  // API Key
+  getAPIKeyStatus: () => request('GET', '/settings/api-key'),
+  generateAPIKey: () => request('POST', '/settings/api-key/generate'),
+  revealAPIKey: () => request('GET', '/settings/api-key/reveal'),
+  rotateAPIKey: () => request('POST', '/settings/api-key/rotate'),
+  revokeAPIKey: () => request('DELETE', '/settings/api-key'),
+
   // Diagnostics
   downloadDiagnostics: async () => {
     const { url, options } = buildApiRequest('GET', '/settings/diagnostics', {})

--- a/web/src/lib/auth.svelte.js
+++ b/web/src/lib/auth.svelte.js
@@ -1,6 +1,6 @@
 /**
- * Auth module stub — API key authentication has been removed.
- * Exports are kept as no-ops so existing imports don't break during cleanup.
+ * Auth module — API key can be configured via Settings > Security.
+ * Exports are used by components that need to know if auth is active.
  */
 
 export function getApiKey() {
@@ -12,5 +12,5 @@ export function isAuthenticated() {
 }
 
 export async function checkAuthStatus() {
-  // No-op: auth is no longer required.
+  // No-op: auth status is driven by the API key settings endpoint.
 }

--- a/web/src/lib/auth.svelte.js
+++ b/web/src/lib/auth.svelte.js
@@ -1,6 +1,13 @@
 /**
- * Auth module — API key can be configured via Settings > Security.
- * Exports are used by components that need to know if auth is active.
+ * Auth stub — no-op placeholder.
+ *
+ * API key authentication is enforced server-side by the APIKeyAuth
+ * middleware (internal/api/middleware.go). The browser UI is always
+ * exempt because it connects via loopback; only remote / LAN clients
+ * must supply the X-API-Key header.
+ *
+ * These exports exist so that future client-side auth features can
+ * import from a single module without a refactor.
  */
 
 export function getApiKey() {

--- a/web/src/pages/Settings.svelte
+++ b/web/src/pages/Settings.svelte
@@ -61,16 +61,26 @@
   // Diagnostics state
   let diagnosticsDownloading = $state(false)
 
+  // API Key state
+  let apiKeyEnabled = $state(false)
+  let apiKeyRevealed = $state('')
+  let apiKeyShowing = $state(false)
+  let apiKeyLoading = $state(false)
+  let apiKeyGenerating = $state(false)
+  let apiKeyRevoking = $state(false)
+  let confirmApiKeyRevoke = $state(false)
+
   function showToast(message, type = 'info') {
     toast = { message, type, key: toast.key + 1 }
   }
 
   onMount(async () => {
     try {
-      const [h, s, enc, staging, dbInfo] = await Promise.all([api.health(), api.getSettings(), api.getEncryptionStatus(), api.getStagingInfo().catch(() => null), api.getDatabaseInfo().catch(() => null)])
+      const [h, s, enc, staging, dbInfo, apiKeyStatus] = await Promise.all([api.health(), api.getSettings(), api.getEncryptionStatus(), api.getStagingInfo().catch(() => null), api.getDatabaseInfo().catch(() => null), api.getAPIKeyStatus().catch(() => null)])
       health = h
       settings = s || {}
       encryptionEnabled = enc?.encryption_enabled || false
+      apiKeyEnabled = apiKeyStatus?.enabled || false
       stagingInfo = staging
       stagingOverrideInput = staging?.override || ''
       discordWebhookUrl = s?.discord_webhook_url || ''
@@ -349,6 +359,76 @@
       showToast(e.message, 'error')
     } finally {
       encSaving = false
+    }
+  }
+
+  async function generateApiKey() {
+    apiKeyGenerating = true
+    try {
+      const res = await api.generateAPIKey()
+      apiKeyEnabled = true
+      apiKeyRevealed = res.api_key
+      apiKeyShowing = true
+      showToast('API key generated — copy it now', 'success')
+    } catch (e) {
+      showToast(e.message, 'error')
+    } finally {
+      apiKeyGenerating = false
+    }
+  }
+
+  async function toggleApiKeyReveal() {
+    if (apiKeyShowing) {
+      apiKeyShowing = false
+      apiKeyRevealed = ''
+      return
+    }
+    apiKeyLoading = true
+    try {
+      const res = await api.revealAPIKey()
+      apiKeyRevealed = res.api_key
+      apiKeyShowing = true
+    } catch (e) {
+      showToast(e.message, 'error')
+    } finally {
+      apiKeyLoading = false
+    }
+  }
+
+  async function rotateApiKey() {
+    apiKeyGenerating = true
+    try {
+      const res = await api.rotateAPIKey()
+      apiKeyRevealed = res.api_key
+      apiKeyShowing = true
+      showToast('API key rotated — copy the new key', 'success')
+    } catch (e) {
+      showToast(e.message, 'error')
+    } finally {
+      apiKeyGenerating = false
+    }
+  }
+
+  async function revokeApiKey() {
+    confirmApiKeyRevoke = false
+    apiKeyRevoking = true
+    try {
+      await api.revokeAPIKey()
+      apiKeyEnabled = false
+      apiKeyRevealed = ''
+      apiKeyShowing = false
+      showToast('API key revoked — authentication disabled', 'success')
+    } catch (e) {
+      showToast(e.message, 'error')
+    } finally {
+      apiKeyRevoking = false
+    }
+  }
+
+  function copyApiKey() {
+    if (apiKeyRevealed) {
+      navigator.clipboard.writeText(apiKeyRevealed)
+      showToast('API key copied to clipboard', 'success')
     }
   }
 
@@ -741,6 +821,89 @@
                   {encSaving ? 'Saving...' : 'Set Passphrase'}
                 </button>
               </div>
+            </div>
+          {/if}
+        </div>
+      </div>
+
+      <!-- API Access -->
+      <div class="bg-surface-2 border border-border rounded-xl overflow-hidden">
+        <div class="px-5 py-4 border-b border-border">
+          <h2 class="text-base font-semibold text-text">API Access <Tooltip text="Generate an API key to authenticate external integrations (Home Assistant, replication) when Vault is exposed on the network. Not required when accessed via localhost." /></h2>
+        </div>
+        <div class="divide-y divide-border">
+          {#if apiKeyEnabled}
+            <!-- Status -->
+            <div class="px-5 py-4">
+              <div class="flex items-center gap-2 mb-2">
+                <span class="inline-block w-2 h-2 rounded-full bg-success"></span>
+                <span class="text-sm font-medium text-text">API key active</span>
+              </div>
+              <p class="text-xs text-text-muted">External clients must include the <code class="bg-surface px-1 rounded">X-API-Key</code> header when connecting from non-localhost addresses. Localhost connections are always exempt.</p>
+            </div>
+
+            <!-- Reveal key -->
+            <div class="px-5 py-4">
+              <div class="flex items-center justify-between gap-4">
+                <div>
+                  <p class="text-sm font-medium text-text">Show API key</p>
+                  <p class="text-xs text-text-muted mt-0.5">Reveal the key to copy it for external integrations.</p>
+                </div>
+                <button onclick={toggleApiKeyReveal} disabled={apiKeyLoading} class="text-sm font-medium text-info hover:text-info/80 transition-colors shrink-0 disabled:opacity-50">
+                  {apiKeyLoading ? 'Loading...' : apiKeyShowing ? 'Hide' : 'Show'}
+                </button>
+              </div>
+              {#if apiKeyShowing && apiKeyRevealed}
+                <div class="mt-3 flex items-center gap-2">
+                  <div class="flex-1 px-3 py-2.5 bg-surface border border-border rounded-lg">
+                    <code class="text-sm text-text break-all select-all">{apiKeyRevealed}</code>
+                  </div>
+                  <button onclick={copyApiKey} class="shrink-0 p-2 text-text-muted hover:text-text transition-colors" aria-label="Copy API key">
+                    <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                  </button>
+                </div>
+              {/if}
+            </div>
+
+            <!-- Rotate key -->
+            <div class="px-5 py-4 flex items-center justify-between gap-4">
+              <div>
+                <p class="text-sm font-medium text-text">Rotate API key</p>
+                <p class="text-xs text-text-muted mt-0.5">Replace with a new key. Existing integrations will need the new key.</p>
+              </div>
+              <button onclick={rotateApiKey} disabled={apiKeyGenerating} class="text-sm font-medium text-warning hover:text-warning/80 transition-colors shrink-0 disabled:opacity-50">
+                {apiKeyGenerating ? 'Rotating...' : 'Rotate'}
+              </button>
+            </div>
+
+            <!-- Revoke key -->
+            <div class="px-5 py-3 flex justify-end">
+              {#if confirmApiKeyRevoke}
+                <div class="flex items-center gap-2">
+                  <span class="text-xs text-danger">Revoke key and disable authentication?</span>
+                  <button onclick={revokeApiKey} disabled={apiKeyRevoking} class="text-xs font-medium text-danger hover:text-danger/80 transition-colors disabled:opacity-50">
+                    {apiKeyRevoking ? 'Revoking...' : 'Yes, revoke'}
+                  </button>
+                  <button onclick={() => confirmApiKeyRevoke = false} class="text-xs text-text-muted hover:text-text transition-colors">
+                    Cancel
+                  </button>
+                </div>
+              {:else}
+                <button onclick={() => confirmApiKeyRevoke = true} disabled={apiKeyRevoking} class="text-xs text-text-dim hover:text-danger transition-colors disabled:opacity-50">
+                  Revoke API key
+                </button>
+              {/if}
+            </div>
+          {:else}
+            <div class="px-5 py-4">
+              <div class="flex items-center gap-2 mb-3">
+                <span class="inline-block w-2 h-2 rounded-full bg-text-dim"></span>
+                <span class="text-sm font-medium text-text">No API key configured</span>
+              </div>
+              <p class="text-xs text-text-muted mb-4">Generate an API key to protect the Vault API when it is exposed beyond localhost. API keys are required for third-party integrations (e.g. Home Assistant) and replication between Vault instances on different servers.</p>
+              <button onclick={generateApiKey} disabled={apiKeyGenerating} class="px-4 py-2 text-sm font-medium rounded-lg bg-vault text-white hover:bg-vault-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+                {apiKeyGenerating ? 'Generating...' : 'Generate API Key'}
+              </button>
             </div>
           {/if}
         </div>

--- a/web/src/pages/Settings.svelte
+++ b/web/src/pages/Settings.svelte
@@ -425,10 +425,14 @@
     }
   }
 
-  function copyApiKey() {
+  async function copyApiKey() {
     if (apiKeyRevealed) {
-      navigator.clipboard.writeText(apiKeyRevealed)
-      showToast('API key copied to clipboard', 'success')
+      try {
+        await navigator.clipboard.writeText(apiKeyRevealed)
+        showToast('API key copied to clipboard', 'success')
+      } catch {
+        showToast('Failed to copy — clipboard access denied', 'error')
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Security hardening based on a comprehensive OWASP Top 10 audit of the codebase. Addresses all MEDIUM and LOW severity findings.

## Changes

### Error Information Leakage (MEDIUM — OWASP A09)
- Added `respondInternalError()` helper in `handlers/respond.go` that logs the real error server-side and returns a generic `"internal server error"` message to API consumers
- Replaced **38 occurrences** of `respondError(w, http.StatusInternalServerError, err.Error())` across all handler files (`health.go`, `storage.go`, `jobs.go`, `recovery.go`, `replication.go`, `activity.go`, `settings.go`)

### SMB Dial Timeout (MEDIUM)
- Added 30-second `context.WithTimeout` to SMB `connect()` to prevent indefinite connection hangs when the target is unreachable

### SFTP Host Key Warning (MEDIUM)
- SFTP adapter now logs a warning when falling back to `InsecureIgnoreHostKey` due to missing host key verification configuration

### OAuth postMessage Origin (MEDIUM)
- Google Drive and OneDrive OAuth callback templates now restrict `postMessage` target origin from wildcard `'*'` to `window.location.origin`

### Runner Data Race (LOW)
- `SetSnapshotManager()` write is now protected by `r.mu` mutex to prevent a data race with concurrent `RunJob` reads

### SMB Close Error Handling (LOW)
- `smbReadCloser.Close()` now uses `errors.Join` to surface file/share/session close failures instead of silently discarding them

### NFS Unmount Error Handling (LOW)
- `unmount()` now logs errors from `umount` and temp directory removal instead of silently discarding them

## Testing
- All 18 internal packages pass unit tests (`go test ./internal/... -short`)
- Full build compiles cleanly (`go build ./...`)
- Ansible build → deploy → verify pipeline passed (3/3 endpoints, CRUD, WebSocket 101, MCP OK)
- VM backup smoke test passed (Fedora cold backup)
- Playwright UI validation: Dashboard, Jobs, Storage, History, Recovery, Settings pages all render correctly

## Screenshots

Playwright verification confirmed all pages render correctly after deployment to Unraid v2026.03.02.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * OAuth callbacks now restrict postMessage target origin.
  * Internal errors return a generic client message while details are logged.
  * SFTP insecure host-key fallback now emits a warning.
* **New Features**
  * API key management: generate, reveal, rotate and revoke keys via Settings UI and API.
  * Optional API-key auth for API routes; clients can send X-API-Key.
  * Replication now supports storing/using per-source API keys.
* **Reliability**
  * SMB dial timeout enforced; SMB/NFS unmount/close failures logged.
* **Chores**
  * .gitignore updated to ignore Python bytecode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->