### PR TITLE
feat(anomaly): make anomaly messages human-readable (closes #192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
-- **Anomaly messages are now plain-English sentences** (closes #192). Every detector now describes what happened versus what was expected in friendly language — e.g. _"This backup took 4m 23s, about 1.2× its usual 3m 40s"_ instead of _"backup duration anomaly: 4m 23s (1.2x median)"_ — across the dashboard, the anomalies page, notifications, the API, and MCP. Notifications also replace the raw JSON blob (`{"z_score":11.06,...}`) with a short context line such as _"Based on the last 10 runs"_, while the precise statistics remain available in the structured `details` field for programmatic consumers.
+- **Anomaly messages are now plain-English sentences** (closes #192). Every detector now describes what happened versus what was expected in friendly language — e.g. _"This backup took 4m 23s, about 1.2× its usual 3m 40s"_ instead of _"backup duration anomaly: 4m 23s (1.2x median)"_ — across the dashboard, the anomalies page, notifications, the API, and MCP. Notifications also replace the raw JSON blob (`{"z_score":11.06,...}`) with a short context line such as _"Based on the last 10 samples"_, while the precise statistics remain available in the structured `details` field for programmatic consumers.
 
 ## [2026.07.01] - 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- **Anomaly messages are now plain-English sentences** (closes #192). Every detector now describes what happened versus what was expected in friendly language — e.g. _"This backup took 4m 23s, about 1.2× its usual 3m 40s"_ instead of _"backup duration anomaly: 4m 23s (1.2x median)"_ — across the dashboard, the anomalies page, notifications, the API, and MCP. Notifications also replace the raw JSON blob (`{"z_score":11.06,...}`) with a short context line such as _"Based on the last 10 runs"_, while the precise statistics remain available in the structured `details` field for programmatic consumers.
+
 ## [2026.07.01] - 2026-07-04
 
 ### Added

--- a/docs/guides/anomaly-detection.md
+++ b/docs/guides/anomaly-detection.md
@@ -101,7 +101,7 @@ Anomaly messages are written as plain-English sentences that state what happened
 - **Reliability:** _This backup has failed 3 runs in a row and needs attention._
 - **Capacity:** _Storage "backups" is filling up — at the current rate of 12 GB per day it will run out of free space in about 6 days._
 
-Notifications show the same sentence plus a short line of context (e.g. _Based on the last 10 runs_) instead of a raw JSON blob. The precise statistics (z-score, growth factor, window size) are still available in the structured `details` field via the API, MCP, and the web UI's **Raw details** expander.
+Notifications show the same sentence plus a short line of context (e.g. _Based on the last 10 samples_) instead of a raw JSON blob. The precise statistics (z-score, growth factor, window size) are still available in the structured `details` field via the API, MCP, and the web UI's **Raw details** expander.
 
 ---
 

--- a/docs/guides/anomaly-detection.md
+++ b/docs/guides/anomaly-detection.md
@@ -93,6 +93,16 @@ Changes take effect on the next evaluation — no daemon restart needed.
 | **Notifications**   | Unraid + Discord alerts for critical anomalies (configurable)                    |
 | **MCP**             | `list_anomalies` / `get_anomaly` / `acknowledge_anomaly` tools for AI assistants |
 
+Anomaly messages are written as plain-English sentences that state what happened versus what was expected, so you don't need to read statistics to understand them:
+
+- **Duration:** _This backup took 4m 23s, about 1.2× its usual 3m 40s._
+- **Size (growth):** _This backup grew to 20 GB, about 5× its usual 4 GB._
+- **Size (shrinkage):** _This backup shrank to 1.8 GB, only 45% of its usual 4 GB — this can signal missing or corrupted data._
+- **Reliability:** _This backup has failed 3 runs in a row and needs attention._
+- **Capacity:** _Storage "backups" is filling up — at the current rate of 12 GB per day it will run out of free space in about 6 days._
+
+Notifications show the same sentence plus a short line of context (e.g. _Based on the last 10 runs_) instead of a raw JSON blob. The precise statistics (z-score, growth factor, window size) are still available in the structured `details` field via the API, MCP, and the web UI's **Raw details** expander.
+
 ---
 
 ## Lifecycle: resolve, acknowledge, mark-expected

--- a/internal/anomaly/capacity.go
+++ b/internal/anomaly/capacity.go
@@ -125,8 +125,8 @@ func (c *CapacityTrajectoryDetector) Evaluate(ec EvalContext) ([]Anomaly, error)
 				Expected:    &expected,
 				Deviation:   &deviation,
 				Summary: fmt.Sprintf(
-					"storage %q free space projected to run out in %.1f days (%s/day drain)",
-					ec.Destination.Name, etaDays, humanizeBytes(-slope),
+					"Storage %q is filling up — at the current rate of %s per day it will run out of free space in about %s.",
+					ec.Destination.Name, humanizeBytes(-slope), humanizeDays(etaDays),
 				),
 				Details: details,
 			})
@@ -149,7 +149,7 @@ func (c *CapacityTrajectoryDetector) Evaluate(ec EvalContext) ([]Anomaly, error)
 			Metric:      "free_bytes_low",
 			Observed:    latestFree,
 			Summary: fmt.Sprintf(
-				"storage %q is critically low: %.1f%% free (%s)",
+				"Storage %q is critically low on free space — only %.1f%% left (%s free).",
 				ec.Destination.Name, pct, humanizeBytes(latestFree),
 			),
 			Details: details,

--- a/internal/anomaly/duration.go
+++ b/internal/anomaly/duration.go
@@ -117,8 +117,8 @@ func (d *DurationDriftDetector) Evaluate(ec EvalContext) ([]Anomaly, error) {
 				Deviation:   &dev,
 				JobRunID:    &runID,
 				Summary: fmt.Sprintf(
-					"job was cancelled after %s (%.1fx median — possible stall/timeout)",
-					humanizeDuration(observed), growthFactor,
+					"This backup was cancelled after running for %s, far longer than its usual %s — it most likely stalled or timed out.",
+					humanizeDuration(observed), humanizeDuration(median),
 				),
 				Details: details,
 			},
@@ -163,8 +163,8 @@ func (d *DurationDriftDetector) Evaluate(ec EvalContext) ([]Anomaly, error) {
 			Deviation:   &dev,
 			JobRunID:    &runID,
 			Summary: fmt.Sprintf(
-				"backup duration anomaly: %s (%.1fx median)",
-				humanizeDuration(observed), growthFactor,
+				"This backup took %s, about %s its usual %s.",
+				humanizeDuration(observed), humanizeMultiplier(growthFactor), humanizeDuration(median),
 			),
 			Details: details,
 		},

--- a/internal/anomaly/humanize.go
+++ b/internal/anomaly/humanize.go
@@ -65,3 +65,44 @@ func humanizeDuration(seconds float64) string {
 	}
 	return fmt.Sprintf("%dh %dm", s/3600, (s%3600)/60)
 }
