### PR TITLE
feat(replication): add Remote Vault API Key for authenticated sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- Remote Vault API Key field on the Add/Edit Replication Target form — allows users to enter the shared API key for authenticating with a remote Vault server during replication sync
+- Replication sync and test-connection now use the configured API key (via `X-API-Key` header) when connecting to authenticated remote Vault instances
+- Test Connection in the replication modal performs a live connectivity check when an API key is provided
+
 - API key management: generate, reveal, rotate, copy, and revoke a shared API key from Settings > Security for authenticating external integrations (Home Assistant, replication) — key is stored sealed (AES-256-GCM) and verified via bcrypt
 - Settings > Security > API Access card showing key status, reveal/copy, rotate, and revoke controls with confirmation dialog
 - `X-API-Key` header support in the replication client for authenticated cross-server sync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - Remote Vault API Key field on the Add/Edit Replication Target form — allows users to enter the shared API key for authenticating with a remote Vault server during replication sync
 - Replication sync and test-connection now use the configured API key (via `X-API-Key` header) when connecting to authenticated remote Vault instances
-- Test Connection in the replication modal performs a live connectivity check when an API key is provided
+- Test Connection in the replication modal now always performs a live connectivity check against the remote Vault server, verifying the URL is reachable and the server is healthy
 
 - API key management: generate, reveal, rotate, copy, and revoke a shared API key from Settings > Security for authenticating external integrations (Home Assistant, replication) — key is stored sealed (AES-256-GCM) and verified via bcrypt
 - Settings > Security > API Access card showing key status, reveal/copy, rotate, and revoke controls with confirmation dialog

--- a/internal/api/handlers/replication.go
+++ b/internal/api/handlers/replication.go
@@ -191,7 +191,19 @@ func (h *ReplicationHandler) TestConnection(w http.ResponseWriter, r *http.Reque
 		}
 		respondJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 	default: // remote_vault
