### PR TITLE
feat(presets): refine Tdarr exclusions and add detection tests (closes #188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- **Tdarr container backups now drop stray log files and are covered by tests** (closes #188). The Tdarr exclusion preset already skipped the transcode cache (`/temp`) and log directory (`/app/logs`); it now also excludes stray `*.log` files, while deliberately keeping `/app/server` (the DB2 database, plugins and samples) and `/app/configs` so Tdarr settings and statistics restore cleanly. Both the combined `tdarr` image and the `tdarr_node` image are recognised, now with regression tests to keep detection working.
+
 ## [2026.07.01] - 2026-07-04
 
 ### Added

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -95,9 +95,12 @@ var ContainerExclusionPresets = map[string][]string{
 	// Transcoding/Processing
 	// Tdarr stores its database (DB2), plugins, samples and config JSON under
 	// /app/server and /app/configs — both are kept so settings and statistics
-	// restore cleanly. Only the transcode cache (/temp) and logs are dropped;
-	// the large /media library is skipped automatically by the shared-data
-	// heuristic. The same key matches the tdarr_node image via substring.
+	// restore cleanly. Only the transcode cache (/temp) and logs are dropped.
+	// The media library is not excluded here: when it is bind-mounted from an
+	// Unraid shared-data path (e.g. /mnt/user/media) the engine's shared-data
+	// heuristic auto-skips it by host source; a media mount from an unusual
+	// host path can be unchecked in the job editor. The same key matches the
+	// tdarr_node image via substring.
 	"tdarr": {
 		"/temp",
 		"/app/logs",

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -93,9 +93,15 @@ var ContainerExclusionPresets = map[string][]string{
 	},
 
 	// Transcoding/Processing
+	// Tdarr stores its database (DB2), plugins, samples and config JSON under
+	// /app/server and /app/configs — both are kept so settings and statistics
+	// restore cleanly. Only the transcode cache (/temp) and logs are dropped;
+	// the large /media library is skipped automatically by the shared-data
+	// heuristic. The same key matches the tdarr_node image via substring.
 	"tdarr": {
 		"/temp",
 		"/app/logs",
+		"*.log",
 	},
 	"unmanic": {
 		"/tmp/unmanic",

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -44,10 +45,15 @@ func TestGetExclusionPreset(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			paths := GetExclusionPreset(tt.image)
-			if tt.wantMatch && len(paths) == 0 {
-				t.Errorf("GetExclusionPreset(%q) returned empty, expected match for key %q", tt.image, tt.wantKey)
-			}
-			if !tt.wantMatch && len(paths) > 0 {
+			if tt.wantMatch {
+				// Assert it resolved to the *specific* expected preset, not just
+				// any non-empty one — otherwise a substring collision or ordering
+				// change that matched the wrong key would slip through.
+				if !slices.Equal(paths, ContainerExclusionPresets[tt.wantKey]) {
+					t.Errorf("GetExclusionPreset(%q) = %v, want the %q preset %v",
+						tt.image, paths, tt.wantKey, ContainerExclusionPresets[tt.wantKey])
+				}
+			} else if len(paths) > 0 {
 				t.Errorf("GetExclusionPreset(%q) returned %v, expected no match", tt.image, paths)
 			}
 		})

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -34,6 +34,10 @@ func TestGetExclusionPreset(t *testing.T) {
 		{"watchtower", "containrrr/watchtower:latest", true, "watchtower"},
 		{"dozzle", "amir20/dozzle:latest", true, "dozzle"},
 		{"dockhand", "ghcr.io/scottyhardy/dockhand:latest", true, "dockhand"},
+		// Tdarr server and node images both resolve to the "tdarr" preset via
+		// substring matching (issue #188).
+		{"tdarr server", "ghcr.io/haveagitgat/tdarr:latest", true, "tdarr"},
+		{"tdarr node", "ghcr.io/haveagitgat/tdarr_node:latest", true, "tdarr"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Refines Vault's out-of-the-box Tdarr container backup handling and adds the regression tests it was missing (#188).

Grounded in the official Tdarr docs (docs.tdarr.io, HaveAGitGat/Tdarr):

| Container path | Contents | Vault handling |
|---|---|---|
| `/app/server` | DB2 database, plugins, samples | **Keep** |
| `/app/configs` | `Tdarr_Server_Config.json` / `Tdarr_Node_Config.json` | **Keep** |
| `/app/logs` | logs | Exclude |
| `/temp` | transcode cache | Exclude |
| `/media` | media library | Skipped automatically by `shouldSkipVolume` |

## Changes

- **Preset** (`internal/config/presets.go`): the `tdarr` entry already excluded `/temp` and `/app/logs`; added a `*.log` glob to catch stray log files (matching the convention used by other presets), and documented that `/app/server` and `/app/configs` are intentionally kept so Tdarr settings/statistics restore cleanly.
- **Tests** (`internal/config/presets_test.go`): added rows proving both `ghcr.io/haveagitgat/tdarr:latest` and `ghcr.io/haveagitgat/tdarr_node:latest` resolve to the `tdarr` preset via substring matching — previously there was **no** Tdarr test coverage.
- **CHANGELOG**: documented under `[Unreleased]`.

Note: I deliberately did **not** add the speculative `/app/server/Tdarr/Cache` exclusion from the issue plan — I couldn't confirm that path exists in the current Tdarr layout, and excluding a wrong subpath of `/app/server` risks dropping real database data. Tdarr's DB is file-based and Vault stops the container before tarring, so `/app/server` is captured consistently.

## Testing

- `make build` (lint + unit tests) + `make deploy` + `make verify`: all passed.
- Verified against the **deployed** daemon that `GET /api/v1/presets/exclusions` returns `["/temp","/app/logs","*.log"]` for both the `tdarr` and `tdarr_node` images (this endpoint is what the job wizard's "Load recommended exclusions" consumes). No Tdarr container exists on the host to drive the wizard UI, and this change touches no UI code.