+
+// humanizeMultiplier renders a growth factor as a friendly "N×" string for use
+// in summary sentences (e.g. 1.18 → "1.2×", 5.0 → "5×"). Whole multiples drop
+// the decimal so "5×" reads cleanly; fractional ones keep one decimal.
+func humanizeMultiplier(factor float64) string {
+	if math.IsNaN(factor) || math.IsInf(factor, 0) {
+		return "—"
+	}
+	r := roundTo(factor, 1)
+	if r == math.Trunc(r) {
+		return fmt.Sprintf("%.0f×", r)
+	}
+	return fmt.Sprintf("%.1f×", r)
+}
+
+// humanizePercent renders a fraction (0–1) as a whole-percent string
+// (e.g. 0.45 → "45%"). Used when a summary compares an observed value against
+// the usual one as a share rather than a multiple.
+func humanizePercent(fraction float64) string {
+	if math.IsNaN(fraction) || math.IsInf(fraction, 0) {
+		return "—"
+	}
+	return fmt.Sprintf("%.0f%%", fraction*100)
+}
+
+// humanizeDays renders a day count as a friendly phrase for runway/ETA text
+// (e.g. 0.4 → "less than a day", 1 → "1 day", 5.6 → "6 days").
+func humanizeDays(days float64) string {
+	if math.IsNaN(days) || math.IsInf(days, 0) || days < 0 {
+		return "—"
+	}
+	r := math.Round(days)
+	switch {
+	case r < 1:
+		return "less than a day"
+	case r == 1:
+		return "1 day"
+	default:
+		return fmt.Sprintf("%.0f days", r)
+	}
+}

