### PR TITLE
feat(vm): detect raw vs qcow2 disks and gate backup types (closes #163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **VM backup jobs now detect raw vs qcow2 disks and only offer supported backup types** (closes #163). Vault reads each VM's disk format at discovery time and exposes it (`disk_format`, `supports_incremental`) on `GET /api/v1/vms`. Because libvirt checkpoint-based incremental/differential backups require qcow2 disks, the job wizard now hides those options — and falls back to Full — when a selected VM uses raw or mixed disks, with an inline note naming the affected VM. This surfaces up front the constraint the engine previously enforced silently by downgrading raw-disk VMs to full backups.
 - **Pre/post-backup scripts now receive job context as environment variables** (part of #187). The job editor has long promised `VAULT_JOB_NAME` and `VAULT_STATUS` to hook scripts, but they were never actually set. Vault now exports `VAULT_JOB_NAME`, `VAULT_STATUS` (`starting` for pre-scripts, the run's final status for post-scripts), `VAULT_JOB_ID`, and `VAULT_RUN_ID` into every pre/post-backup script's environment — enabling, for example, an Immich `pg_dump` pre-script that targets the right job.
 - **Container exclusion presets can now carry advisory notes and warnings** (part of #187). `GET /api/v1/presets/exclusions` returns optional `notes`/`warnings` for apps that need a caveat, and the job wizard shows them inline beneath the container's exclusions.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -98,16 +98,16 @@ Loopback requests (`127.0.0.1` and `::1`) are always exempt from API key validat
 
 ## Discovery
 
-| Method | Endpoint              | Description                                                                                                |
-| ------ | --------------------- | ---------------------------------------------------------------------------------------------------------- |
-| GET    | `/browse?path=…`      | Browse filesystem paths (safepath-gated; allowed under `/mnt` etc.)                                        |
-| GET    | `/path-exists?path=…` | Safepath-gated `os.Stat` (used by the Folder picker for staleness)                                         |
-| GET    | `/containers`         | Discover Docker containers                                                                                 |
-| GET    | `/vms`                | Discover libvirt VMs                                                                                       |
-| GET    | `/folders`            | Discover folder presets (engine-known paths)                                                               |
-| GET    | `/plugins`            | Discover installed Unraid plugins                                                                          |
-| GET    | `/zfs`                | Discover ZFS datasets                                                                                      |
-| GET    | `/presets/exclusions` | Per-container exclusion presets (`paths`), plus advisory `notes`/`warnings` for some apps (e.g. Immich DB) |
+| Method | Endpoint              | Description                                                                                                                                   |
+| ------ | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| GET    | `/browse?path=…`      | Browse filesystem paths (safepath-gated; allowed under `/mnt` etc.)                                                                           |
+| GET    | `/path-exists?path=…` | Safepath-gated `os.Stat` (used by the Folder picker for staleness)                                                                            |
+| GET    | `/containers`         | Discover Docker containers                                                                                                                    |
+| GET    | `/vms`                | Discover libvirt VMs; each item's `settings` includes `disk_format` (`qcow2`/`raw`/`mixed`/`unknown`) and `supports_incremental` (qcow2-only) |
+| GET    | `/folders`            | Discover folder presets (engine-known paths)                                                                                                  |
+| GET    | `/plugins`            | Discover installed Unraid plugins                                                                                                             |
+| GET    | `/zfs`                | Discover ZFS datasets                                                                                                                         |
+| GET    | `/presets/exclusions` | Per-container exclusion presets (`paths`), plus advisory `notes`/`warnings` for some apps (e.g. Immich DB)                                    |
 
 ## Activity Logs
 

--- a/internal/engine/vm.go
+++ b/internal/engine/vm.go
@@ -57,12 +57,29 @@ func (h *VMHandler) ListItems() ([]BackupItem, error) {
 
 		stateStr := domainStateString(libvirt.DomainState(state))
 
+		// Detect disk format so the job wizard can offer only the backup types
+		// the VM actually supports (incremental/differential need qcow2 disks).
+		// Read the persistent (inactive) config so the result is stable
+		// regardless of running state or in-flight snapshots. Any failure
+		// degrades to a conservative "unknown"/not-incremental result rather
+		// than failing the whole listing.
+		diskFormat, supportsIncremental := "unknown", false
+		if xmlDesc, xmlErr := h.conn.DomainGetXMLDesc(dom, libvirt.DomainXMLInactive); xmlErr != nil {
+			log.Printf("engine/vm: disk-format detection for %q: reading domain XML: %v", dom.Name, xmlErr)
+		} else if disks, _, parseErr := parseDomainDisksWithTargets(xmlDesc); parseErr != nil {
+			log.Printf("engine/vm: disk-format detection for %q: parsing disks: %v", dom.Name, parseErr)
+		} else {
+			diskFormat, supportsIncremental = summariseDiskFormat(disks)
+		}
+
 		items = append(items, BackupItem{
 			Name: dom.Name,
 			Type: "vm",
 			Settings: map[string]any{
-				"uuid":  formatDomainUUID(dom.UUID),
-				"state": stateStr,
+				"uuid":                 formatDomainUUID(dom.UUID),
+				"state":                stateStr,
+				"disk_format":          diskFormat,
+				"supports_incremental": supportsIncremental,
 			},
 		})
 	}

--- a/internal/engine/vm_format_test.go
+++ b/internal/engine/vm_format_test.go
@@ -156,3 +156,56 @@ func TestAllDisksQcow2UsesFormat(t *testing.T) {
 		t.Fatal("expected extension fallback for disks without Format")
 	}
 }
+
+func TestSummariseDiskFormat(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		disks           []domainDisk
+		wantFormat      string
+		wantIncremental bool
+	}{
+		{
+			name:            "all qcow2 supports incremental",
+			disks:           []domainDisk{{Path: "a.img", Format: "qcow2"}, {Path: "b.img", Format: "qcow2"}},
+			wantFormat:      "qcow2",
+			wantIncremental: true,
+		},
+		{
+			name:            "all raw does not",
+			disks:           []domainDisk{{Path: "a.img", Format: "raw"}, {Path: "b.img", Format: "raw"}},
+			wantFormat:      "raw",
+			wantIncremental: false,
+		},
+		{
+			name:            "mixed formats",
+			disks:           []domainDisk{{Path: "a.img", Format: "qcow2"}, {Path: "b.img", Format: "raw"}},
+			wantFormat:      "mixed",
+			wantIncremental: false,
+		},
+		{
+			name:            "empty or skipped-only is unknown",
+			disks:           nil,
+			wantFormat:      "unknown",
+			wantIncremental: false,
+		},
+		{
+			name:            "extension fallback when Format unset",
+			disks:           []domainDisk{{Path: "/mnt/cache/domains/haos/haos.qcow2"}},
+			wantFormat:      "qcow2",
+			wantIncremental: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			format, incremental := summariseDiskFormat(c.disks)
+			if format != c.wantFormat || incremental != c.wantIncremental {
+				t.Errorf("summariseDiskFormat(%s) = (%q, %v), want (%q, %v)",
+					c.name, format, incremental, c.wantFormat, c.wantIncremental)
+			}
+		})
+	}
+}

