### PR TITLE
docs: keep settings-reference key column on one line

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,7 @@
+/* Keep setting keys and struct field names (the first table column of the
+   generated Settings Reference) on a single line. Long identifiers such as
+   `dedup_compaction_min_dead_ratio` were breaking mid-token. Tables remain
+   horizontally scrollable on narrow viewports, so nothing is clipped. */
+.md-typeset table:not([class]) td:first-child {
+  white-space: nowrap;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,8 @@ theme:
     - navigation.top
     - content.code.copy
     - search.suggest
+extra_css:
+  - stylesheets/extra.css
 markdown_extensions:
   - admonition
   - pymdownx.details


### PR DESCRIPTION
Follow-up to the GitHub Pages manual (#186).

Long setting keys and struct field names (e.g. `dedup_compaction_min_dead_ratio`) were wrapping mid-token in the generated Settings Reference tables. This adds `docs/stylesheets/extra.css` (wired via `extra_css`) to keep the first table column on one line; tables remain horizontally scrollable on narrow viewports, so nothing is clipped.

Verified with `mkdocs build --strict` (exit 0) after generating the reference pages, and the stylesheet is bundled into the site output.