### PR TITLE
fix: keep modals open on backdrop click (#148); back up Unassigned Devices appdata (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- **Modals no longer close when you click the background** (closes #148). Clicking the dimmed backdrop behind a dialog – or releasing a text selection whose drag ended outside the dialog – used to dismiss the modal and discard any in-progress work, such as a half-filled backup job. Backdrop click-to-close has been removed from every modal: the job and storage wizards, confirmation dialogs, the command palette, and the path and script browsers. Modals are still dismissed the deliberate ways – the close (×) button, Cancel, or the Escape key – all unchanged.
+
+### Fixed
+
+- **Container appdata on Unassigned Devices is no longer auto-excluded from backups** (closes #152). Bind mounts under `/mnt/disks/` (the Unassigned Devices mount point) were wrongly flagged as a "direct disk volume" and shown greyed-out in the job wizard's **Container Mounts & Exclusions** step, so appdata kept on an Unassigned Devices SSD (e.g. a container's `/config` at `/mnt/disks/<device>/appdata/<app>`) could not be included in a backup. The direct-disk rule now matches only real array disks (`/mnt/disk1`, `/mnt/disk2`, …) and no longer catches the plural `/mnt/disks/`, so those mounts are backed up by default and are tickable like any other path.
+
 ## [2026.06.06] - 2026-06-22
 
 ### Added

--- a/internal/engine/container.go
+++ b/internal/engine/container.go
@@ -109,8 +109,11 @@ func shouldSkipVolume(source string) (bool, string) {
 		}
 	}
 
-	// Skip direct disk access paths (/mnt/disk1, /mnt/disk2, etc.).
-	if strings.HasPrefix(norm, "/mnt/disk") {
+	// Skip direct array-disk access paths (/mnt/disk1, /mnt/disk2, etc.). A
+	// digit must follow "/mnt/disk" so this does not also match "/mnt/disks/"
+	// (the Unassigned Devices mount point), which holds legitimate appdata and
+	// data that must be backed up.
+	if rest := strings.TrimPrefix(norm, "/mnt/disk"); rest != norm && rest != "" && rest[0] >= '0' && rest[0] <= '9' {
 		return true, "direct disk volume"
 	}
 

--- a/internal/engine/container_test.go
+++ b/internal/engine/container_test.go
@@ -146,7 +146,7 @@ func TestShouldSkipVolume(t *testing.T) {
 			if gotSkip != tt.wantSkip {
 				t.Errorf("shouldSkipVolume(%q) skip = %v, want %v", tt.source, gotSkip, tt.wantSkip)
 			}
-			if tt.wantReason != "" && gotReason != tt.wantReason {
+			if gotReason != tt.wantReason {
 				t.Errorf("shouldSkipVolume(%q) reason = %q, want %q", tt.source, gotReason, tt.wantReason)
 			}
 		})

--- a/internal/engine/container_test.go
+++ b/internal/engine/container_test.go
@@ -119,6 +119,10 @@ func TestShouldSkipVolume(t *testing.T) {
 		{"disk1", "/mnt/disk1/share", true, "direct disk volume"},
 		{"disk12", "/mnt/disk12/data", true, "direct disk volume"},
 
+		// Unassigned Devices (/mnt/disks/, plural) — backed up, not direct disk.
+		{"unassigned devices appdata", "/mnt/disks/SSD-Device/appdata/Jellyfin", false, ""},
+		{"unassigned devices share", "/mnt/disks/SSD-Device/data", false, ""},
+
 		// Root /mnt — skipped.
 		{"root mnt", "/mnt", true, "root /mnt mount"},
 

--- a/web/src/components/CommandPalette.svelte
+++ b/web/src/components/CommandPalette.svelte
@@ -139,7 +139,6 @@
 {#if show}
   <div
     class="fixed inset-0 z-[60] flex items-start justify-center pt-[15vh] bg-black/60 backdrop-blur-sm animate-backdrop"
-    onclick={(e) => { if (e.target === e.currentTarget) onclose() }}
     onkeydown={handleKeydown}
     role="dialog"
     aria-modal="true"

--- a/web/src/components/ConfirmDialog.svelte
+++ b/web/src/components/ConfirmDialog.svelte
@@ -12,10 +12,6 @@
 
   let dialogEl = $state(null)
 
-  function handleBackdrop(e) {
-    if (e.target === e.currentTarget) oncancel()
-  }
-
   function handleKey(e) {
     if (e.key === 'Escape') oncancel()
     if (e.key === 'Tab' && dialogEl) {
@@ -58,7 +54,6 @@
 {#if show}
   <div
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-backdrop"
-    onclick={handleBackdrop}
     onkeydown={handleKey}
     role="dialog"
     aria-modal="true"

--- a/web/src/components/Modal.svelte
+++ b/web/src/components/Modal.svelte
@@ -6,10 +6,6 @@
 
   let dialogEl = $state(null)
 
-  function handleBackdrop(e) {
-    if (e.target === e.currentTarget) onclose()
-  }
-
   function handleKey(e) {
     if (e.key === 'Escape') onclose()
     // Focus trap: cycle focus within the modal
@@ -48,7 +44,6 @@
 {#if show}
   <div
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-backdrop"
-    onclick={handleBackdrop}
     onkeydown={handleKey}
     role="dialog"
     aria-modal="true"

--- a/web/src/components/PathBrowser.svelte
+++ b/web/src/components/PathBrowser.svelte
@@ -68,7 +68,7 @@
   </div>
 
   {#if open}
-    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-backdrop" role="presentation" onclick={(e) => { if (e.target === e.currentTarget) open = false }}>
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-backdrop" role="presentation">
       <div class="bg-surface-2 border border-border rounded-xl shadow-2xl w-full max-w-lg mx-4 max-h-[80vh] flex flex-col animate-panel-up">
         <!-- Header -->
         <div class="flex items-center justify-between px-5 py-3 border-b border-border">

--- a/web/src/components/ScriptBrowser.svelte
+++ b/web/src/components/ScriptBrowser.svelte
@@ -87,8 +87,7 @@
   </div>
 
   {#if open}
-    <!-- eslint-disable-next-line -->
-    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-backdrop" role="presentation" onclick={(e) => { if (e.target === e.currentTarget) open = false }} onkeydown={() => {}}>
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-backdrop" role="presentation">
       <div class="bg-surface-2 border border-border rounded-xl shadow-2xl w-full max-w-lg mx-4 max-h-[80vh] flex flex-col animate-panel-up">
         <!-- Header -->
         <div class="flex items-center justify-between px-5 py-3 border-b border-border">

--- a/web/src/pages/Jobs.svelte
+++ b/web/src/pages/Jobs.svelte
@@ -1969,10 +1969,10 @@
   {/if}
 </Modal>
 
+<svelte:window onkeydown={(e) => { if (e.key === 'Escape' && confirmDelete.show) confirmDelete = { show: false, id: 0, name: '', deleteFiles: false } }} />
 {#if confirmDelete.show}
   <div
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-backdrop"
-    onkeydown={(e) => { if (e.key === 'Escape') confirmDelete = { show: false, id: 0, name: '', deleteFiles: false } }}
     role="dialog" aria-modal="true" aria-labelledby="delete-title" tabindex="-1"
   >
     <div class="bg-surface-2 border border-border rounded-xl shadow-2xl w-full max-w-md mx-4 p-6 animate-panel-up">

--- a/web/src/pages/Jobs.svelte
+++ b/web/src/pages/Jobs.svelte
@@ -1972,7 +1972,6 @@
 {#if confirmDelete.show}
   <div
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-backdrop"
-    onclick={(e) => { if (e.target === e.currentTarget) confirmDelete = { show: false, id: 0, name: '', deleteFiles: false } }}
     onkeydown={(e) => { if (e.key === 'Escape') confirmDelete = { show: false, id: 0, name: '', deleteFiles: false } }}
     role="dialog" aria-modal="true" aria-labelledby="delete-title" tabindex="-1"
   >

--- a/web/src/pages/Storage.svelte
+++ b/web/src/pages/Storage.svelte
@@ -1046,7 +1046,6 @@
 {#if confirmDelete.show}
   <div
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-backdrop"
-    onclick={(e) => { if (e.target === e.currentTarget) confirmDelete = { show: false, id: 0, name: '', deleteFiles: false, jobCount: 0 } }}
     onkeydown={(e) => { if (e.key === 'Escape') confirmDelete = { show: false, id: 0, name: '', deleteFiles: false, jobCount: 0 } }}
     role="dialog" aria-modal="true" aria-labelledby="del-storage-title" tabindex="-1"
   >

--- a/web/src/pages/Storage.svelte
+++ b/web/src/pages/Storage.svelte
@@ -1043,10 +1043,10 @@
 </Modal>
 
 <!-- Enhanced Delete Dialog -->
+<svelte:window onkeydown={(e) => { if (e.key === 'Escape' && confirmDelete.show) confirmDelete = { show: false, id: 0, name: '', deleteFiles: false, jobCount: 0 } }} />
 {#if confirmDelete.show}
   <div
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-backdrop"
-    onkeydown={(e) => { if (e.key === 'Escape') confirmDelete = { show: false, id: 0, name: '', deleteFiles: false, jobCount: 0 } }}
     role="dialog" aria-modal="true" aria-labelledby="del-storage-title" tabindex="-1"
   >
     <div class="bg-surface-2 border border-border rounded-xl shadow-2xl w-full max-w-md mx-4 p-6 animate-panel-up">


### PR DESCRIPTION
Fixes two reported issues, both verified end-to-end on Unraid (`192.168.20.21`).

## #148 — Modals no longer close when clicking the background
Clicking the dimmed backdrop (or releasing a text selection drag outside the dialog) used to dismiss a modal and discard in-progress work, e.g. a half-filled backup job.

- Removed backdrop click-to-close from **every** modal: shared `Modal.svelte` and `ConfirmDialog.svelte`, `CommandPalette.svelte`, `PathBrowser.svelte`, `ScriptBrowser.svelte`, and the inline delete dialogs in `Jobs.svelte` / `Storage.svelte`.
- Escape, Cancel, and the close (×) button still dismiss modals — all unchanged.
- Cleaned up the now-orphaned `handleBackdrop` functions and a redundant no-op `onkeydown`/`eslint-disable` in `ScriptBrowser.svelte`.

**Verified (Playwright):** Create Backup Job modal and the Jobs delete dialog both stay open after a real mouse click on the backdrop; Escape still closes both; no job was modified/deleted.

## #152 — Container appdata on Unassigned Devices is no longer auto-excluded
Bind mounts under `/mnt/disks/` (the Unassigned Devices mount point) were flagged as a `direct disk volume` and greyed out in **Container Mounts & Exclusions**, so appdata on an Unassigned Devices SSD (e.g. `/config` → `/mnt/disks/<dev>/appdata/<app>`) couldn't be backed up.

- `shouldSkipVolume` now requires a **trailing digit** after `/mnt/disk`, so it matches only real array disks (`/mnt/disk1`, `/mnt/disk2`, …) and no longer catches the plural `/mnt/disks/`.
- Follows CodeRabbit's plan (digit guard via `strings.TrimPrefix`, no `regexp`; rely on fall-through rather than special-casing appdata).
- Added regression tests: `/mnt/disks/<dev>/appdata/<app>` and `/mnt/disks/<dev>/data` → not skipped; existing `/mnt/disk1`, `/mnt/disk12` → still skipped.

**Verified:** unit tests (TDD red→green); live mounts API returns correct verdicts; wizard renders appdata as tickable and shared/device paths as auto-excluded.

## Workflow
- `make build` ✅ (lint + test + web + cross-compile)
- CodeRabbit CLI review ✅ (0 findings)
- `make deploy` ✅ / `make verify` ✅ (3/3 endpoints, WS 101, MCP ok)
- Playwright UI verification ✅
- CHANGELOG updated under `[Unreleased]`

Closes #148
Closes #152


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Container appdata on Unassigned Devices is no longer incorrectly excluded from backups.
  * Bind mounts under `/mnt/disks/` are now correctly backed up by default.

* **Changes**
  * Modals no longer close when clicking the backdrop area. Dismissal is now limited to the close button, Cancel, or Escape key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->