--- a/internal/engine/vm_snapshot.go
+++ b/internal/engine/vm_snapshot.go
@@ -182,6 +182,17 @@ func parseDomainDiskInventory(xmlDesc string) (domainDiskInventory, error) {
 	return inventory, nil
 }
 
+// resolveDiskFormat returns a disk's effective image format: the domain XML
+// <driver type> when present, otherwise the path-extension heuristic. Shared by
+// summariseDiskFormat and allDisksQcow2 so the "supports incremental" and
+// "all qcow2" decisions can never diverge on the fallback rule.
+func resolveDiskFormat(d domainDisk) string {
+	if d.Format != "" {
+		return d.Format
+	}
+	return backupDriverType(d.Path)
+}
+
 // summariseDiskFormat condenses a domain's disks into a single format label
 // ("qcow2", "raw", the shared format, or "mixed") plus whether the VM supports
 // libvirt checkpoint-based incremental/differential backups (qcow2-only).
@@ -196,10 +207,7 @@ func summariseDiskFormat(disks []domainDisk) (format string, supportsIncremental
 	first := ""
 	uniform := true
 	for i, d := range disks {
-		f := d.Format
-		if f == "" {
-			f = backupDriverType(d.Path)
-		}
+		f := resolveDiskFormat(d)
 		if i == 0 {
 			first = f
 		} else if f != first {
@@ -217,11 +225,7 @@ func summariseDiskFormat(disks []domainDisk) (format string, supportsIncremental
 // for callers that did not populate Format.
 func allDisksQcow2(disks []domainDisk) bool {
 	for _, d := range disks {
-		format := d.Format
-		if format == "" {
-			format = backupDriverType(d.Path)
-		}
-		if format != "qcow2" {
+		if resolveDiskFormat(d) != "qcow2" {
 			return false
 		}
 	}

--- a/internal/engine/vm_snapshot.go
+++ b/internal/engine/vm_snapshot.go
@@ -21,6 +21,7 @@ var (
 	_ = selectBackupDiskXML
 	_ = stripDomainBackingStores
 	_ = allDisksQcow2
+	_ = summariseDiskFormat
 	_ = describeDomainDisks
 	_ = formatSkippedDomainDisks
 )
@@ -179,6 +180,36 @@ func parseDomainDiskInventory(xmlDesc string) (domainDiskInventory, error) {
 	}
 
 	return inventory, nil
+}
+
+// summariseDiskFormat condenses a domain's disks into a single format label
+// ("qcow2", "raw", the shared format, or "mixed") plus whether the VM supports
+// libvirt checkpoint-based incremental/differential backups (qcow2-only).
+//
+// An empty disk list (no file-backed disks, e.g. block/network-only or an
+// unreadable inventory) is reported as "unknown" / not incremental-capable so
+// callers surface a conservative default rather than a misleading format.
+func summariseDiskFormat(disks []domainDisk) (format string, supportsIncremental bool) {
+	if len(disks) == 0 {
+		return "unknown", false
+	}
+	first := ""
+	uniform := true
+	for i, d := range disks {
+		f := d.Format
+		if f == "" {
+			f = backupDriverType(d.Path)
+		}
+		if i == 0 {
+			first = f
+		} else if f != first {
+			uniform = false
+		}
+	}
+	if !uniform {
+		return "mixed", false
+	}
+	return first, first == "qcow2"
 }
 
 // allDisksQcow2 reports whether every disk is qcow2-formatted, which gates

--- a/web/src/pages/Jobs.svelte
+++ b/web/src/pages/Jobs.svelte
@@ -395,6 +395,25 @@
     return ''
   }
 
+  // Reads the disk-format capability a VM item carries from discovery.
+  // supportsIncremental is only true when the backend positively detected
+  // qcow2 disks; a known non-qcow2 format ('raw'/'mixed') blocks incremental.
+  // Missing/'unknown' formats (legacy items, detection failures) do NOT block —
+  // the engine still downgrades to full safely.
+  function getVMDiskFormat(item) {
+    const settings = parseItemSettings(item)
+    const format = settings.disk_format || 'unknown'
+    const supportsIncremental = settings.supports_incremental === true
+    return {
+      format, // display only
+      supportsIncremental,
+      // Trust the backend's incremental-support decision; only skip the
+      // restriction when the format is genuinely unknown (legacy items or a
+      // detection failure) so we don't over-restrict a capable VM.
+      blocksIncremental: format !== 'unknown' && !supportsIncremental,
+    }
+  }
+
   function getContainerExclusionPaths(item) {
     const settings = parseItemSettings(item)
     return Array.isArray(settings.exclude_paths) ? settings.exclude_paths : []
@@ -779,6 +798,24 @@
   let selectedVMItems = $derived(form.items.filter(i => i.item_type === 'vm'))
   let selectedContainerItems = $derived(form.items.filter(i => i.item_type === 'container'))
   let vmRestoreVerifyErrors = $derived(selectedVMItems.map(getVMRestoreVerifyError).filter(Boolean))
+
+  // Selected VMs whose disks don't support libvirt checkpoints (raw/mixed), so
+  // incremental/differential backups aren't available for this job.
+  let incrementalBlockedVMs = $derived(
+    selectedVMItems.filter(vm => getVMDiskFormat(vm).blocksIncremental)
+  )
+  let vmDiskFormatRestriction = $derived(incrementalBlockedVMs.length > 0)
+  let incrementalBlockedSummary = $derived(
+    incrementalBlockedVMs.map(vm => `${vm.item_name} (${getVMDiskFormat(vm).format})`).join(', ')
+  )
+
+  // Coerce away an unavailable backup type when the selection only supports full
+  // (e.g. a raw-disk VM was just added while incremental was selected).
+  $effect(() => {
+    if (vmDiskFormatRestriction && form.backup_type_chain !== 'full') {
+      form.backup_type_chain = 'full'
+    }
+  })
 
   let containerPresets = $state({})
   // Advisory notes/warnings per container (e.g. the Immich database caveat),
@@ -1282,14 +1319,19 @@
             <select id="backup_type" bind:value={form.backup_type_chain}
               class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text">
               <option value="full">Full</option>
-              <option value="incremental">Incremental</option>
-              <option value="differential">Differential</option>
+              {#if !vmDiskFormatRestriction}
+                <option value="incremental">Incremental</option>
+                <option value="differential">Differential</option>
+              {/if}
             </select>
             <p class="text-xs text-text-dim mt-1">
               {form.backup_type_chain === 'full' ? 'Backs up everything every time. Largest but most reliable.' :
                form.backup_type_chain === 'incremental' ? 'Only backs up changes since last backup. Fastest and smallest.' :
                form.backup_type_chain === 'differential' ? 'Backs up changes since last full backup. Balance of speed and safety.' : ''}
             </p>
+            {#if vmDiskFormatRestriction}
+              <p class="text-xs text-warning mt-1">Incremental and differential backups require qcow2 disks. {incrementalBlockedSummary} don't, so only Full is available.</p>
+            {/if}
           </div>
           <div>
             <label for="compression" class="block text-sm font-medium text-text-muted mb-1.5">Compression</label>


### PR DESCRIPTION
## Summary

Vault now automatically detects whether each VM uses **raw** or **qcow2** disks at discovery time, and the job wizard only offers the backup types that VM actually supports. libvirt checkpoint-based **incremental/differential** backups require qcow2 disks — the engine already downgraded raw-disk VMs to full backups *silently*, and this surfaces that constraint up front (#163).

## Changes

**Backend** (`internal/engine/`)
- New pure helper `summariseDiskFormat(disks) (format, supportsIncremental)` in `vm_snapshot.go`, reusing the existing domain-XML disk parsing (`parseDomainDisksWithTargets`). Returns `qcow2`/`raw`/`mixed`/`unknown` and gates incremental support to qcow2-only.
- `VMHandler.ListItems()` reads each domain's persistent (inactive) XML and populates `BackupItem.Settings` with `disk_format` and `supports_incremental` (alongside `uuid`/`state`). Detection failures are logged and degrade to a conservative `unknown`/not-incremental result rather than failing the whole listing.

**Frontend** (`web/src/pages/Jobs.svelte`)
- The backup-type selector hides **Incremental** and **Differential** (and coerces the value back to **Full**) when any selected VM reports raw/mixed disks, with an inline note naming the affected VM(s). The restriction trusts the backend `supports_incremental` flag rather than re-deriving it, and leaves non-VM jobs unaffected.

**Docs**: `/vms` settings fields documented in `api.md`; `CHANGELOG` entry under `[Unreleased]`.

## Testing

- Added `TestSummariseDiskFormat` covering all-qcow2, all-raw, mixed, empty/skipped-only, and extension-fallback cases.
- `make build` (lint + tests + Svelte compile + linux cross-compile), `make deploy`, `make verify`: all pass.
- Verified against the **deployed** daemon that `GET /api/v1/vms` reports `disk_format`/`supports_incremental` for the host's real (qcow2) VMs.
- **Playwright on the deployed UI**, intercepting `/vms` to inject one raw and one qcow2 VM:
  - Raw VM selected → backup-type options = `["full"]`, value coerced to `full`, inline warning shown.
  - qcow2 VM selected → options = `["full","incremental","differential"]`, no warning.

## CodeRabbit review

Ran `coderabbit review` (5 findings) and applied the valid ones: accurate warning copy for mixed (not just raw) VMs, frontend restriction now relies on the backend `supports_incremental` flag, and detection failures are logged. Skipped two: the `unknown`-extension→`raw` label is pre-existing `backupDriverType` behaviour and display-only (the incremental gate is still correct), and removing the `_ = summariseDiskFormat` marker would trip the `unused` linter on non-Linux builds (it matches the file's established pattern).

## Note on mixed-format VMs

A libvirt/Unraid VM **can** have disks of different formats (e.g. one qcow2 + one raw). Since checkpoints require *all* disks to be qcow2, such a VM is reported as `mixed` / not incremental-capable and restricted to Full — same as an all-raw VM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VM backup jobs now detect disk format during discovery and show whether incremental backups are supported.
  * The backup wizard now hides unsupported incremental/differential options for VMs with non-`qcow2` or mixed disks.
  * When needed, jobs automatically default to a **Full** backup and show an inline warning naming the affected VM(s).

* **Documentation**
  * Updated the API docs and changelog to reflect the new VM disk-format and backup capability details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->