-		client, clientErr := replication.NewClient(src.URL)
+		var cfg struct {
+			APIKey string `json:"api_key"`
+		}
+		if src.Config != "" && src.Config != "{}" {
+			_ = json.Unmarshal([]byte(src.Config), &cfg)
+		}
+		var client *replication.Client
+		var clientErr error
+		if cfg.APIKey != "" {
+			client, clientErr = replication.NewClientWithAPIKey(src.URL, cfg.APIKey)
+		} else {
+			client, clientErr = replication.NewClient(src.URL)
+		}
 		if clientErr != nil {
 			respondError(w, http.StatusBadRequest, "invalid url: "+clientErr.Error())
 			return
@@ -205,10 +217,11 @@ func (h *ReplicationHandler) TestConnection(w http.ResponseWriter, r *http.Reque
 }
 
 // TestURL validates and normalizes a remote Vault URL before it is saved.
-// Accepts JSON body: {"url": "http://..."}.
+// Accepts JSON body: {"url": "http://...", "api_key": "..."}.
 func (h *ReplicationHandler) TestURL(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		URL string `json:"url"`
+		URL    string `json:"url"`
+		APIKey string `json:"api_key"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		respondError(w, http.StatusBadRequest, "invalid JSON")
@@ -224,6 +237,28 @@ func (h *ReplicationHandler) TestURL(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, "invalid url: "+err.Error())
 		return
 	}
+
+	// If an API key is provided, perform live connectivity test.
+	if req.APIKey != "" {
+		client, clientErr := replication.NewClientWithAPIKey(normalizedURL, req.APIKey)
+		if clientErr != nil {
+			respondError(w, http.StatusBadRequest, "invalid url: "+clientErr.Error())
+			return
+		}
+		health, connErr := client.TestConnection()
+		if connErr != nil {
+			respondError(w, http.StatusBadGateway, connErr.Error())
+			return
+		}
+		respondJSON(w, http.StatusOK, map[string]string{
+			"status":  "ok",
+			"url":     normalizedURL,
+			"version": health.Version,
+			"message": "Connected successfully",
+		})
+		return
+	}
+
 	respondJSON(w, http.StatusOK, map[string]string{
 		"status":  "ok",
 		"url":     normalizedURL,

--- a/internal/api/handlers/replication.go
+++ b/internal/api/handlers/replication.go
@@ -238,31 +238,28 @@ func (h *ReplicationHandler) TestURL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If an API key is provided, perform live connectivity test.
+	// Build client with or without API key and perform live connectivity test.
+	var client *replication.Client
+	var clientErr error
 	if req.APIKey != "" {
-		client, clientErr := replication.NewClientWithAPIKey(normalizedURL, req.APIKey)
-		if clientErr != nil {
-			respondError(w, http.StatusBadRequest, "invalid url: "+clientErr.Error())
-			return
-		}
-		health, connErr := client.TestConnection()
-		if connErr != nil {
-			respondError(w, http.StatusBadGateway, connErr.Error())
-			return
-		}
-		respondJSON(w, http.StatusOK, map[string]string{
-			"status":  "ok",
-			"url":     normalizedURL,
-			"version": health.Version,
-			"message": "Connected successfully",
-		})
+		client, clientErr = replication.NewClientWithAPIKey(normalizedURL, req.APIKey)
+	} else {
+		client, clientErr = replication.NewClient(normalizedURL)
+	}
+	if clientErr != nil {
+		respondError(w, http.StatusBadRequest, "invalid url: "+clientErr.Error())
 		return
 	}
-
+	health, connErr := client.TestConnection()
+	if connErr != nil {
+		respondError(w, http.StatusBadGateway, connErr.Error())
+		return
+	}
 	respondJSON(w, http.StatusOK, map[string]string{
 		"status":  "ok",
 		"url":     normalizedURL,
-		"message": "URL format is valid. Save the source and use Test Connection to verify remote reachability.",
+		"version": health.Version,
+		"message": "Connected successfully",
 	})
 }
 

--- a/internal/api/handlers/replication.go
+++ b/internal/api/handlers/replication.go
@@ -5,12 +5,18 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/ruaan-deysel/vault/internal/db"
 	"github.com/ruaan-deysel/vault/internal/replication"
 	"github.com/ruaan-deysel/vault/internal/storage"
 )
+
+// testConnectionTimeout is the HTTP client timeout used for connectivity
+// checks so that Test Connection / Test URL fail fast instead of blocking
+// for the default 10-minute transfer timeout.
+const testConnectionTimeout = 15 * time.Second
 
 // SyncerProvider returns the replication syncer (resolved lazily).
 type SyncerProvider = func() *replication.Syncer
@@ -195,7 +201,10 @@ func (h *ReplicationHandler) TestConnection(w http.ResponseWriter, r *http.Reque
 			APIKey string `json:"api_key"`
 		}
 		if src.Config != "" && src.Config != "{}" {
-			_ = json.Unmarshal([]byte(src.Config), &cfg)
+			if err := json.Unmarshal([]byte(src.Config), &cfg); err != nil {
+				respondError(w, http.StatusBadRequest, "invalid config JSON: "+err.Error())
+				return
+			}
 		}
 		var client *replication.Client
 		var clientErr error
@@ -208,6 +217,7 @@ func (h *ReplicationHandler) TestConnection(w http.ResponseWriter, r *http.Reque
 			respondError(w, http.StatusBadRequest, "invalid url: "+clientErr.Error())
 			return
 		}
+		client.SetTimeout(testConnectionTimeout)
 		if _, connErr := client.TestConnection(); connErr != nil {
 			respondError(w, http.StatusBadGateway, connErr.Error())
 			return
@@ -216,8 +226,10 @@ func (h *ReplicationHandler) TestConnection(w http.ResponseWriter, r *http.Reque
 	}
 }
 
-// TestURL validates and normalizes a remote Vault URL before it is saved.
-// Accepts JSON body: {"url": "http://...", "api_key": "..."}.
+// TestURL validates a remote Vault URL and performs a live connectivity check
+// by hitting the /api/v1/health endpoint on the remote server. Returns the
+// normalized URL and remote version on success, or 502 if the remote is
+// unreachable. Accepts JSON body: {"url": "http://...", "api_key": "..."}.
 func (h *ReplicationHandler) TestURL(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		URL    string `json:"url"`
@@ -250,6 +262,7 @@ func (h *ReplicationHandler) TestURL(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, "invalid url: "+clientErr.Error())
 		return
 	}
+	client.SetTimeout(testConnectionTimeout)
 	health, connErr := client.TestConnection()
 	if connErr != nil {
 		respondError(w, http.StatusBadGateway, connErr.Error())

--- a/internal/api/handlers/replication_test.go
+++ b/internal/api/handlers/replication_test.go
@@ -155,18 +155,59 @@ func TestReplicationHandlerValidation(t *testing.T) {
 
 func TestReplicationHandlerTestURLConnectsToRemote(t *testing.T) {
 	t.Parallel()
-
 	h, _ := setupReplicationTest(t)
-	body := `{"url":"https://vault.example.com:24085"}`
-	req := httptest.NewRequest(http.MethodPost, "/replication/test-url", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	h.TestURL(w, req)
 
-	// The URL is valid but the host is unreachable, so we expect a 502.
-	if w.Code != http.StatusBadGateway {
-		t.Fatalf("TestURL: got %d, want %d; body: %s", w.Code, http.StatusBadGateway, w.Body.String())
-	}
+	t.Run("success - reachable server", func(t *testing.T) {
+		t.Parallel()
+		// Simulate a remote Vault /api/v1/health endpoint.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/v1/health" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","version":"2026.4.0"}`))
+		}))
+		defer srv.Close()
+
+		body := `{"url":"` + srv.URL + `"}`
+		req := httptest.NewRequest(http.MethodPost, "/replication/test-url", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.TestURL(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("TestURL: got %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+		var resp map[string]string
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if resp["version"] != "2026.4.0" {
+			t.Errorf("version = %q, want %q", resp["version"], "2026.4.0")
+		}
+		if resp["message"] != "Connected successfully" {
+			t.Errorf("message = %q, want %q", resp["message"], "Connected successfully")
+		}
+	})
+
+	t.Run("failure - unreachable server", func(t *testing.T) {
+		t.Parallel()
+		// Use a closed server to guarantee connection refused.
+		srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		closedURL := srv.URL
+		srv.Close()
+
+		body := `{"url":"` + closedURL + `"}`
+		req := httptest.NewRequest(http.MethodPost, "/replication/test-url", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.TestURL(w, req)
+
+		if w.Code != http.StatusBadGateway {
+			t.Fatalf("TestURL: got %d, want %d; body: %s", w.Code, http.StatusBadGateway, w.Body.String())
+		}
+	})
 }
 
 func TestReplicationHandlerCreateRejectsURLWithPath(t *testing.T) {

--- a/internal/api/handlers/replication_test.go
+++ b/internal/api/handlers/replication_test.go
@@ -153,7 +153,7 @@ func TestReplicationHandlerValidation(t *testing.T) {
 	}
 }
 
-func TestReplicationHandlerTestURLValidatesFormatOnly(t *testing.T) {
+func TestReplicationHandlerTestURLConnectsToRemote(t *testing.T) {
 	t.Parallel()
 
 	h, _ := setupReplicationTest(t)
@@ -163,16 +163,9 @@ func TestReplicationHandlerTestURLValidatesFormatOnly(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.TestURL(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("TestURL: got %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
-	}
-
-	var resp map[string]string
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if resp["url"] != "https://vault.example.com:24085" {
-		t.Fatalf("normalized url = %q", resp["url"])
+	// The URL is valid but the host is unreachable, so we expect a 502.
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("TestURL: got %d, want %d; body: %s", w.Code, http.StatusBadGateway, w.Body.String())
 	}
 }
 

--- a/internal/replication/client.go
+++ b/internal/replication/client.go
@@ -43,6 +43,12 @@ func NewClientWithAPIKey(baseURL, apiKey string) (*Client, error) {
 	return c, nil
 }
 
+// SetTimeout overrides the HTTP client timeout. Use a short duration for
+// connectivity checks so the caller doesn't block on slow DNS or TCP connects.
+func (c *Client) SetTimeout(d time.Duration) {
+	c.httpClient.Timeout = d
+}
+
 // NormalizeBaseURL validates and canonicalizes a remote Vault base URL.
 func NormalizeBaseURL(baseURL string) (string, error) {
 	trimmed := strings.TrimSpace(baseURL)

--- a/internal/replication/sync.go
+++ b/internal/replication/sync.go
@@ -86,7 +86,12 @@ func (s *Syncer) syncRemoteVault(src db.ReplicationSource, progress ProgressFunc
 	// Extract optional API key from config.
 	var cfg remoteVaultConfig
 	if src.Config != "" && src.Config != "{}" {
-		_ = json.Unmarshal([]byte(src.Config), &cfg)
+		if err := json.Unmarshal([]byte(src.Config), &cfg); err != nil {
+			errMsg := fmt.Sprintf("invalid config JSON for source %q: %v", src.Name, err)
+			s.updateSyncStatus(sourceID, "failed", errMsg)
+			s.logSyncError(sourceID, src.Name, errMsg)
+			return nil, fmt.Errorf("unmarshal source config: %w", err)
+		}
 	}
 
 	// Build the remote client.

--- a/internal/replication/sync.go
+++ b/internal/replication/sync.go
@@ -74,12 +74,29 @@ func (s *Syncer) SyncSource(sourceID int64, progress ProgressFunc) (*SyncResult,
 	}
 }
 
+// remoteVaultConfig holds optional settings for remote_vault replication sources.
+type remoteVaultConfig struct {
+	APIKey string `json:"api_key"`
+}
+
 // syncRemoteVault performs a pull-based sync from a remote Vault instance.
 func (s *Syncer) syncRemoteVault(src db.ReplicationSource, progress ProgressFunc) (*SyncResult, error) {
 	sourceID := src.ID
 
+	// Extract optional API key from config.
+	var cfg remoteVaultConfig
+	if src.Config != "" && src.Config != "{}" {
+		_ = json.Unmarshal([]byte(src.Config), &cfg)
+	}
+
 	// Build the remote client.
-	client, err := NewClient(src.URL)
+	var client *Client
+	var err error
+	if cfg.APIKey != "" {
+		client, err = NewClientWithAPIKey(src.URL, cfg.APIKey)
+	} else {
+		client, err = NewClient(src.URL)
+	}
 	if err != nil {
 		errMsg := fmt.Sprintf("normalize source url %q: %v", src.Name, err)
 		s.updateSyncStatus(sourceID, "failed", err.Error())

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -112,7 +112,7 @@ export const api = {
   updateReplicationSource: (id, data) => request('PUT', `/replication/${id}`, data),
   deleteReplicationSource: (id) => request('DELETE', `/replication/${id}`),
   testReplicationSource: (id) => request('POST', `/replication/${id}/test`),
-  testReplicationURL: (url) => request('POST', '/replication/test-url', { url }),
+  testReplicationURL: (url, apiKey = '') => request('POST', '/replication/test-url', { url, api_key: apiKey }),
   syncReplicationSource: (id) => request('POST', `/replication/${id}/sync`),
   listReplicatedJobs: (id) => request('GET', `/replication/${id}/jobs`),
 

--- a/web/src/pages/Replication.svelte
+++ b/web/src/pages/Replication.svelte
@@ -110,7 +110,8 @@
     modalTesting = true
     modalTestResult = null
     try {
-      const result = await api.testReplicationURL(form.url)
+      const apiKey = cloudConfig.api_key || ''
+      const result = await api.testReplicationURL(form.url, apiKey)
       modalTestResult = {
         success: true,
         version: result.version,
@@ -575,6 +576,13 @@
           <input id="repl-url" type="url" required bind:value={form.url} placeholder="http://192.168.1.100:24085"
             class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-text text-sm placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-vault/50 focus:border-vault" />
           <p class="text-xs text-text-dim mt-1">The base URL of the remote Vault server (include port)</p>
+        </div>
+
+        <div>
+          <label for="repl-apikey" class="block text-sm font-medium text-text mb-1">Remote Vault API Key</label>
+          <input id="repl-apikey" type="password" value={cloudConfig.api_key || ''} oninput={(e) => updateCloudConfig('api_key', e.target.value)} placeholder="Enter the remote server's API key"
+            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-text text-sm placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-vault/50 focus:border-vault" />
+          <p class="text-xs text-text-dim mt-1">The shared API key configured on the remote Vault server for authentication</p>
         </div>
 
         <!-- Test Connection -->


### PR DESCRIPTION
## Summary

Adds a **Remote Vault API Key** field to the replication setup form and wires it through the backend so that replication sync and test-connection use the configured API key when connecting to authenticated remote Vault instances.

## Changes

### Backend
- **`internal/replication/sync.go`** — Added `remoteVaultConfig` struct; `syncRemoteVault()` now parses `api_key` from the source config JSON and uses `NewClientWithAPIKey()` when set
- **`internal/api/handlers/replication.go`** — `TestConnection` handler extracts `api_key` from config for `remote_vault` targets; `TestURL` handler always performs a live connectivity check (hits `/api/v1/health` on the remote server)
- **`internal/api/handlers/replication_test.go`** — Updated test to expect 502 for unreachable hosts (was 200 for format-only validation)

### Frontend
- **`web/src/pages/Replication.svelte`** — Added "Remote Vault API Key" password input field below the URL field in the Add/Edit modal
- **`web/src/lib/api.js`** — `testReplicationURL` now passes `api_key` parameter

### Other
- **`CHANGELOG.md`** — Added entries under Unreleased > Added

## Testing
- All unit tests pass (`make build` — lint, test, web build, cross-compile)
- Deployed and verified on Unraid (`make deploy` + `make verify` — 62 checks pass)
- UI verified with Playwright: API Key field renders, Test Connection performs live connectivity, "Connected successfully" shown for reachable servers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added remote Vault API key configuration field on the replication target form
  * Replication now authenticates to remote instances using the configured API key
  * "Test Connection" performs live remote connectivity and health verification checks
  * Updated connection test success message to "Connected successfully"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->