### PR TITLE
feat(ui): add Documentation link to Settings → Reference (closes #189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **Documentation link in Settings → Reference** (closes #189). The About Vault card now links directly to the online manual at [ruaan-deysel.github.io/vault](https://ruaan-deysel.github.io/vault/), so users can reach the guides and settings reference without leaving the plugin.
 - **Optional "Backups" quick link in the Unraid top navigation** (closes #162). Enable it under Settings → Utilities → Vault → Quick Access to get a one-click **Backups** entry in the Unraid top bar that opens the Vault web UI embedded in the Unraid interface. Off by default. Unlike the community add-on that inspired it, this uses Unraid's supported plugin menu extension point — no core files are patched and no background watchdog is needed; the embedded view also refreshes its session token automatically when you return to a long-idle tab.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- **Documentation link in Settings → Reference** (closes #189). The About Vault card now links directly to the online manual at [ruaan-deysel.github.io/vault](https://ruaan-deysel.github.io/vault/), so users can reach the guides and settings reference without leaving the plugin.
+- **Documentation link in Settings → Reference** (closes #189). A new Documentation card at the top of the Reference tab links directly to the online manual at [ruaan-deysel.github.io/vault](https://ruaan-deysel.github.io/vault/), so users can reach the guides and settings reference without leaving the plugin.
 - **Optional "Backups" quick link in the Unraid top navigation** (closes #162). Enable it under Settings → Utilities → Vault → Quick Access to get a one-click **Backups** entry in the Unraid top bar that opens the Vault web UI embedded in the Unraid interface. Off by default. Unlike the community add-on that inspired it, this uses Unraid's supported plugin menu extension point — no core files are patched and no background watchdog is needed; the embedded view also refreshes its session token automatically when you return to a long-idle tab.
 
 ### Fixed

--- a/web/src/pages/Settings.svelte
+++ b/web/src/pages/Settings.svelte
@@ -1622,15 +1622,12 @@
           <p class="text-sm text-text-muted mb-4">
             The full Vault manual &mdash; getting started, guides, and a complete settings reference &mdash; is published online and stays in sync with each release.
           </p>
-          <div class="flex items-center gap-3 flex-wrap">
-            <a href="https://ruaan-deysel.github.io/vault/" target="_blank" rel="noopener"
-              aria-label="Open documentation (opens in a new tab)"
-              class="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-white bg-vault rounded-lg hover:bg-vault-dark transition-colors">
-              <svg aria-hidden="true" class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M6 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6H6zm7 1.5L18.5 9H13V3.5zM8 12h8v1.5H8V12zm0 3h6v1.5H8V15z"/></svg>
-              Open documentation
-            </a>
-            <span class="text-xs text-text-muted font-mono">ruaan-deysel.github.io/vault</span>
-          </div>
+          <a href="https://ruaan-deysel.github.io/vault/" target="_blank" rel="noopener"
+            aria-label="Open documentation (opens in a new tab)"
+            class="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-white bg-vault rounded-lg hover:bg-vault-dark transition-colors">
+            <svg aria-hidden="true" class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M6 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6H6zm7 1.5L18.5 9H13V3.5zM8 12h8v1.5H8V12zm0 3h6v1.5H8V15z"/></svg>
+            Open documentation
+          </a>
         </div>
       </div>
 

--- a/web/src/pages/Settings.svelte
+++ b/web/src/pages/Settings.svelte
@@ -1620,7 +1620,7 @@
         </div>
         <div class="p-5">
           <p class="text-sm text-text-muted mb-4">
-            The full Vault manual &mdash; getting started, guides, and a complete settings reference &mdash; is published online and stays in sync with each release.
+            The full Vault manual (getting started, guides, and a complete settings reference) is published online and stays in sync with each release.
           </p>
           <a href="https://ruaan-deysel.github.io/vault/" target="_blank" rel="noopener"
             aria-label="Open documentation (opens in a new tab)"

--- a/web/src/pages/Settings.svelte
+++ b/web/src/pages/Settings.svelte
@@ -1613,6 +1613,26 @@
 
       <!-- === REFERENCE TAB === -->
       {#if activeTab === 'reference'}
+      <!-- Online documentation -->
+      <div class="bg-surface-2 border border-border rounded-xl overflow-hidden">
+        <div class="px-5 py-4 border-b border-border">
+          <h2 class="text-base font-semibold text-text">Documentation</h2>
+        </div>
+        <div class="p-5">
+          <p class="text-sm text-text-muted mb-4">
+            The full Vault manual &mdash; getting started, guides, and a complete settings reference &mdash; is published online and stays in sync with each release.
+          </p>
+          <div class="flex items-center gap-3 flex-wrap">
+            <a href="https://ruaan-deysel.github.io/vault/" target="_blank" rel="noopener"
+              class="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-white bg-vault rounded-lg hover:bg-vault-dark transition-colors">
+              <svg aria-hidden="true" class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M6 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6H6zm7 1.5L18.5 9H13V3.5zM8 12h8v1.5H8V12zm0 3h6v1.5H8V15z"/></svg>
+              Open documentation
+            </a>
+            <span class="text-xs text-text-muted font-mono">ruaan-deysel.github.io/vault</span>
+          </div>
+        </div>
+      </div>
+
       <!-- Compression Info -->
       <div class="bg-surface-2 border border-border rounded-xl overflow-hidden">
         <div class="px-5 py-4 border-b border-border">

--- a/web/src/pages/Settings.svelte
+++ b/web/src/pages/Settings.svelte
@@ -1624,6 +1624,7 @@
           </p>
           <div class="flex items-center gap-3 flex-wrap">
             <a href="https://ruaan-deysel.github.io/vault/" target="_blank" rel="noopener"
+              aria-label="Open documentation (opens in a new tab)"
               class="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-white bg-vault rounded-lg hover:bg-vault-dark transition-colors">
               <svg aria-hidden="true" class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M6 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6H6zm7 1.5L18.5 9H13V3.5zM8 12h8v1.5H8V12zm0 3h6v1.5H8V15z"/></svg>
               Open documentation


### PR DESCRIPTION
Closes #189.

Adds a **Documentation** card at the top of **Settings → Reference** with a primary "Open documentation" button linking to the online manual at [ruaan-deysel.github.io/vault](https://ruaan-deysel.github.io/vault/), so users can reach the guides and settings reference without leaving the plugin.

### Verification
- `make build` — web frontend compiles, unit tests + linter pass.
- `make deploy` + `make verify` — all endpoint checks pass on Unraid.
- **Playwright** (via SSH tunnel to the local-only daemon): navigated to Settings → Reference; the Documentation card renders correctly above the Compression/Backup Type guides; link resolves to `https://ruaan-deysel.github.io/vault/` with `target=_blank rel=noopener`; 0 console errors.
- **CodeRabbit CLI**: reviewed, 0 findings (fixed an inaccurate CHANGELOG line and added an a11y `aria-label` from its feedback).
- CHANGELOG updated under `[Unreleased] → Added`.