--- a/internal/anomaly/humanize.go
+++ b/internal/anomaly/humanize.go
@@ -69,11 +69,22 @@ func humanizeDuration(seconds float64) string {
 // humanizeMultiplier renders a growth factor as a friendly "N×" string for use
 // in summary sentences (e.g. 1.18 → "1.2×", 5.0 → "5×"). Whole multiples drop
 // the decimal so "5×" reads cleanly; fractional ones keep one decimal.
+//
+// A tight MAD can fire a z-score anomaly at a growth factor only just above 1,
+// where rounding to a bare "1×" would read like no change at all. Such values
+// collapse to ">1×" (and "<1×" below 1) so the summary still signals a real
+// deviation.
 func humanizeMultiplier(factor float64) string {
 	if math.IsNaN(factor) || math.IsInf(factor, 0) {
 		return "—"
 	}
 	r := roundTo(factor, 1)
+	if r == 1 && factor > 1 {
+		return ">1×"
+	}
+	if r == 1 && factor < 1 {
+		return "<1×"
+	}
 	if r == math.Trunc(r) {
 		return fmt.Sprintf("%.0f×", r)
 	}

--- a/internal/anomaly/humanize_test.go
+++ b/internal/anomaly/humanize_test.go
@@ -72,7 +72,9 @@ func TestHumanizeMultiplier(t *testing.T) {
 	}{
 		{"whole", 5, "5×"},
 		{"fractional", 1.18, "1.2×"},
-		{"just over one", 1.04, "1×"},
+		{"exactly one", 1, "1×"},
+		{"just over one stays a deviation", 1.04, ">1×"},
+		{"just under one stays a deviation", 0.97, "<1×"},
 		{"large fractional", 12.35, "12.4×"},
 		{"infinity", math.Inf(1), "—"},
 		{"NaN", math.NaN(), "—"},

--- a/internal/anomaly/humanize_test.go
+++ b/internal/anomaly/humanize_test.go
@@ -63,6 +63,76 @@ func TestHumanizeDuration(t *testing.T) {
 	}
 }
 
+func TestHumanizeMultiplier(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   float64
+		want string
+	}{
+		{"whole", 5, "5×"},
+		{"fractional", 1.18, "1.2×"},
+		{"just over one", 1.04, "1×"},
+		{"large fractional", 12.35, "12.4×"},
+		{"infinity", math.Inf(1), "—"},
+		{"NaN", math.NaN(), "—"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := humanizeMultiplier(c.in); got != c.want {
+				t.Errorf("humanizeMultiplier(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestHumanizePercent(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   float64
+		want string
+	}{
+		{"half", 0.5, "50%"},
+		{"rounds", 0.456, "46%"},
+		{"tiny", 0.02, "2%"},
+		{"infinity", math.Inf(1), "—"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := humanizePercent(c.in); got != c.want {
+				t.Errorf("humanizePercent(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestHumanizeDays(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   float64
+		want string
+	}{
+		{"sub-day", 0.4, "less than a day"},
+		{"one day", 1, "1 day"},
+		{"rounds to one", 1.2, "1 day"},
+		{"several", 5.6, "6 days"},
+		{"negative", -3, "—"},
+		{"infinity", math.Inf(1), "—"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := humanizeDays(c.in); got != c.want {
+				t.Errorf("humanizeDays(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
 func TestRoundTo(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/internal/anomaly/reliability.go
+++ b/internal/anomaly/reliability.go
@@ -123,7 +123,7 @@ func (r *ReliabilityDetector) evalStreak(ec EvalContext, jobID int64) *Anomaly {
 		Metric:      "failure_streak",
 		Observed:    float64(streak),
 		JobRunID:    &runID,
-		Summary:     fmt.Sprintf("job has failed %d runs in a row", streak),
+		Summary:     fmt.Sprintf("This backup has failed %s in a row and needs attention.", pluralizeRuns(streak)),
 		Details:     details,
 	}
 }
@@ -171,9 +171,18 @@ func (r *ReliabilityDetector) evalVerifyRegression(jobID int64) (*Anomaly, error
 		ScopeID:     jobID,
 		Metric:      "verify_outcome",
 		Observed:    0, // no numeric metric; presence is the signal
-		Summary:     "backup verification regressed: previous run passed, latest run failed",
+		Summary:     "This backup's latest verification failed after the previous one passed — the backed-up data may no longer be restorable.",
 		Details:     details,
 	}, nil
+}
+
+// pluralizeRuns renders a run count as "1 run" or "N runs" so the streak
+// summary reads naturally regardless of the configured sensitivity threshold.
+func pluralizeRuns(n int) string {
+	if n == 1 {
+		return "1 run"
+	}
+	return fmt.Sprintf("%d runs", n)
 }
 
 // buildStreakDetails marshals the streak count into a JSON Details string.

--- a/internal/anomaly/size.go
+++ b/internal/anomaly/size.go
@@ -96,7 +96,7 @@ func (d *SizeDriftDetector) Evaluate(ec EvalContext) ([]Anomaly, error) {
 				Expected:    &median,
 				Deviation:   &dev,
 				JobRunID:    &runID,
-				Summary:     fmt.Sprintf("backup shrank to %s (%.0f%% of expected %s)", humanizeBytes(observed), growthFactor*100, humanizeBytes(median)),
+				Summary:     fmt.Sprintf("This backup shrank to %s, only %s of its usual %s — this can signal missing or corrupted data.", humanizeBytes(observed), humanizePercent(growthFactor), humanizeBytes(median)),
 				Details:     details,
 			},
 		}, nil
@@ -139,7 +139,7 @@ func (d *SizeDriftDetector) Evaluate(ec EvalContext) ([]Anomaly, error) {
 			Expected:    &median,
 			Deviation:   &dev,
 			JobRunID:    &runID,
-			Summary:     fmt.Sprintf("backup size anomaly: %s (%.1fx median)", humanizeBytes(observed), growthFactor),
+			Summary:     fmt.Sprintf("This backup grew to %s, about %s its usual %s.", humanizeBytes(observed), humanizeMultiplier(growthFactor), humanizeBytes(median)),
 			Details:     details,
 		},
 	}, nil

--- a/internal/notify/anomaly.go
+++ b/internal/notify/anomaly.go
@@ -3,6 +3,7 @@ package notify
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -114,11 +115,15 @@ func renderAnomalyDetails(details string) string {
 	}
 
 	var lines []string
-	if n, ok := intField(m, "window_size"); ok {
-		lines = append(lines, fmt.Sprintf("Based on the last %d runs", n))
+	// window_size counts the samples the detector looked back over — backup
+	// runs for drift/reliability, but capacity health-check samples for the
+	// capacity detector — so use the neutral "sample(s)" label rather than
+	// "runs", which would misdescribe capacity anomalies.
+	if n, ok := intField(m, "window_size"); ok && n > 0 {
+		lines = append(lines, "Based on the last "+countLabel(n, "sample"))
 	}
-	if n, ok := intField(m, "streak"); ok {
-		lines = append(lines, fmt.Sprintf("%d consecutive failed runs", n))
+	if n, ok := intField(m, "streak"); ok && n > 0 {
+		lines = append(lines, countLabel(n, "run")+" failed in a row")
 	}
 	if newest, ok := m["newest_status"].(string); ok {
 		if prev, ok2 := m["previous_status"].(string); ok2 {
@@ -128,17 +133,28 @@ func renderAnomalyDetails(details string) string {
 	return strings.Join(lines, "\n")
 }
 
+// countLabel renders a count with a singular/plural unit, e.g. countLabel(1,
+// "sample") → "1 sample" and countLabel(3, "run") → "3 runs".
+func countLabel(n int, unit string) string {
+	if n == 1 {
+		return "1 " + unit
+	}
+	return fmt.Sprintf("%d %ss", n, unit)
+}
+
 // intField reads a numeric JSON field as an int. JSON numbers decode to
-// float64 through map[string]any, so it accepts float64 (and int for safety).
+// float64 through map[string]any, so only float64 is accepted; fractional,
+// non-finite, or out-of-range values are rejected (ok=false) so malformed
+// payloads never produce nonsense counts in user-facing notification text.
 func intField(m map[string]any, key string) (int, bool) {
-	switch v := m[key].(type) {
-	case float64:
-		return int(v), true
-	case int:
-		return v, true
-	default:
+	f, ok := m[key].(float64)
+	if !ok {
 		return 0, false
 	}
+	if math.IsNaN(f) || math.IsInf(f, 0) || f != math.Trunc(f) || f < math.MinInt || f > math.MaxInt {
+		return 0, false
+	}
+	return int(f), true
 }
 
 func importanceForSeverity(severity string) Importance {

--- a/internal/notify/anomaly.go
+++ b/internal/notify/anomaly.go
@@ -1,6 +1,10 @@
 package notify
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
 
 // Anomaly Discord embed colour constants (hex values stored as int).
 // Used by BuildAnomalyEmbed so callers don't hard-code magic numbers.
@@ -64,10 +68,10 @@ func BuildAnomalyEmbed(p AnomalyEmbedParams) DiscordEmbed {
 		Value:  p.Severity,
 		Inline: true,
 	})
-	if p.Details != "" {
+	if ctx := renderAnomalyDetails(p.Details); ctx != "" {
 		fields = append(fields, DiscordField{
-			Name:  "Details",
-			Value: truncate(p.Details, 256),
+			Name:  "Context",
+			Value: truncate(ctx, 256),
 		})
 	}
 
@@ -88,7 +92,53 @@ func BuildAnomalyEmbed(p AnomalyEmbedParams) DiscordEmbed {
 // the call is a no-op that logs and returns nil — same behaviour as Send.
 func SendAnomalyUnraid(summary, details, severity string) error {
 	imp := importanceForSeverity(severity)
-	return Send("Vault", fmt.Sprintf("Anomaly detected: %s", summary), details, imp)
+	return Send("Vault", fmt.Sprintf("Anomaly detected: %s", summary), renderAnomalyDetails(details), imp)
+}
+
+// renderAnomalyDetails converts an anomaly's structured Details JSON into
+// short, human-readable context lines for notifications, replacing the raw
+// JSON blob that used to be shown to users. It only surfaces fields that add
+// approachable context and deliberately omits purely statistical values
+// (e.g. z_score, slope) that the plain-English Summary already conveys.
+//
+// Unrecognised or unparsable payloads yield an empty string so the caller
+// simply omits the context rather than dumping raw JSON. The underlying
+// Details JSON is left untouched for the API, MCP, and web UI that parse it.
+func renderAnomalyDetails(details string) string {
+	if strings.TrimSpace(details) == "" {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(details), &m); err != nil {
+		return ""
+	}
+
+	var lines []string
+	if n, ok := intField(m, "window_size"); ok {
+		lines = append(lines, fmt.Sprintf("Based on the last %d runs", n))
+	}
+	if n, ok := intField(m, "streak"); ok {
+		lines = append(lines, fmt.Sprintf("%d consecutive failed runs", n))
+	}
+	if newest, ok := m["newest_status"].(string); ok {
+		if prev, ok2 := m["previous_status"].(string); ok2 {
+			lines = append(lines, fmt.Sprintf("Latest verification %s (previous run %s)", newest, prev))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// intField reads a numeric JSON field as an int. JSON numbers decode to
+// float64 through map[string]any, so it accepts float64 (and int for safety).
+func intField(m map[string]any, key string) (int, bool) {
+	switch v := m[key].(type) {
+	case float64:
+		return int(v), true
+	case int:
+		return v, true
+	default:
+		return 0, false
+	}
 }
 
 func importanceForSeverity(severity string) Importance {

--- a/internal/notify/anomaly_test.go
+++ b/internal/notify/anomaly_test.go
@@ -1,6 +1,7 @@
 package notify
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -111,26 +112,50 @@ func TestBuildAnomalyEmbed_ScopeField(t *testing.T) {
 	}
 }
 
-// TestBuildAnomalyEmbed_DetailsTruncation verifies very long Details strings are
-// capped so the Discord embed doesn't exceed field limits.
-func TestBuildAnomalyEmbed_DetailsTruncation(t *testing.T) {
+// TestBuildAnomalyEmbed_ContextRendering verifies the embed surfaces friendly,
+// labelled context derived from the Details JSON rather than dumping the raw
+// blob (or leaking purely technical fields like z_score) at the user.
+func TestBuildAnomalyEmbed_ContextRendering(t *testing.T) {
 	t.Parallel()
-
-	longDetails := make([]byte, 1000)
-	for i := range longDetails {
-		longDetails[i] = 'x'
-	}
 
 	embed := BuildAnomalyEmbed(AnomalyEmbedParams{
 		Severity: "warning",
-		Summary:  "test",
-		Details:  string(longDetails),
+		Summary:  "This backup grew to 20 GB, about 5× its usual 4 GB.",
+		Details:  `{"z_score":11.06,"growth_factor":5,"window_size":10}`,
 	})
 
+	var ctx string
 	for _, f := range embed.Fields {
+		if f.Name == "Context" {
+			ctx = f.Value
+		}
 		if f.Name == "Details" {
-			if len([]rune(f.Value)) > 256 {
-				t.Errorf("Details field length %d exceeds 256 runes", len([]rune(f.Value)))
+			t.Errorf("embed still exposes a raw Details field: %q", f.Value)
+		}
+	}
+	if want := "Based on the last 10 runs"; ctx != want {
+		t.Errorf("Context = %q, want %q", ctx, want)
+	}
+	if strings.Contains(ctx, "z_score") {
+		t.Errorf("Context leaked a technical field: %q", ctx)
+	}
+}
+
+// TestBuildAnomalyEmbed_OmitsUnrenderableContext verifies that empty, non-JSON,
+// or purely-technical Details payloads produce no Context field at all (the
+// self-explanatory Summary stands on its own) rather than raw JSON.
+func TestBuildAnomalyEmbed_OmitsUnrenderableContext(t *testing.T) {
+	t.Parallel()
+
+	for _, details := range []string{"", "not json", `{"pct_free":2.3}`} {
+		embed := BuildAnomalyEmbed(AnomalyEmbedParams{
+			Severity: "warning",
+			Summary:  "test",
+			Details:  details,
+		})
+		for _, f := range embed.Fields {
+			if f.Name == "Context" {
+				t.Errorf("details %q: unexpected Context field %q", details, f.Value)
 			}
 		}
 	}

--- a/internal/notify/anomaly_test.go
+++ b/internal/notify/anomaly_test.go
@@ -139,6 +139,29 @@ func TestBuildAnomalyEmbed_ContextRendering(t *testing.T) {
 	if strings.Contains(ctx, "z_score") {
 		t.Errorf("Context leaked a technical field: %q", ctx)
 	}
+	// The Context field must stay within Discord's per-field limit.
+	if n := len([]rune(ctx)); n > 256 {
+		t.Errorf("Context field length %d exceeds 256 runes", n)
+	}
+}
+
+// TestTruncate verifies the field-length guard that keeps notification embed
+// fields within Discord's 256-rune limit (regression guard for long values).
+func TestTruncate(t *testing.T) {
+	t.Parallel()
+
+	if got := truncate("short", 256); got != "short" {
+		t.Errorf("truncate short string = %q, want %q", got, "short")
+	}
+
+	long := strings.Repeat("x", 1000)
+	got := truncate(long, 256)
+	if n := len([]rune(got)); n > 256 {
+		t.Errorf("truncate() length %d exceeds 256 runes", n)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncate() should append an ellipsis when truncating, got %q", got)
+	}
 }
 
 // TestBuildAnomalyEmbed_OmitsUnrenderableContext verifies that empty, non-JSON,

--- a/internal/notify/anomaly_test.go
+++ b/internal/notify/anomaly_test.go
@@ -133,7 +133,7 @@ func TestBuildAnomalyEmbed_ContextRendering(t *testing.T) {
 			t.Errorf("embed still exposes a raw Details field: %q", f.Value)
 		}
 	}
-	if want := "Based on the last 10 runs"; ctx != want {
+	if want := "Based on the last 10 samples"; ctx != want {
 		t.Errorf("Context = %q, want %q", ctx, want)
 	}
 	if strings.Contains(ctx, "z_score") {
@@ -158,6 +158,39 @@ func TestBuildAnomalyEmbed_OmitsUnrenderableContext(t *testing.T) {
 				t.Errorf("details %q: unexpected Context field %q", details, f.Value)
 			}
 		}
+	}
+}
+
+// TestRenderAnomalyDetails covers the readable-context rendering: neutral
+// "sample(s)"/"run(s)" wording with singular/plural handling, verify-regression
+// phrasing, and rejection of fractional/negative counts.
+func TestRenderAnomalyDetails(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		details string
+		want    string
+	}{
+		{"window plural", `{"z_score":8.2,"window_size":10}`, "Based on the last 10 samples"},
+		{"window singular", `{"window_size":1}`, "Based on the last 1 sample"},
+		{"streak plural", `{"streak":3}`, "3 runs failed in a row"},
+		{"streak singular", `{"streak":1}`, "1 run failed in a row"},
+		{"verify regression", `{"newest_status":"failed","previous_status":"passed"}`, "Latest verification failed (previous run passed)"},
+		{"fractional window rejected", `{"window_size":10.9}`, ""},
+		{"negative window rejected", `{"window_size":-4}`, ""},
+		{"low-free has no context", `{"free_bytes":1000,"total_bytes":50000,"pct_free":2}`, ""},
+		{"empty", "", ""},
+		{"not json", "not json", ""},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := renderAnomalyDetails(c.details); got != c.want {
+				t.Errorf("renderAnomalyDetails(%q) = %q, want %q", c.details, got, c.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Improves the readability of anomaly detection messages so they read as plain-English sentences instead of statistical shorthand. Implements the CodeRabbit plan on #192.

Before:
> Anomaly detected: backup duration anomaly: 4m 23s (1.2x median)
> `{"z_score":11.06,"growth_factor":1.18,"window_size":10}`

After:
> Anomaly detected: This backup took 4m 23s, about 1.2× its usual 3m 40s.
> Context: Based on the last 10 runs

## Changes

**Self-explanatory summaries at the source** (`internal/anomaly/`) — reworded every detector's `Summary` to state what happened vs. what's expected, reusing the humanize helpers so all downstream channels (notifications, API, MCP, UI) benefit at once:
- **duration** — `"This backup took 4m 23s, about 1.2× its usual 3m 40s."` + friendlier cancelled/stall variant.
- **size** — growth: `"This backup grew to 20 GB, about 5× its usual 4 GB."`; shrinkage: `"…only 45% of its usual 4 GB — this can signal missing or corrupted data."`
- **capacity** — `"Storage \"backups\" is filling up — at the current rate of 12 GB per day it will run out of free space in about 6 days."` + clearer low-free wording.
- **reliability** — `"This backup has failed 3 runs in a row and needs attention."` + a plain verify-regression sentence.
- **humanize** — added `humanizeMultiplier` (`5×`), `humanizePercent` (`45%`), `humanizeDays` (`6 days`), and a `pluralizeRuns` helper. Existing helpers are untouched (their exact-output tests still pass).

**Readable notifications** (`internal/notify/anomaly.go`) — `renderAnomalyDetails` translates the `details` JSON into a short context line (e.g. `Based on the last 10 runs`) and omits purely technical fields (z-score). The Discord embed (now a **Context** field) and the Unraid body use it instead of dumping raw JSON. The structured `Details` is left intact for programmatic consumers.

**Frontend** — verification only, no code change: `prettyAnomalySummary`'s regex only rewrites `<n> bytes`/bare `<n>s` tokens (absent from the new pre-formatted text, still useful for legacy anomalies) and the detail-panel keys are unchanged.

**Docs/CHANGELOG** — added an example-messages section to the anomaly guide and a `### Changed` entry under `## [Unreleased]`.

## Testing

- Added unit tests for the new humanize helpers; rewrote the notify test to assert Context rendering (raw JSON no longer leaks, technical fields omitted).
- **CodeRabbit CLI** (`review --agent -t uncommitted`): 0 findings.
- `make build` (lint + tests + web + cross-compile), `make deploy`, `make verify`: all passed.
- **Playwright on the deployed Unraid UI**: confirmed the reworded summaries render cleanly on the Anomalies page and Dashboard card, and the detail panel still maps metadata (`Observed: 1.8 GB`, `Expected: 4 GB`) with the structured JSON preserved in *Raw details*.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anomaly messages now use clearer plain-English sentences describing what happened versus what was expected, consistently across the dashboard, anomalies page, notifications, the API, and MCP.
  * Notifications now show a short contextual line (while keeping full structured statistics available in the app and via the API/MCP “raw details” view).
* **Bug Fixes**
  * Improved humanised wording for duration, size, capacity, and reliability anomalies (including clearer grammar and safer formatting for unusual values).
* **Documentation**
  * Updated the anomaly detection guide to explain the new message and notification formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->