### PR TITLE
feat: guided disaster recovery — Recover Vault wizard (closes #220)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
       - name: Generate settings reference
         run: go run ./cmd/gendocs
       - uses: actions/setup-python@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,10 +133,10 @@ type Handler interface {
 ### SQLite Configuration
 
 ```go
-sql.Open("sqlite", path+"?_journal_mode=WAL&_busy_timeout=5000")
+sql.Open("sqlite", path+"?_txlock=immediate&_pragma=busy_timeout(30000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)&_pragma=journal_size_limit(67108864)")
 ```
 
-WAL mode for concurrent reads. Foreign keys enabled via PRAGMA. Schema applied inline at `Open()` time via `CREATE TABLE IF NOT EXISTS` (no migration versioning framework).
+WAL mode for concurrent reads. Foreign keys, busy timeout and WAL are set as DSN pragmas so every connection gets them (modernc.org/sqlite ignores the mattn-style \_journal_mode=/\_busy_timeout= keys). Schema applied inline at `Open()` time via `CREATE TABLE IF NOT EXISTS` (no migration versioning framework).
 
 ## Build Commands
 
@@ -177,6 +177,7 @@ Defaults: DB at `/boot/config/plugins/vault/vault.db`, API on port 24085.
 Both `rg` (ripgrep) and `ast-grep` are available. **Default to `rg` for most queries** (~5–20 ms on this repo, handles every file type, no parser surprises). Reach for `ast-grep` (~30–130 ms) only when you need AST-aware matching — typically a structural refactor or a pattern whose meaning depends on syntactic context.
 
 **Use `rg` for:**
+
 - Literal strings (log messages, error strings, URLs, JSON keys)
 - Definitions by name: `rg -n '^func .*FolderHandler.* Backup\b' --type go`
 - **Package-qualified call sites**: `rg -n 'runner\.New\(' --type go` — ast-grep returns zero matches for this; see Gotchas
@@ -185,12 +186,14 @@ Both `rg` (ripgrep) and `ast-grep` are available. **Default to `rg` for most que
 - Svelte files: `rg --type-add 'svelte:*.svelte' --type svelte 'pattern'` — **ast-grep does not support svelte** (0.42.3)
 
 **Use `ast-grep` for:**
+
 - Function definitions matching a structural shape: `ast-grep run -p 'func ($H *FolderHandler) Backup($$$ARGS) $$$RET { $$$BODY }' -l go`
 - All `fmt.Errorf(...)` calls without false-positive matches in strings/comments
 - Struct/interface declarations
 - Multi-clause queries via `ast-grep scan --rule rule.yml` (`has` / `inside` / `where`)
 
 **Verified gotchas:**
+
 - Package-qualified calls (`db.Open(...)`, `runner.New(...)`) return **zero** matches with the obvious pattern because the Go parser treats them as type conversions. Workaround: a YAML rule with `kind: call_expression`, or use `rg`.
 - Languages confirmed working: `go`, `ts`, `tsx`, `js`, `html`, `css`, `yaml`, `json`, `bash`, `python`, `rust`, `java`. **Not** `svelte` or `sh`.
 - Variadic metavariables must be **named** and usually preceded by a positional: `fmt.Errorf($FMT, $$$ARGS)`, not `fmt.Errorf($$$)`.
@@ -296,8 +299,8 @@ go test ./internal/db/... -run TestJobCreate -v  # Single test
 3. **Verify API:** Run `make verify` (endpoint checks + folder/VM smoke tests against Unraid). Fix any failures before proceeding.
 4. **Verify UI:** Use Playwright, browser MCP tools, or manual testing to navigate affected pages on `http://<unraid-server>:24085`. Take snapshots to confirm the UI renders correctly.
 5. **Update CHANGELOG.md (NON-NEGOTIABLE):** Add entries under `## [Unreleased]` using [Keep a Changelog](https://keepachangelog.com/) format. `CHANGELOG.md` is consumed by THREE systems: the in-app View Changelog modal (Settings → About Vault, parser at `internal/release/changelog.go`), the `release.yml` GitHub-release notes extractor, and operator-facing upgrade diffs — a missing or malformed entry breaks all three. Required format:
-   - Section headings (per version): `### Added`, `### Changed`, `### Fixed`, `### Removed`, `### Security` — any other `### ` heading is silently dropped.
-   - Bullets start with `- ` at column 0. Inline markdown that renders in the modal: `**bold**`, `` `code` ``, `*italic*`. Nothing else is interpreted.
+   - Section headings (per version): `### Added`, `### Changed`, `### Fixed`, `### Removed`, `### Security` — any other `###` heading is silently dropped.
+   - Bullets start with `-` at column 0. Inline markdown that renders in the modal: `**bold**`, `` `code` ``, `*italic*`. Nothing else is interpreted.
    - Be concise but descriptive — entries stand alone with no PR context. Reference issue numbers (e.g. `closes #123`) where applicable.
    - `[Unreleased]` is intentionally hidden from the modal. At release time, promote it to `## [vX.Y.Z] - YYYY-MM-DD` (heading must match the tag exactly) BEFORE pushing the `v*` tag.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,7 +300,7 @@ go test ./internal/db/... -run TestJobCreate -v  # Single test
 4. **Verify UI:** Use Playwright, browser MCP tools, or manual testing to navigate affected pages on `http://<unraid-server>:24085`. Take snapshots to confirm the UI renders correctly.
 5. **Update CHANGELOG.md (NON-NEGOTIABLE):** Add entries under `## [Unreleased]` using [Keep a Changelog](https://keepachangelog.com/) format. `CHANGELOG.md` is consumed by THREE systems: the in-app View Changelog modal (Settings → About Vault, parser at `internal/release/changelog.go`), the `release.yml` GitHub-release notes extractor, and operator-facing upgrade diffs — a missing or malformed entry breaks all three. Required format:
    - Section headings (per version): `### Added`, `### Changed`, `### Fixed`, `### Removed`, `### Security` — any other `###` heading is silently dropped.
-   - Bullets start with `-` at column 0. Inline markdown that renders in the modal: `**bold**`, `` `code` ``, `*italic*`. Nothing else is interpreted.
+   - Bullets start with `-` (dash + space) at column 0 — the parser only recognizes that exact prefix. Inline markdown that renders in the modal: `**bold**`, `` `code` ``, `*italic*`. Nothing else is interpreted.
    - Be concise but descriptive — entries stand alone with no PR context. Reference issue numbers (e.g. `closes #123`) where applicable.
    - `[Unreleased]` is intentionally hidden from the modal. At release time, promote it to `## [vX.Y.Z] - YYYY-MM-DD` (heading must match the tag exactly) BEFORE pushing the `v*` tag.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Path check after recovery**: `GET /api/v1/recovery/path-audit` flags folder and local-storage paths from the restored config that don't exist on this server, and `POST /api/v1/recovery/path-remap` updates them in place — the exact "my array and shares are different now" pain from #220.
 - **Disaster Recovery guide** in the docs — including why hand-copying `vault.db` to the flash drive doesn't work and what to do instead.
 
+### Fixed
+
+- **Vault's own database now reliably runs in WAL mode with a 30-second lock timeout.** The SQLite driver was silently ignoring the connection options that were meant to set these, so freshly created databases ran in rollback-journal mode with no busy timeout — slower under concurrent access and more prone to "database is locked" errors. All connection settings are now applied in a form the driver understands, and Vault logs a warning if WAL is unavailable on the filesystem.
+
 ### Changed
 
 - **License changed from MIT to AGPL-3.0.** Vault is now distributed under the GNU Affero General Public License v3.0 to keep derivative and network-served modifications open source.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Recover Vault wizard — guided disaster recovery after a server rebuild** (closes #220). A fresh install now offers a clear choice — **Set up Vault** or **Recover from a backup** — and the new five-step wizard walks you through reconnecting your backup storage, entering your backup password, restoring the Vault database (jobs, storage, history, settings), and fixing folder paths that changed on the rebuilt server. Also reachable any time from Recovery → **Recover Vault**.
+- **Database restore now works with encrypted backups.** `POST /api/v1/storage/{id}/restore-db` restores the encrypted `vault.db.latest.age` snapshots Vault writes by default (previously only a plaintext `vault.db` could be restored), verifies your backup password before touching anything (`verify_only`), re-seals the password with the new server's key so scheduled DB backups stay encrypted after recovery, and reloads the database in-process — **no daemon restart needed** after a restore.
+- `GET /api/v1/storage/{id}/db-backups` lists the database snapshots available on a destination (newest first, with the latest pointer flagged).
+- **Path check after recovery**: `GET /api/v1/recovery/path-audit` flags folder and local-storage paths from the restored config that don't exist on this server, and `POST /api/v1/recovery/path-remap` updates them in place — the exact "my array and shares are different now" pain from #220.
+- **Disaster Recovery guide** in the docs — including why hand-copying `vault.db` to the flash drive doesn't work and what to do instead.
+
 ### Changed
 
 - **License changed from MIT to AGPL-3.0.** Vault is now distributed under the GNU Affero General Public License v3.0 to keep derivative and network-served modifications open source.

--- a/docs/api.md
+++ b/docs/api.md
@@ -69,7 +69,8 @@ Loopback requests (`127.0.0.1` and `::1`) are always exempt from API key validat
 | POST   | `/storage/{id}/gc`             | Run mark-and-sweep GC on the destination's dedup repo                                                              |
 | POST   | `/storage/{id}/scan`           | Scan storage for importable backups                                                                                |
 | POST   | `/storage/{id}/import`         | Import backups discovered during scan (preserves dedup manifest IDs)                                               |
-| POST   | `/storage/{id}/restore-db`     | Restore the Vault database from a centralized backup at `_vault/vault.db`                                          |
+| GET    | `/storage/{id}/db-backups`     | List Vault database backups found under `_vault/` on the destination (newest first)                                |
+| POST   | `/storage/{id}/restore-db`     | Restore the Vault database from a `_vault/` backup — see body fields below                                         |
 | GET    | `/storage/{id}/jobs`           | Returns `{ jobs: [{id, name}], job_count: N }` — dependent-job list                                                |
 | GET    | `/storage/{id}/list`           | List files under a storage path                                                                                    |
 | GET    | `/storage/{id}/files`          | Download a file from storage                                                                                       |
@@ -140,9 +141,21 @@ Loopback requests (`127.0.0.1` and `::1`) are always exempt from API key validat
 
 ## Recovery
 
-| Method | Endpoint         | Description                                                                                                  |
-| ------ | ---------------- | ------------------------------------------------------------------------------------------------------------ |
-| GET    | `/recovery/plan` | Recovery plan with per-step item status; step downgrades to `warning` if any item is missing a restore point |
+| Method | Endpoint               | Description                                                                                                  |
+| ------ | ---------------------- | ------------------------------------------------------------------------------------------------------------ |
+| GET    | `/recovery/plan`       | Recovery plan with per-step item status; step downgrades to `warning` if any item is missing a restore point |
+| GET    | `/recovery/path-audit` | List job/item paths that don't exist on this server (used by the Recover Vault wizard's path check)          |
+| POST   | `/recovery/path-remap` | Rewrite audited paths to new locations (e.g. after a share or disk was renamed)                              |
+
+### Restoring the database (`restore-db`)
+
+`POST /storage/{id}/restore-db` takes a JSON body:
+
+- `storage_path` — path of the database backup on the destination, e.g. `_vault/vault.db.latest.age` (encrypted) or a timestamped copy like `_vault/vault.db.2026-07-01T02-00-00.age`. Unencrypted backups use the `.db` extension.
+- `passphrase` — the backup password; required when the backup is encrypted.
+- `verify_only` — when `true`, validates the backup (and passphrase) without replacing the current database.
+
+List the available backups first with `GET /storage/{id}/db-backups`.
 
 ## MCP (Model Context Protocol)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,13 +35,21 @@ CLI (Cobra) -> API Server (Chi + WebSocket Hub) -> Handlers -> DB / Storage / En
 ```go
 type Adapter interface {
     Write(path string, reader io.Reader) error
+    WriteFrom(path string, open func() (io.ReadCloser, error)) error
     Read(path string) (io.ReadCloser, error)
+    ReadRange(path string, offset, length int64) (io.ReadCloser, error)
     Delete(path string) error
     List(prefix string) ([]FileInfo, error)
     Stat(path string) (FileInfo, error)
     TestConnection() error
+    GetCapacity(ctx context.Context) (Capacity, error)
+    Usage() (free, total int64, err error)
 }
 ```
+
+`WriteFrom` lets the retry layer re-issue a failed upload from a fresh stream;
+`ReadRange` serves the dedup layer's partial pack reads; `GetCapacity` and
+`Usage` feed the capacity widgets and trajectory detector.
 
 Adapters that hold persistent resources (SFTP, SMB) implement `io.Closer` and
 are released by `storage.CloseAdapter`. Bandwidth throttling is layered on
@@ -52,8 +60,8 @@ constructed via `storage.NewAdapter(type, configJSON)`.
 
 ```go
 type Handler interface {
-    Backup(item BackupItem, dest string, progress ProgressFunc) (*BackupResult, error)
-    Restore(item BackupItem, source string, progress ProgressFunc) error
+    Backup(ctx context.Context, item BackupItem, dest string, progress ProgressFunc) (*BackupResult, error)
+    Restore(ctx context.Context, item BackupItem, source string, progress ProgressFunc) error
     ListItems() ([]BackupItem, error)
 }
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # Architecture
 
+This page is for developers and contributors — it describes Vault's internal design. If you just want to use Vault, start with [Getting Started](getting-started.md).
+
 Vault is a single Go binary that runs as a daemon on Unraid servers. It provides backup and restore for Docker containers, libvirt VMs, ZFS datasets, folders, and plugins.
 
 ## Layered Design

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,7 +72,7 @@ can route them through the dedup repo on dedup-enabled destinations.
 SQLite with WAL mode and busy timeout. Pure Go driver via `modernc.org/sqlite` (no CGO).
 
 ```go
-sql.Open("sqlite", path+"?_journal_mode=WAL&_busy_timeout=5000")
+sql.Open("sqlite", path+"?_txlock=immediate&_pragma=busy_timeout(30000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)&_pragma=journal_size_limit(67108864)")
 ```
 
 Schema is applied inline at open time via `CREATE TABLE IF NOT EXISTS` (no versioned migrations). Twelve tables: `storage_destinations`, `jobs`, `job_items`, `job_runs`, `restore_points`, `settings`, `activity_log`, `verify_runs`, `replication_sources`, `dedup_packs`, `dedup_chunks`, `dedup_gc_runs`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,29 @@
 # FAQ
 
+## Is Vault free?
+
+Yes. Vault is free and open source, licensed under AGPL-3.0. There are no paid tiers or locked features.
+
+## Where should my backups go?
+
+Keep at least one copy off the server itself — an SMB/NFS/SFTP share on another machine, or S3-compatible cloud storage. The Dashboard's 3-2-1 widget shows how close you are to the classic rule (3 copies, 2 media, 1 off-site). See [Storage Destinations](guides/storage-destinations.md).
+
+## Do I need the backup password to restore?
+
+Only if your backups are encrypted — they are whenever you set a password under Settings → Encryption (recommended). Keep the password somewhere off the server, like a password manager; without it, encrypted backups cannot be decrypted by anyone.
+
+## What happens if my server dies completely?
+
+You reinstall Unraid and the Vault plugin, then use the Recover Vault wizard to reconnect your backup storage and bring your settings and data back. Nothing from the old server is needed. The [Disaster Recovery guide](guides/disaster-recovery.md) walks through it step by step.
+
+## Does Vault back up Docker volumes?
+
+Yes. A container backup includes the container image, its XML template, and every mapped volume — including named volumes and appdata paths. You can exclude sub-paths per container (e.g. caches). See [Backup Jobs](guides/backup-jobs.md).
+
+## Can I run a job manually instead of on a schedule?
+
+Yes. Every job has a **Run Now** button, and you can leave the schedule empty to create a manual-only job that never runs on its own. See [Backup Jobs](guides/backup-jobs.md).
+
 <!-- prettier-ignore -->
 !!! note
     This page grows from questions asked on the Unraid forums. Have one that isn't answered here? Ask on the forum thread.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,7 +45,7 @@ The Dashboard shows a three-step welcome guide: add storage → create job → r
 Vault needs somewhere to write your backups before you can create any jobs.
 
 1. Go to **Storage** in the left sidebar
-2. Click **Add Destination**
+2. Click **Add Storage**
 3. Give it a name (e.g. "NAS Backups")
 4. Choose a type:
 
@@ -59,7 +59,7 @@ Vault needs somewhere to write your backups before you can create any jobs.
    | **S3**     | AWS S3 and S3-compatible object storage — Backblaze B2, MinIO, Cloudflare R2, Wasabi, MEGA |
 
 5. Fill in the connection details. See [Storage Destinations](guides/storage-destinations.md) for field-by-field guidance.
-6. Click **Test Connection** to verify Vault can reach the destination.
+6. Click **Test connection** to verify Vault can reach the destination.
 7. Click **Save**.
 
 ![Storage destinations page](screenshots/03-storage.png)
@@ -74,25 +74,25 @@ A job defines _what_ to back up, _where_ to put it, _when_ to run, and how many 
 2. Click **Create Job**
 3. Work through the wizard:
 
-   **Step 1 — Name & Type**
-
-   - Give the job a descriptive name (e.g. "Weekly Container Backup")
-   - Choose a backup type: **Full**, **Incremental**, or **Differential**
-
-   **Step 2 — Select Items**
+   **Step 1 — What**
 
    - Pick which Docker containers, VMs, ZFS datasets, folders, or plugins to include
    - Items are listed automatically from what Vault discovers on your server
    - For containers you can also list sub-paths to exclude (e.g. Plex transcode cache)
 
-   **Step 3 — Storage Destination**
+   **Step 2 — Where & when**
 
-   - Select the destination you created in step 3
+   - Select the storage destination you created earlier
+   - Set a schedule (hourly, daily, weekly, monthly, yearly, or custom cron) — or leave it empty for a manual-only job
 
-   **Step 4 — Schedule & Retention**
+   **Step 3 — How**
 
-   - Set a cron schedule (hourly, daily, weekly, monthly, yearly, or custom cron)
-   - Choose retention: either _keep last N restore points_ or a Long-Term Retention (LTR) policy that keeps a tunable number of daily / weekly / monthly / yearly snapshots
+   - Choose a backup type: **Full**, **Incremental**, or **Differential**
+   - Optionally adjust compression and advanced options like retention: either _keep last N restore points_ or a Long-Term Retention (LTR) policy that keeps a tunable number of daily / weekly / monthly / yearly snapshots
+
+   **Step 4 — Name & review**
+
+   - Give the job a descriptive name (e.g. "Weekly Container Backup")
 
 4. Review the summary and click **Save**.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,7 +149,9 @@ For a ready-to-use Home Assistant custom integration, see
 > **Disaster recovery:** Back up **both** `vault.db` and `vault.key` (siblings in
 > `/boot/config/plugins/vault/`). To rebuild a lost dedup index from intact storage,
 > run `vault dedup repair --dest <id>`. If you restored `vault.key` to a different
-> location, pass `--key /path/to/vault.key`.
+> location, pass `--key /path/to/vault.key`. For bringing Vault back after a lost
+> or rebuilt server — including why hand-copying `vault.db` to the flash drive
+> doesn't work — see the [Disaster Recovery guide](guides/disaster-recovery.md).
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -146,12 +146,14 @@ Each restore point also shows chain health annotations so you can see if a full 
 For a ready-to-use Home Assistant custom integration, see
 [ha-vault](https://github.com/ruaan-deysel/ha-vault).
 
-> **Disaster recovery:** Back up **both** `vault.db` and `vault.key` (siblings in
-> `/boot/config/plugins/vault/`). To rebuild a lost dedup index from intact storage,
-> run `vault dedup repair --dest <id>`. If you restored `vault.key` to a different
-> location, pass `--key /path/to/vault.key`. For bringing Vault back after a lost
-> or rebuilt server — including why hand-copying `vault.db` to the flash drive
-> doesn't work — see the [Disaster Recovery guide](guides/disaster-recovery.md).
+> **Disaster recovery:** Enable **Include in DB backup** on at least one storage
+> destination so your settings travel with your data (hand-copying `vault.db`
+> around is **not** a viable recovery path), and keep your backup password
+> somewhere safe off the server. To rebuild a lost dedup index from intact
+> storage, run `vault dedup repair --dest <id>`; if you restored `vault.key` to
+> a different location, pass `--key /path/to/vault.key`. For bringing Vault back
+> after a lost or rebuilt server, see the
+> [Disaster Recovery guide](guides/disaster-recovery.md).
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -143,17 +143,11 @@ Each restore point also shows chain health annotations so you can see if a full 
 | Use the REST API                                  | [API Reference](api.md)                                        |
 | Use the MCP server                                | [MCP](mcp.md)                                                  |
 
-For a ready-to-use Home Assistant custom integration, see
-[ha-vault](https://github.com/ruaan-deysel/ha-vault).
-
-> **Disaster recovery:** Enable **Include in DB backup** on at least one storage
-> destination so your settings travel with your data (hand-copying `vault.db`
-> around is **not** a viable recovery path), and keep your backup password
-> somewhere safe off the server. To rebuild a lost dedup index from intact
-> storage, run `vault dedup repair --dest <id>`; if you restored `vault.key` to
-> a different location, pass `--key /path/to/vault.key`. For bringing Vault back
-> after a lost or rebuilt server, see the
-> [Disaster Recovery guide](guides/disaster-recovery.md).
+> **Prepare for disaster now:** Enable **Include in DB backup** on at least one
+> storage destination so your Vault settings travel with your data, and keep
+> your backup password somewhere safe off the server. If you ever lose the
+> server, the [Disaster Recovery guide](guides/disaster-recovery.md) walks you
+> through bringing everything back.
 
 ---
 

--- a/docs/guides/backup-jobs.md
+++ b/docs/guides/backup-jobs.md
@@ -39,18 +39,18 @@ Pick which items to include in this job. Vault discovers items automatically fro
 | **Folders**          | Any arbitrary path on your server (e.g. `/mnt/user/appdata`, `/boot/config`)                         |
 | **Plugins**          | Installed Unraid plugins                                                                             |
 
-**Notes on containers:**
+#### Notes on containers
 
 - Vault backs up the container image, its XML template, and all host paths mapped into the container.
 - Special files (Unix sockets, device nodes, named pipes) are skipped automatically — they cannot be archived and their presence does not fail the backup.
 - Tailscale-enabled containers are fully supported.
 - Bind-mounts that point at the host root (`/` → `/rootfs`, used by Glances, Telegraf, Netdata, cAdvisor, node-exporter) are detected and skipped without walking the host filesystem.
 
-**Excluding container sub-paths:**
+#### Excluding container sub-paths
 
 You can list paths to exclude from a container backup (e.g. `/config/Library/Application Support/Plex Media Server/Cache` or `/config/Sonarr/MediaCover`). The job wizard exposes a free-text list per container, and Vault ships a `GET /api/v1/presets/exclusions` catalogue of common rules for popular containers (Plex, Sonarr, Radarr, etc.) the UI offers as starting points. For some apps the response also carries advisory `notes`/`warnings` (e.g. the Immich database caveat below), which the wizard shows inline.
 
-**Backing up Immich:**
+#### Backing up Immich
 
 Immich detection works for both the official `ghcr.io/immich-app/immich-server` image (media root mounted at `/data`) and the imagegenius fork `ghcr.io/imagegenius/immich` (`/photos`). The recommended exclusions cover both layouts:
 
@@ -67,13 +67,13 @@ Thumbnails and re-encoded video are re-created by Immich on demand after a resto
 2. **Back up the Postgres container as its own Vault job.** Add the Immich Postgres container to a separate job; Vault stops it before archiving, giving a consistent copy of its data directory.
 3. **Dump via a pre-backup script.** Vault runs a job's **Pre-backup script** before stopping any containers, with `VAULT_JOB_NAME`, `VAULT_STATUS`, `VAULT_JOB_ID`, and `VAULT_RUN_ID` exported into its environment. A script can `docker exec` a `pg_dump` into the media root before the backup runs.
 
-**Notes on ZFS datasets:**
+#### Notes on ZFS datasets
 
 - Vault uses `zfs send` (full) and `zfs send -i` (incremental) under the hood and manages the snapshot lifecycle itself.
 - Restoration goes through `zfs receive`, preserving properties and child datasets.
 - The host `zfs` binary must be on `PATH` — true on any Unraid system with a ZFS pool.
 
-**Notes on folders:**
+#### Notes on folders
 
 - You can back up `/mnt/user/appdata` to get all container appdata in one shot without selecting individual containers.
 - Folder backups only wake the destination disk when writing — the source array is read sequentially.
@@ -109,7 +109,7 @@ The schedule UI uses your Unraid time format setting (12-hour or 24-hour) automa
 
 #### Retention
 
-Retention controls how many restore points are kept before the oldest is deleted. Vault supports two modes; you can use either or both at once.
+Retention controls how many restore points are kept before the oldest is deleted. (A _restore point_ is one completed backup you can restore from.) Vault supports two modes; you can use either or both at once.
 
 **Mode 1 — Simple count**
 
@@ -230,6 +230,8 @@ The encryption status is shown on the Dashboard's 3-2-1 compliance widget, and o
 
 ## Deduplication
 
+Deduplication stores each unique piece of data only once, so repeated data across runs and sources doesn't cost extra space — see [How Backup Works](../how-backup-works.md#deduplication) for the concept. The rest of this section covers the operational details.
+
 When you enable _Dedup_ on a storage destination, Vault chunks every backup with Keyed-FastCDC (256 KiB / 1 MiB / 4 MiB min/avg/max) and stores only one copy of each chunk in a per-destination dedup repo at `<dest>/_vault/packs/` and `<dest>/_vault/index/`. The repo's chunker is keyed off a 32-byte secret per destination, which closes the fingerprinting-attack class described in Truong et al. 2025 — observers without the secret can't recompute chunk boundaries from public corpora.
 
 Operational notes:
@@ -241,3 +243,11 @@ Operational notes:
 - Dedup-mode and non-dedup destinations can coexist on the same Vault install; the flag is per-destination and immutable after creation.
 
 Imported backups (Storage → _Scan_ + _Import_) carry per-item dedup manifest IDs in their `manifest.json`, so dedup restore points produced on one Vault instance can be re-discovered and restored on another.
+
+---
+
+## Next steps
+
+- Point your job at the right target: [Storage Destinations](storage-destinations.md)
+- Let Vault warn you when backups drift from normal: [Anomaly Detection](anomaly-detection.md)
+- Make sure you can recover if the server dies: [Disaster Recovery](disaster-recovery.md)

--- a/docs/guides/backup-jobs.md
+++ b/docs/guides/backup-jobs.md
@@ -8,26 +8,7 @@ Go to **Jobs** → **Create Job**. The wizard has four steps.
 
 ---
 
-### Step 1 — Name & Type
-
-| Field           | Description                                                                     |
-| --------------- | ------------------------------------------------------------------------------- |
-| **Name**        | A unique name for this job. Shown on the Dashboard, History, and Restore pages. |
-| **Backup Type** | The backup strategy: Full, Incremental, or Differential (see below).            |
-
-#### Backup Types
-
-| Type             | What it backs up                          | Restore speed                        | Storage use                   |
-| ---------------- | ----------------------------------------- | ------------------------------------ | ----------------------------- |
-| **Full**         | Everything, every run                     | Fastest — single archive             | Highest — full copy each time |
-| **Incremental**  | Changes since the last backup of any type | Slowest — may need to chain archives | Lowest                        |
-| **Differential** | Changes since the last _full_ backup      | Medium — needs full + one diff       | Medium                        |
-
-For most home server use cases, a weekly **Full** backup with daily **Incremental** runs gives a good balance between storage cost and restore speed.
-
----
-
-### Step 2 — Select Items
+### Step 1 — What
 
 Pick which items to include in this job. Vault discovers items automatically from your server:
 
@@ -80,13 +61,9 @@ Thumbnails and re-encoded video are re-created by Immich on demand after a resto
 
 ---
 
-### Step 3 — Storage Destination
+### Step 2 — Where & when
 
-Select which storage destination this job will write to. If you have not added one yet, save the wizard and go to **Storage** first — see [Storage Destinations](storage-destinations.md).
-
----
-
-### Step 4 — Schedule & Retention
+Select which storage destination this job will write to. If you have not added one yet, save the wizard and go to **Storage** first — see [Storage Destinations](storage-destinations.md). This step also sets the schedule.
 
 #### Schedule
 
@@ -105,11 +82,27 @@ Instead of a fixed day number, you can choose _First day of month_ or _Last day 
 **Time format:**
 The schedule UI uses your Unraid time format setting (12-hour or 24-hour) automatically.
 
-> **Unscheduled / manual-only jobs:** Currently all jobs require a schedule. To run a backup ad hoc, use the **Run Now** button. A dedicated "no schedule" option is planned.
+> **Manual-only jobs:** Leave the schedule empty to create a job that never runs on its own — you run it on demand with the **Run Now** button.
+
+---
+
+### Step 3 — How
+
+Choose the backup strategy and, under _Advanced options_, tune compression, retention, verification, and scripts.
+
+#### Backup Types
+
+| Type             | What it backs up                          | Restore speed                        | Storage use                   |
+| ---------------- | ----------------------------------------- | ------------------------------------ | ----------------------------- |
+| **Full**         | Everything, every run                     | Fastest — single archive             | Highest — full copy each time |
+| **Incremental**  | Changes since the last backup of any type | Slowest — may need to chain archives | Lowest                        |
+| **Differential** | Changes since the last _full_ backup      | Medium — needs full + one diff       | Medium                        |
+
+For most home server use cases, a weekly **Full** backup with daily **Incremental** runs gives a good balance between storage cost and restore speed.
 
 #### Retention
 
-Retention controls how many restore points are kept before the oldest is deleted. (A _restore point_ is one completed backup you can restore from.) Vault supports two modes; you can use either or both at once.
+Retention controls how many restore points are kept before the oldest is deleted. (A _restore point_ is one completed backup you can restore from.) Vault supports two modes. If any Long-Term Retention value is set, LTR is used and the simple settings are ignored.
 
 **Mode 1 — Simple count**
 
@@ -131,13 +124,23 @@ Good for "always keep my last 7 backups" type policies.
 
 Long-Term Retention (LTR) lets you keep, say, "last 7 days + last 4 weeks + last 6 months + last 3 years" without paying for hundreds of restore points. The Job UI shows a _retention preview_ — exactly which restore points the policy would prune on the next run — before you save.
 
-If you leave the LTR counters at 0 and set only _Keep last N_, classic simple-count retention applies. If any LTR counter is greater than 0, Vault uses LTR for that job and ignores the simple _Keep last N_ count.
+If you leave all LTR counters at 0, classic simple retention applies. If any LTR counter is greater than 0, Vault uses LTR for that job and ignores the simple settings (_Keep last N_ and _keep-for-N-days_).
 
 Set retention based on storage budget and how far back you want to be able to restore:
 
 - 7 daily backups → simple count = 7
 - A weekly full + 6 daily incrementals → simple count = 7, two jobs (one weekly full, one daily incremental)
 - Year of history without storage bloat → LTR with `keep_daily=7`, `keep_weekly=4`, `keep_monthly=12`, `keep_yearly=3`
+
+---
+
+### Step 4 — Name & review
+
+| Field    | Description                                                                     |
+| -------- | ------------------------------------------------------------------------------- |
+| **Name** | A unique name for this job. Shown on the Dashboard, History, and Restore pages. |
+
+Check the plain-language summary of what the job will do, then click **Save**.
 
 ---
 
@@ -171,10 +174,9 @@ To stop an in-progress backup:
 
 Vault signals cancellation through the entire pipeline — file I/O, directory traversal, and engine handlers all check for cancellation and stop gracefully. The job is marked as "cancelled" in History.
 
-Jobs also have automatic safeguards:
+Jobs also have an automatic safeguard:
 
-- **4-hour hard timeout** — a job running longer than 4 hours is automatically cancelled
-- **2-hour stall detection** — a job with no progress for 2 hours is cancelled (with a warning at 30 minutes)
+- **2-hour stall detection** — a job with no progress for 2 hours is cancelled (with a warning at 30 minutes). There is no overall time limit: a backup that is still transferring data can run for as long as it needs.
 
 ---
 
@@ -222,7 +224,7 @@ Both paths use the same code, so per-run and on-demand results are directly comp
 
 ## Encryption
 
-If you set a passphrase under **Settings → Security → Encryption**, all backup archives are encrypted with AES-256-GCM before they leave the host. The encryption key is derived from your passphrase and a per-installation salt; without the passphrase, restoring is not possible. Encryption is transparent to storage destinations — it applies equally to local, SFTP, SMB, NFS, WebDAV, and S3.
+If you set a passphrase under **Settings → Security → Encryption**, all backup archives are encrypted with your backup password (age encryption — a modern, audited standard) before they leave the host. Without the passphrase, restoring is not possible. Encryption is transparent to storage destinations — it applies equally to local, SFTP, SMB, NFS, WebDAV, and S3.
 
 The encryption status is shown on the Dashboard's 3-2-1 compliance widget, and on each restore point's chain-health badge.
 

--- a/docs/guides/disaster-recovery.md
+++ b/docs/guides/disaster-recovery.md
@@ -11,8 +11,9 @@ a failed boot drive, a rebuilt array, or a full Unraid reinstall.
    and restore your settings.
 4. Fix any folder paths that changed, then restore your data from the Restore page.
 
-You need two things: **access to your backup storage** and **your backup
-password** (the encryption password from Settings → Encryption). Nothing from
+You always need **access to your backup storage**. You also need **your
+backup password**, but only if your backups are encrypted — they are whenever
+you set a password under Settings → Encryption (recommended). Nothing from
 the old server is required.
 
 ---
@@ -32,10 +33,12 @@ the `restore-db` API), which validates the backup and swaps it in atomically.
 
 ## Recovering with the wizard
 
-On a fresh install, Vault has no jobs, no storage destinations, and no
-history — that empty state is what triggers the wizard. Open the **Recovery**
-page and click **Recover Vault** (or choose **Recover from a backup** on first
-run) to start it. The wizard has five steps.
+Open the **Recovery** page and click **Recover Vault** (or choose **Recover
+from a backup** on first run) to start the wizard. It is available any time —
+not just on a fresh install. Keep in mind that restoring **replaces** the
+jobs and storage destinations currently on this Vault; on a configured system
+the wizard warns you with the exact counts before it does anything. The
+wizard has five steps.
 
 <!-- screenshot: step-1 -->
 
@@ -63,7 +66,8 @@ were never encrypted, this step is skipped automatically.
 
 The most recent backup is preselected from a list showing each snapshot's
 date. Confirm to proceed. The wizard states explicitly that this replaces the
-current (empty) settings on the new install — your jobs, storage
+settings currently on this Vault — on a configured system it shows how many
+jobs and storage destinations will be replaced. Your jobs, storage
 destinations, and history come back from the snapshot. Nothing on your backup
 storage is read or modified beyond downloading the database file: your actual
 container, VM, and folder archives are untouched.

--- a/docs/guides/disaster-recovery.md
+++ b/docs/guides/disaster-recovery.md
@@ -115,17 +115,17 @@ API from any machine that can reach the daemon:
 
 ```sh
 read -rs VAULT_BACKUP_PASSWORD   # prompts without echoing or recording history
+jq -n --arg p "$VAULT_BACKUP_PASSWORD" \
+  '{storage_path: "_vault/vault.db.latest.age", passphrase: $p}' |
 curl -X POST http://SERVER:24085/api/v1/storage/ID/restore-db \
-  -H 'Content-Type: application/json' \
-  -d @- <<EOF
-{"storage_path": "_vault/vault.db.latest.age", "passphrase": "$VAULT_BACKUP_PASSWORD"}
-EOF
+  -H 'Content-Type: application/json' -d @-
 unset VAULT_BACKUP_PASSWORD
 ```
 
 `read -rs` prompts for the password without echoing it and keeps it out of
-your shell history and the process list (a JSON file with `-d @restore.json`
-works too).
+your shell history and the process list; `jq` (included with Unraid) encodes
+it safely even if it contains quotes or backslashes. A JSON file with
+`-d @restore.json` works too.
 
 List available snapshots first with `GET /api/v1/storage/ID/db-backups`.
 

--- a/docs/guides/disaster-recovery.md
+++ b/docs/guides/disaster-recovery.md
@@ -1,0 +1,127 @@
+# Disaster Recovery
+
+This guide covers bringing Vault back after you lose the server it ran on —
+a failed boot drive, a rebuilt array, or a full Unraid reinstall.
+
+## The short version
+
+1. Reinstall Unraid and the Vault plugin.
+2. Open Vault and choose **Recover from a backup** (or Recovery → **Recover Vault**).
+3. Reconnect the storage that holds your backups, enter your backup password,
+   and restore your settings.
+4. Fix any folder paths that changed, then restore your data from the Restore page.
+
+You need two things: **access to your backup storage** and **your backup
+password** (the encryption password from Settings → Encryption). Nothing from
+the old server is required.
+
+---
+
+## Why copying vault.db to the flash drive doesn't work
+
+Vault's database doesn't live where you might expect. At runtime the working
+copy is in memory-backed storage, and at every boot Vault restores it from its
+own snapshot chain (cache-pool snapshot, rotated copies, USB shadow copy). A
+`vault.db` you place on the boot flash by hand is overwritten by that chain
+before Vault ever reads it.
+
+The supported way to bring settings back is the **Recover Vault** wizard (or
+the `restore-db` API), which validates the backup and swaps it in atomically.
+
+---
+
+## Recovering with the wizard
+
+On a fresh install, Vault has no jobs, no storage destinations, and no
+history — that empty state is what triggers the wizard. Open the **Recovery**
+page and click **Recover Vault** (or choose **Recover from a backup** on first
+run) to start it. The wizard has five steps.
+
+<!-- screenshot: step-1 -->
+
+### Step 1 — Connect storage
+
+Add the storage destination that holds your backups — the same host, share,
+or bucket you were writing to before — and click **Test Connection**. Once
+the connection succeeds, the wizard looks for a `_vault` folder on that
+destination and lists the database backups it finds there, newest first.
+
+<!-- screenshot: step-2 -->
+
+### Step 2 — Backup password
+
+If your database backups are encrypted, enter the passphrase from
+**Settings → Encryption** on your old server. Vault verifies the password
+before touching anything — a wrong password shows a friendly error and lets
+you try again rather than failing partway through a restore. If your backups
+were never encrypted, this step is skipped automatically.
+
+<!-- screenshot: step-3 -->
+
+### Step 3 — Restore
+
+The most recent backup is preselected from a list showing each snapshot's
+date. Confirm to proceed. The wizard states explicitly that this replaces the
+current (empty) settings on the new install — your jobs, storage
+destinations, and history come back from the snapshot. Nothing on your backup
+storage is read or modified beyond downloading the database file: your actual
+container, VM, and folder archives are untouched.
+
+<!-- screenshot: step-4 -->
+
+### Step 4 — Check paths
+
+Restored jobs and folder items may reference paths that don't exist on the
+rebuilt server — a share renamed during the rebuild, a disk assigned to a
+different mount point. This step flags any path that isn't found and offers
+a remap field with suggested mounts from the current server. It's skippable
+if you'd rather fix paths later from the Jobs or Storage pages.
+
+<!-- screenshot: step-5 -->
+
+### Step 5 — Done
+
+A summary of what was restored (jobs, storage destinations, restore point
+count) closes out the wizard, with a pointer to the normal **Restore** page
+to bring your actual data — container appdata, VM disks, folders — back from
+the restore points that came with the database.
+
+---
+
+## Prepare before disaster strikes
+
+- **Store your backup password off the server** — password manager, printed
+  note, anywhere that survives the server. Without it, encrypted backups
+  cannot be decrypted by anyone, including you.
+- **Enable database backup on at least one destination** (Storage →
+  destination → **Include in DB backup**). This writes your settings
+  alongside your data after every successful backup.
+- **Keep one destination off-box** (SMB/NFS/SFTP/S3) so a dead server doesn't
+  take your backups with it.
+- Optionally note your storage connection details (host, share, username)
+  somewhere safe — recovery starts by reconnecting to storage.
+
+---
+
+## Recovering without the web UI (CLI fallback)
+
+If you cannot reach the web console, you can restore the database over the
+API from any machine that can reach the daemon:
+
+```
+curl -X POST http://SERVER:24085/api/v1/storage/ID/restore-db \
+  -H 'Content-Type: application/json' \
+  -d '{"storage_path": "_vault/vault.db.latest.age", "passphrase": "YOUR-BACKUP-PASSWORD"}'
+```
+
+List available snapshots first with `GET /api/v1/storage/ID/db-backups`.
+
+---
+
+## After recovery
+
+- Run the path check (wizard step 4, or review Jobs/Storage) if your array or
+  share layout changed.
+- Restore data via **Restore** as usual.
+- Re-check Settings → Encryption and consider a fresh test backup to confirm
+  the pipeline end to end.

--- a/docs/guides/disaster-recovery.md
+++ b/docs/guides/disaster-recovery.md
@@ -42,8 +42,9 @@ run) to start it. The wizard has five steps.
 ### Step 1 — Connect storage
 
 Add the storage destination that holds your backups — the same host, share,
-or bucket you were writing to before — and click **Test Connection**. Once
-the connection succeeds, the wizard looks for a `_vault` folder on that
+or bucket you were writing to before — and click **Connect**. You can
+optionally click **Test connection** first to check the details before
+saving. Once you connect, the wizard looks for a `_vault` folder on that
 destination and lists the database backups it finds there, newest first.
 
 <!-- screenshot: step-2 -->
@@ -81,8 +82,8 @@ if you'd rather fix paths later from the Jobs or Storage pages.
 
 ### Step 5 — Done
 
-A summary of what was restored (jobs, storage destinations, restore point
-count) closes out the wizard, with a pointer to the normal **Restore** page
+A summary of what was restored (jobs and storage destinations) closes out
+the wizard, with a pointer to the normal **Restore** page
 to bring your actual data — container appdata, VM disks, folders — back from
 the restore points that came with the database.
 
@@ -115,6 +116,9 @@ curl -X POST http://SERVER:24085/api/v1/storage/ID/restore-db \
 ```
 
 List available snapshots first with `GET /api/v1/storage/ID/db-backups`.
+
+If an API key is configured and you are calling from a non-loopback address,
+include it with `-H 'X-API-Key: YOUR-KEY'`.
 
 ---
 

--- a/docs/guides/disaster-recovery.md
+++ b/docs/guides/disaster-recovery.md
@@ -110,15 +110,21 @@ If you cannot reach the web console, you can restore the database over the
 API from any machine that can reach the daemon:
 
 ```
+export VAULT_BACKUP_PASSWORD='your backup password'   # or read it from a file
 curl -X POST http://SERVER:24085/api/v1/storage/ID/restore-db \
   -H 'Content-Type: application/json' \
-  -d '{"storage_path": "_vault/vault.db.latest.age", "passphrase": "YOUR-BACKUP-PASSWORD"}'
+  -d @- <<EOF
+{"storage_path": "_vault/vault.db.latest.age", "passphrase": "$VAULT_BACKUP_PASSWORD"}
+EOF
 ```
+
+Passing the passphrase via an environment variable (or a JSON file with
+`-d @restore.json`) keeps it out of your shell history and the process list.
 
 List available snapshots first with `GET /api/v1/storage/ID/db-backups`.
 
 If an API key is configured and you are calling from a non-loopback address,
-include it with `-H 'X-API-Key: YOUR-KEY'`.
+include it with `-H "X-API-Key: $VAULT_API_KEY"`.
 
 ---
 

--- a/docs/guides/disaster-recovery.md
+++ b/docs/guides/disaster-recovery.md
@@ -109,17 +109,19 @@ the restore points that came with the database.
 If you cannot reach the web console, you can restore the database over the
 API from any machine that can reach the daemon:
 
-```
-export VAULT_BACKUP_PASSWORD='your backup password'   # or read it from a file
+```sh
+read -rs VAULT_BACKUP_PASSWORD   # prompts without echoing or recording history
 curl -X POST http://SERVER:24085/api/v1/storage/ID/restore-db \
   -H 'Content-Type: application/json' \
   -d @- <<EOF
 {"storage_path": "_vault/vault.db.latest.age", "passphrase": "$VAULT_BACKUP_PASSWORD"}
 EOF
+unset VAULT_BACKUP_PASSWORD
 ```
 
-Passing the passphrase via an environment variable (or a JSON file with
-`-d @restore.json`) keeps it out of your shell history and the process list.
+`read -rs` prompts for the password without echoing it and keeps it out of
+your shell history and the process list (a JSON file with `-d @restore.json`
+works too).
 
 List available snapshots first with `GET /api/v1/storage/ID/db-backups`.
 

--- a/docs/guides/storage-destinations.md
+++ b/docs/guides/storage-destinations.md
@@ -160,20 +160,21 @@ Vault writes to:    /mnt/user/backups/vault/my-server
 
 - Vault uses the AWS SDK v2's reusable client, which pools HTTP connections internally — a single S3 destination can sustain many concurrent uploads.
 - Server-side encryption is your provider's responsibility. Vault's own encryption (Settings → Security) layers on top and protects backups even from the storage operator.
-- **"Test Connection succeeds but every upload fails with `SignatureDoesNotMatch`"** — a known quirk of many S3-compatible providers (MEGA, Backblaze B2, IDrive E2, older MinIO), and Vault handles it for you automatically whenever a custom **Endpoint** is set. Background: recent AWS SDK versions add a checksum trailer to every upload that these providers don't understand, so they reject the request; the connection test passes because it sends no data. With a custom endpoint Vault omits the trailer (real AWS S3 keeps it), and Vault's own SHA-256 verification still guarantees backup integrity either way. If you see this error anyway, double-check the Endpoint URL and region.
+- **"Test connection succeeds but every upload fails with `SignatureDoesNotMatch`"** — a known quirk of many S3-compatible providers (MEGA, Backblaze B2, IDrive E2, older MinIO), and Vault handles it for you automatically whenever a custom **Endpoint** is set. Background: recent AWS SDK versions add a checksum trailer to every upload that these providers don't understand, so they reject the request; the connection test passes because it sends no data. With a custom endpoint Vault omits the trailer (real AWS S3 keeps it), and Vault's own SHA-256 verification still guarantees backup integrity either way. If you see this error anyway, double-check the Endpoint URL and region.
 - **Sizing Part size** — the S3 protocol caps a multipart upload at 10,000 parts, so the maximum object Vault can upload is `part_size × 10,000`. Default 64 MiB → 640 GB ceiling, which fits typical home-server workloads. For Immich libraries, full-disk images, or other multi-TB datasets, raise the value: 256 → 2.5 TB, 512 → 5 TB, 1024 → 10 TB. Peak upload memory ≈ `part_size × concurrency` (default 5), so 1 GiB parts cost ~5 GiB RAM during an active upload. Backblaze B2, MinIO, AWS S3, Cloudflare R2, and Wasabi all accept parts in the 5 MiB – 5 GiB range.
 
 ---
 
 ## Testing a Connection
 
-After filling in the fields, always click **Test Connection** before saving. Vault will:
+After filling in the fields, always click **Test connection** before saving. What the test checks depends on the destination type:
 
-1. Attempt to connect using the provided credentials
-2. Try to create and delete a temporary test file in the configured path
-3. Report success or a specific error (wrong password, path not found, permission denied, etc.)
+- **All types** — the destination is reachable and the credentials work.
+- **Local, SFTP, NFS, WebDAV** — Vault also writes and deletes a small test file, so write access is confirmed.
+- **S3** — Vault only checks that the bucket exists and is accessible (no data is written).
+- **SMB** — Vault only lists the configured directory (no data is written).
 
-If the test fails, fix the error before saving — the destination will not work for backups until the connection succeeds.
+On failure you get a specific error (wrong password, path not found, permission denied, etc.) — fix it before saving. Note that on S3 and SMB a passing test can still be followed by an upload failure if the bucket or share is read-only, because the test does not write any data there.
 
 ---
 
@@ -193,7 +194,7 @@ Imported backups appear as restore points on the relevant jobs so you can restor
 
 ## Encryption
 
-If you have configured an encryption passphrase under **Settings → Security → Encryption**, all backup archives written to storage are encrypted with AES-256-GCM before they leave the server. The encryption key is derived from your passphrase — make sure to keep it safe, as there is no recovery path if it is lost.
+If you have configured an encryption passphrase under **Settings → Security → Encryption**, all backup archives written to storage are encrypted with your backup password (age encryption — a modern, audited standard) before they leave the server. Make sure to keep the password safe, as there is no recovery path if it is lost.
 
 Encryption is transparent to storage destinations — it applies regardless of destination type.
 

--- a/docs/guides/storage-destinations.md
+++ b/docs/guides/storage-destinations.md
@@ -144,7 +144,7 @@ Vault writes to:    /mnt/user/backups/vault/my-server
 | **Base Path**                   | Optional key prefix prepended to every object Vault writes.                                                                                                                                                            |
 | **Force path-style addressing** | Enable for older S3-compatible servers (e.g. older MinIO) that don't support virtual-hosted-style buckets. AWS S3 does not need this.                                                                                  |
 | **Upload timeout (minutes)**    | Optional. Hard ceiling on a single object upload (including multipart transfers). Default `0` = 240 (4 hours). Raise for very large files over slow links.                                                             |
-| **Part size (MiB)**             | Optional. Multipart part size used for uploads. S3 caps the number of parts at 10,000 so this directly sets the per-object ceiling (`part_size × 10,000`). Default `0` = 64 MiB → 640 GB ceiling. Range 5–5120 MiB.   |
+| **Part size (MiB)**             | Optional. Multipart part size used for uploads. S3 caps the number of parts at 10,000 so this directly sets the per-object ceiling (`part_size × 10,000`). Default `0` = 64 MiB → 640 GB ceiling. Range 5–5120 MiB.    |
 
 **Provider notes:**
 
@@ -160,7 +160,7 @@ Vault writes to:    /mnt/user/backups/vault/my-server
 
 - Vault uses the AWS SDK v2's reusable client, which pools HTTP connections internally — a single S3 destination can sustain many concurrent uploads.
 - Server-side encryption is your provider's responsibility. Vault's own encryption (Settings → Security) layers on top and protects backups even from the storage operator.
-- **Custom endpoints and the AWS SDK flexible-checksum trailer** — Since AWS SDK Go v2 v1.32, every `PutObject` and `UploadPart` is signed with an `x-amz-checksum-crc32` trailer header. AWS S3 includes that trailer in the SigV4 canonical request; most S3-compatible gateways (MEGA, Backblaze B2, IDrive E2, older MinIO builds) do not, so they recompute the signature without it and respond `403 SignatureDoesNotMatch`. The most common symptom is "Test Connection succeeds but every upload fails", because the test path (`HeadBucket`) has no body and no trailer. Vault now automatically dials back the checksum behaviour to `WhenRequired` whenever a custom **Endpoint** is configured — real AWS keeps the trailer for end-to-end integrity, S3-compat services get a clean request and accept the PUT. Vault's own SHA-256 verification in the runner (`verify_backup`) continues to guarantee object integrity end-to-end regardless of whether the trailer is sent.
+- **"Test Connection succeeds but every upload fails with `SignatureDoesNotMatch`"** — a known quirk of many S3-compatible providers (MEGA, Backblaze B2, IDrive E2, older MinIO), and Vault handles it for you automatically whenever a custom **Endpoint** is set. Background: recent AWS SDK versions add a checksum trailer to every upload that these providers don't understand, so they reject the request; the connection test passes because it sends no data. With a custom endpoint Vault omits the trailer (real AWS S3 keeps it), and Vault's own SHA-256 verification still guarantees backup integrity either way. If you see this error anyway, double-check the Endpoint URL and region.
 - **Sizing Part size** — the S3 protocol caps a multipart upload at 10,000 parts, so the maximum object Vault can upload is `part_size × 10,000`. Default 64 MiB → 640 GB ceiling, which fits typical home-server workloads. For Immich libraries, full-disk images, or other multi-TB datasets, raise the value: 256 → 2.5 TB, 512 → 5 TB, 1024 → 10 TB. Peak upload memory ≈ `part_size × concurrency` (default 5), so 1 GiB parts cost ~5 GiB RAM during an active upload. Backblaze B2, MinIO, AWS S3, Cloudflare R2, and Wasabi all accept parts in the 5 MiB – 5 GiB range.
 
 ---
@@ -196,3 +196,10 @@ Imported backups appear as restore points on the relevant jobs so you can restor
 If you have configured an encryption passphrase under **Settings → Security → Encryption**, all backup archives written to storage are encrypted with AES-256-GCM before they leave the server. The encryption key is derived from your passphrase — make sure to keep it safe, as there is no recovery path if it is lost.
 
 Encryption is transparent to storage destinations — it applies regardless of destination type.
+
+---
+
+## Next steps
+
+- Create a job that writes to your new destination: [Backup Jobs](backup-jobs.md)
+- Keep a copy of your settings with your data for recovery: [Disaster Recovery](disaster-recovery.md)

--- a/docs/how-backup-works.md
+++ b/docs/how-backup-works.md
@@ -34,7 +34,7 @@ For the exact retention fields on a job, see the [Job Configuration reference](r
 
 ## Encryption
 
-Backups can be encrypted with **AES-256-GCM**, using a key derived from your passphrase. Encryption is applied to the backup content so that data at rest on the destination cannot be read without the passphrase.
+Backups can be encrypted with your backup password using **age** encryption — a modern, audited standard. Encryption is applied to the backup content so that data at rest on the destination cannot be read without the password.
 
 ## Deduplication
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Vault is a backup and restore daemon for [Unraid](https://unraid.net/) servers. 
 - **Back up more than containers** — Docker containers, libvirt VMs, ZFS datasets, folders, and installed Unraid plugins.
 - **Send backups anywhere** — local disk, SFTP, SMB, NFS, WebDAV, or S3-compatible object storage, with per-destination bandwidth throttling.
 - **Choose a strategy** — full, incremental, and differential chains with simple-count or Long-Term Retention.
-- **Stay safe** — AES-256-GCM encryption, content-defined deduplication, and per-run SHA-256 verification.
+- **Stay safe** — backups encrypted with your backup password (age encryption — a modern, audited standard), content-defined deduplication, and per-run SHA-256 verification.
 - **Monitor in real time** — live WebSocket progress streaming across Dashboard, Jobs, Restore, Storage, History, Replication, Recovery, Logs, and Settings pages.
 
 See [How Backup Works](how-backup-works.md) for the concepts behind these features.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,13 @@ Vault is a backup and restore daemon for [Unraid](https://unraid.net/) servers. 
 
 See [How Backup Works](how-backup-works.md) for the concepts behind these features.
 
+## Finding your way
+
+- **New to Vault?** [Getting Started](getting-started.md) walks you from install to your first backup in about ten minutes.
+- **Setting things up?** The [Guides](guides/backup-jobs.md) are step-by-step recipes for jobs, storage, anomaly detection, and disaster recovery.
+- **Curious how it works?** [How Backup Works](how-backup-works.md) explains full/incremental chains, retention, encryption, and deduplication in plain language.
+- **Automating?** See the [REST API](api.md) and [MCP server](mcp.md).
+
 ## Integrations
 
 - **Home Assistant** — monitor jobs and trigger backups from your dashboard with the ready-to-use custom integration [`ha-vault`](https://github.com/ruaan-deysel/ha-vault).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ruaan-deysel/vault
 
-go 1.26.4
+go 1.26.5
 
 require (
 	filippo.io/age v1.3.1

--- a/internal/api/handlers/coverage_gapfill_test.go
+++ b/internal/api/handlers/coverage_gapfill_test.go
@@ -77,7 +77,7 @@ func TestRestoreDB_BadStorageConfig(t *testing.T) {
 		t.Fatalf("create dest: %v", err)
 	}
 
-	h := NewStorageHandler(d, nil)
+	h := NewStorageHandler(d, nil, nil)
 	idStr := strconv.FormatInt(destID, 10)
 	body := []byte(`{"storage_path":"any-path"}`)
 	w := httptest.NewRecorder()
@@ -106,7 +106,7 @@ func TestRefreshCapacity_BadAdapterConfig(t *testing.T) {
 		t.Fatalf("create dest: %v", err)
 	}
 
-	h := NewStorageHandler(d, nil)
+	h := NewStorageHandler(d, nil, nil)
 	idStr := strconv.FormatInt(destID, 10)
 	w := httptest.NewRecorder()
 	h.RefreshCapacity(w, reqWithID(http.MethodPost, "/api/v1/storage/x/capacity-check", idStr, nil))
@@ -135,7 +135,7 @@ func TestRefreshCapacity_AdapterGetCapacityFails(t *testing.T) {
 		t.Fatalf("create dest: %v", err)
 	}
 
-	h := NewStorageHandler(d, nil)
+	h := NewStorageHandler(d, nil, nil)
 	idStr := strconv.FormatInt(destID, 10)
 	w := httptest.NewRecorder()
 	h.RefreshCapacity(w, reqWithID(http.MethodPost, "/api/v1/storage/x/capacity-check", idStr, nil))
@@ -149,7 +149,7 @@ func TestRefreshCapacity_AdapterGetCapacityFails(t *testing.T) {
 func TestRefreshCapacity_DestNotFound(t *testing.T) {
 	t.Parallel()
 	d := newTestDB(t)
-	h := NewStorageHandler(d, nil)
+	h := NewStorageHandler(d, nil, nil)
 	w := httptest.NewRecorder()
 	h.RefreshCapacity(w, reqWithID(http.MethodPost, "/api/v1/storage/9999/capacity-check", "9999", nil))
 	if w.Code != http.StatusNotFound {

--- a/internal/api/handlers/error_branches_test.go
+++ b/internal/api/handlers/error_branches_test.go
@@ -505,7 +505,7 @@ func TestStorageCloseBreaker_NilRunner(t *testing.T) {
 		t.Fatalf("create dest: %v", err)
 	}
 
-	h := NewStorageHandler(d, nil) // explicit nil runner.
+	h := NewStorageHandler(d, nil, nil) // explicit nil runner.
 	idStr := strconv.FormatInt(destID, 10)
 	w := httptest.NewRecorder()
 	h.CloseBreaker(w, reqWithID(http.MethodPost, "/api/v1/storage/x/breaker/close", idStr, nil))

--- a/internal/api/handlers/more_branches2_test.go
+++ b/internal/api/handlers/more_branches2_test.go
@@ -245,7 +245,7 @@ func TestRunDedupGC_NoRunner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create dest: %v", err)
 	}
-	h := NewStorageHandler(d, nil)
+	h := NewStorageHandler(d, nil, nil)
 
 	w := httptest.NewRecorder()
 	h.RunDedupGC(w, reqWithID(http.MethodPost, "/api/v1/storage/x/gc",

--- a/internal/api/handlers/recovery.go
+++ b/internal/api/handlers/recovery.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"time"
@@ -257,6 +258,7 @@ func (h *RecoveryHandler) PathAudit(w http.ResponseWriter, _ *http.Request) {
 	for _, j := range jobs {
 		items, ierr := h.db.GetJobItems(j.ID)
 		if ierr != nil {
+			log.Printf("path-audit: skipping job %d: %v", j.ID, ierr)
 			continue
 		}
 		for _, it := range items {
@@ -332,6 +334,9 @@ func (h *RecoveryHandler) remapStorage(id int64, newPath string) (bool, string) 
 	if err != nil {
 		return false, "storage destination not found"
 	}
+	if dest.Type != "local" {
+		return false, "only local destinations can be remapped"
+	}
 	var cfg map[string]any
 	if err := json.Unmarshal([]byte(dest.Config), &cfg); err != nil {
 		return false, "could not read destination config"
@@ -357,9 +362,12 @@ func (h *RecoveryHandler) remapJobItem(jobID, itemID int64, newPath string) (boo
 		if it.ID != itemID {
 			continue
 		}
+		if it.ItemType != "folder" {
+			return false, "only folder items can be remapped"
+		}
 		var s map[string]any
 		if err := json.Unmarshal([]byte(it.Settings), &s); err != nil {
-			s = map[string]any{}
+			return false, "could not read item settings"
 		}
 		s["path"] = newPath
 		raw, err := json.Marshal(s)

--- a/internal/api/handlers/recovery.go
+++ b/internal/api/handlers/recovery.go
@@ -14,13 +14,21 @@ import (
 
 // RecoveryHandler serves the disaster recovery plan.
 type RecoveryHandler struct {
-	db      *db.DB
-	version string
+	db             *db.DB
+	version        string
+	onConfigChange ConfigChangeHook
 }
 
 // NewRecoveryHandler creates a RecoveryHandler.
 func NewRecoveryHandler(database *db.DB, version string) *RecoveryHandler {
 	return &RecoveryHandler{db: database, version: version}
+}
+
+// SetConfigChangeHook registers a function called after path remaps mutate
+// persistent configuration (typically used by the daemon to flush the DB
+// snapshot to USB flash).
+func (h *RecoveryHandler) SetConfigChangeHook(fn ConfigChangeHook) {
+	h.onConfigChange = fn
 }
 
 // GetPlan compiles a disaster recovery plan from existing data.
@@ -244,7 +252,11 @@ func (h *RecoveryHandler) PathAudit(w http.ResponseWriter, _ *http.Request) {
 		var cfg struct {
 			Path string `json:"path"`
 		}
-		if json.Unmarshal([]byte(d.Config), &cfg) != nil || cfg.Path == "" {
+		if err := json.Unmarshal([]byte(d.Config), &cfg); err != nil {
+			log.Printf("path-audit: skipping storage %d (%s): malformed config: %v", d.ID, d.Name, err)
+			continue
+		}
+		if cfg.Path == "" {
 			continue
 		}
 		entries = append(entries, pathAuditEntry{Kind: "storage", ID: d.ID, Name: d.Name, Path: cfg.Path, Exists: dirExists(cfg.Path)})
@@ -312,6 +324,7 @@ func (h *RecoveryHandler) PathRemap(w http.ResponseWriter, r *http.Request) {
 		Error   string `json:"error,omitempty"`
 	}
 	results := make([]remapResult, 0, len(req.Updates))
+	anyApplied := false
 	for _, u := range req.Updates {
 		res := remapResult{Kind: u.Kind, ID: u.ID}
 		switch {
@@ -324,7 +337,11 @@ func (h *RecoveryHandler) PathRemap(w http.ResponseWriter, r *http.Request) {
 		default:
 			res.Error = "unknown kind"
 		}
+		anyApplied = anyApplied || res.Applied
 		results = append(results, res)
+	}
+	if anyApplied && h.onConfigChange != nil {
+		h.onConfigChange()
 	}
 	respondJSON(w, http.StatusOK, map[string]any{"results": results})
 }
@@ -339,15 +356,18 @@ func (h *RecoveryHandler) remapStorage(id int64, newPath string) (bool, string) 
 	}
 	var cfg map[string]any
 	if err := json.Unmarshal([]byte(dest.Config), &cfg); err != nil {
+		log.Printf("path-remap: storage %d: malformed config: %v", id, err)
 		return false, "could not read destination config"
 	}
 	cfg["path"] = newPath
 	raw, err := json.Marshal(cfg)
 	if err != nil {
+		log.Printf("path-remap: storage %d: marshal config: %v", id, err)
 		return false, "could not update destination config"
 	}
 	dest.Config = string(raw)
 	if err := h.db.UpdateStorageDestination(dest); err != nil {
+		log.Printf("path-remap: storage %d: save: %v", id, err)
 		return false, "saving destination failed"
 	}
 	return true, ""
@@ -367,14 +387,17 @@ func (h *RecoveryHandler) remapJobItem(jobID, itemID int64, newPath string) (boo
 		}
 		var s map[string]any
 		if err := json.Unmarshal([]byte(it.Settings), &s); err != nil {
+			log.Printf("path-remap: job item %d: malformed settings: %v", itemID, err)
 			return false, "could not read item settings"
 		}
 		s["path"] = newPath
 		raw, err := json.Marshal(s)
 		if err != nil {
+			log.Printf("path-remap: job item %d: marshal settings: %v", itemID, err)
 			return false, "could not update item settings"
 		}
 		if err := h.db.UpdateJobItemSettings(itemID, string(raw)); err != nil {
+			log.Printf("path-remap: job item %d: save: %v", itemID, err)
 			return false, "saving item failed"
 		}
 		return true, ""

--- a/internal/api/handlers/recovery.go
+++ b/internal/api/handlers/recovery.go
@@ -1,11 +1,14 @@
 package handlers
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/ruaan-deysel/vault/internal/db"
+	"github.com/ruaan-deysel/vault/internal/unraid"
 )
 
 // RecoveryHandler serves the disaster recovery plan.
@@ -205,4 +208,168 @@ func (h *RecoveryHandler) GetPlan(w http.ResponseWriter, r *http.Request) {
 		"last_updated": time.Now().UTC(),
 	}
 	respondJSON(w, http.StatusOK, result)
+}
+
+type pathAuditEntry struct {
+	Kind   string `json:"kind"` // "storage" or "job_item"
+	ID     int64  `json:"id"`
+	JobID  int64  `json:"job_id,omitempty"`
+	Name   string `json:"name"`
+	Path   string `json:"path"`
+	Exists bool   `json:"exists"`
+}
+
+func dirExists(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && info.IsDir()
+}
+
+// PathAudit reports which configured local paths exist on this system —
+// after a DR restore the config references the OLD server's layout.
+//
+//	GET /api/v1/recovery/path-audit
+func (h *RecoveryHandler) PathAudit(w http.ResponseWriter, _ *http.Request) {
+	entries := []pathAuditEntry{}
+
+	dests, err := h.db.ListStorageDestinations()
+	if err != nil {
+		respondInternalError(w, err)
+		return
+	}
+	for _, d := range dests {
+		if d.Type != "local" {
+			continue
+		}
+		var cfg struct {
+			Path string `json:"path"`
+		}
+		if json.Unmarshal([]byte(d.Config), &cfg) != nil || cfg.Path == "" {
+			continue
+		}
+		entries = append(entries, pathAuditEntry{Kind: "storage", ID: d.ID, Name: d.Name, Path: cfg.Path, Exists: dirExists(cfg.Path)})
+	}
+
+	jobs, err := h.db.ListJobs()
+	if err != nil {
+		respondInternalError(w, err)
+		return
+	}
+	for _, j := range jobs {
+		items, ierr := h.db.GetJobItems(j.ID)
+		if ierr != nil {
+			continue
+		}
+		for _, it := range items {
+			if it.ItemType != "folder" {
+				continue
+			}
+			var s struct {
+				Path string `json:"path"`
+			}
+			if json.Unmarshal([]byte(it.Settings), &s) != nil || s.Path == "" {
+				continue
+			}
+			entries = append(entries, pathAuditEntry{Kind: "job_item", ID: it.ID, JobID: j.ID, Name: it.ItemName, Path: s.Path, Exists: dirExists(s.Path)})
+		}
+	}
+
+	// Candidate mounts to pick a replacement path from. Empty off-Unraid.
+	candidates := append([]string{}, unraid.DiscoverPools()...)
+	if shares, rerr := os.ReadDir("/mnt/user"); rerr == nil {
+		for _, sh := range shares {
+			if sh.IsDir() {
+				candidates = append(candidates, "/mnt/user/"+sh.Name())
+			}
+		}
+	}
+
+	respondJSON(w, http.StatusOK, map[string]any{"entries": entries, "candidates": candidates})
+}
+
+// PathRemap applies user-chosen replacement paths. Per-row results — one
+// bad row never blocks the others, and nothing is ever auto-rewritten.
+//
+//	POST /api/v1/recovery/path-remap
+func (h *RecoveryHandler) PathRemap(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Updates []struct {
+			Kind    string `json:"kind"`
+			ID      int64  `json:"id"`
+			JobID   int64  `json:"job_id"`
+			NewPath string `json:"new_path"`
+		} `json:"updates"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	type remapResult struct {
+		Kind    string `json:"kind"`
+		ID      int64  `json:"id"`
+		Applied bool   `json:"applied"`
+		Error   string `json:"error,omitempty"`
+	}
+	results := make([]remapResult, 0, len(req.Updates))
+	for _, u := range req.Updates {
+		res := remapResult{Kind: u.Kind, ID: u.ID}
+		switch {
+		case !dirExists(u.NewPath):
+			res.Error = "that path doesn't exist on this system — pick one of the suggested mounts or create it first"
+		case u.Kind == "storage":
+			res.Applied, res.Error = h.remapStorage(u.ID, u.NewPath)
+		case u.Kind == "job_item":
+			res.Applied, res.Error = h.remapJobItem(u.JobID, u.ID, u.NewPath)
+		default:
+			res.Error = "unknown kind"
+		}
+		results = append(results, res)
+	}
+	respondJSON(w, http.StatusOK, map[string]any{"results": results})
+}
+
+func (h *RecoveryHandler) remapStorage(id int64, newPath string) (bool, string) {
+	dest, err := h.db.GetStorageDestination(id)
+	if err != nil {
+		return false, "storage destination not found"
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(dest.Config), &cfg); err != nil {
+		return false, "could not read destination config"
+	}
+	cfg["path"] = newPath
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return false, "could not update destination config"
+	}
+	dest.Config = string(raw)
+	if err := h.db.UpdateStorageDestination(dest); err != nil {
+		return false, "saving destination failed"
+	}
+	return true, ""
+}
+
+func (h *RecoveryHandler) remapJobItem(jobID, itemID int64, newPath string) (bool, string) {
+	items, err := h.db.GetJobItems(jobID)
+	if err != nil {
+		return false, "job not found"
+	}
+	for _, it := range items {
+		if it.ID != itemID {
+			continue
+		}
+		var s map[string]any
+		if err := json.Unmarshal([]byte(it.Settings), &s); err != nil {
+			s = map[string]any{}
+		}
+		s["path"] = newPath
+		raw, err := json.Marshal(s)
+		if err != nil {
+			return false, "could not update item settings"
+		}
+		if err := h.db.UpdateJobItemSettings(itemID, string(raw)); err != nil {
+			return false, "saving item failed"
+		}
+		return true, ""
+	}
+	return false, "job item not found"
 }

--- a/internal/api/handlers/recovery.go
+++ b/internal/api/handlers/recovery.go
@@ -6,6 +6,9 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/ruaan-deysel/vault/internal/db"
@@ -17,11 +20,22 @@ type RecoveryHandler struct {
 	db             *db.DB
 	version        string
 	onConfigChange ConfigChangeHook
+
+	// maintMu guards PathRemap's writes against racing a database restore
+	// (a remap committing mid-swap would be silently lost). Defaults to an
+	// own lock; production shares StorageHandler's via SetMaintenanceLock.
+	maintMu *sync.Mutex
 }
 
 // NewRecoveryHandler creates a RecoveryHandler.
 func NewRecoveryHandler(database *db.DB, version string) *RecoveryHandler {
-	return &RecoveryHandler{db: database, version: version}
+	return &RecoveryHandler{db: database, version: version, maintMu: &sync.Mutex{}}
+}
+
+// SetMaintenanceLock shares StorageHandler's restore lifecycle lock so
+// PathRemap never writes while a database restore swaps the file.
+func (h *RecoveryHandler) SetMaintenanceLock(mu *sync.Mutex) {
+	h.maintMu = mu
 }
 
 // SetConfigChangeHook registers a function called after path remaps mutate
@@ -229,6 +243,12 @@ type pathAuditEntry struct {
 }
 
 func dirExists(p string) bool {
+	// Only absolute, traversal-free paths are ever stat'ed. Mount points and
+	// share paths are always absolute, so this rejects nothing legitimate —
+	// and it is the sanitization barrier for remap's user-provided new_path.
+	if !filepath.IsAbs(p) || strings.Contains(p, "..") {
+		return false
+	}
 	info, err := os.Stat(p)
 	return err == nil && info.IsDir()
 }
@@ -317,6 +337,13 @@ func (h *RecoveryHandler) PathRemap(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
+	// A remap committing while RestoreDB swaps the database file would be
+	// silently lost — share the maintenance lock instead of racing it.
+	if !h.maintMu.TryLock() {
+		respondError(w, http.StatusConflict, "a database restore is in progress — try again when it finishes")
+		return
+	}
+	defer h.maintMu.Unlock()
 	type remapResult struct {
 		Kind    string `json:"kind"`
 		ID      int64  `json:"id"`

--- a/internal/api/handlers/recovery_test.go
+++ b/internal/api/handlers/recovery_test.go
@@ -583,3 +583,41 @@ func TestPathRemapGuards(t *testing.T) {
 }
 
 func itoa(n int64) string { return strconv.FormatInt(n, 10) }
+
+// A successful remap must fire the config-change hook (DB → flash flush);
+// a remap where nothing applied must not.
+func TestPathRemapFiresConfigChangeHook(t *testing.T) {
+	d := newTestDB(t)
+	h := NewRecoveryHandler(d, "v1.0.0")
+	calls := 0
+	h.SetConfigChangeHook(func() { calls++ })
+
+	destID, err := d.CreateStorageDestination(db.StorageDestination{
+		Name: "hook-dest", Type: "local", Config: `{"path":"/mnt/gone/away"}`,
+	})
+	if err != nil {
+		t.Fatalf("create dest: %v", err)
+	}
+
+	newDir := t.TempDir()
+	body := []byte(`{"updates":[{"kind":"storage","id":` + itoa(destID) + `,"new_path":"` + newDir + `"}]}`)
+	w := httptest.NewRecorder()
+	h.PathRemap(w, newReq(http.MethodPost, "/api/v1/recovery/path-remap", body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+	}
+	if calls != 1 {
+		t.Fatalf("hook calls = %d, want 1", calls)
+	}
+
+	// Nothing applied → no hook call.
+	body = []byte(`{"updates":[{"kind":"storage","id":` + itoa(destID) + `,"new_path":"/still/does/not/exist"}]}`)
+	w = httptest.NewRecorder()
+	h.PathRemap(w, newReq(http.MethodPost, "/api/v1/recovery/path-remap", body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+	}
+	if calls != 1 {
+		t.Fatalf("hook calls after failed remap = %d, want still 1", calls)
+	}
+}

--- a/internal/api/handlers/recovery_test.go
+++ b/internal/api/handlers/recovery_test.go
@@ -499,4 +499,87 @@ func TestPathRemap(t *testing.T) {
 	}
 }
 
+func TestPathRemapGuards(t *testing.T) {
+	d := newTestDB(t)
+	h := NewRecoveryHandler(d, "v1.0.0")
+
+	sftpID, err := d.CreateStorageDestination(db.StorageDestination{
+		Name: "guard-sftp", Type: "sftp", Config: `{"path":"/remote"}`,
+	})
+	if err != nil {
+		t.Fatalf("create sftp dest: %v", err)
+	}
+	localID, err := d.CreateStorageDestination(db.StorageDestination{
+		Name: "guard-local", Type: "local", Config: `{"path":"/mnt/gone"}`,
+	})
+	if err != nil {
+		t.Fatalf("create local dest: %v", err)
+	}
+	jobID, err := d.CreateJob(db.Job{
+		Name: "guard-job", Enabled: true, StorageDestID: localID,
+		BackupTypeChain: "full", Schedule: "@daily",
+	})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	containerItemID, err := d.AddJobItem(db.JobItem{
+		JobID: jobID, ItemType: "container", ItemName: "plex", ItemID: "plex",
+	})
+	if err != nil {
+		t.Fatalf("add container item: %v", err)
+	}
+	corruptItemID, err := d.AddJobItem(db.JobItem{
+		JobID: jobID, ItemType: "folder", ItemName: "corrupt", ItemID: "corrupt",
+		Settings: `{not json`,
+	})
+	if err != nil {
+		t.Fatalf("add corrupt item: %v", err)
+	}
+
+	newDir := t.TempDir()
+	body := []byte(`{"updates":[
+		{"kind":"storage","id":` + itoa(sftpID) + `,"new_path":"` + newDir + `"},
+		{"kind":"job_item","id":` + itoa(containerItemID) + `,"job_id":` + itoa(jobID) + `,"new_path":"` + newDir + `"},
+		{"kind":"job_item","id":` + itoa(corruptItemID) + `,"job_id":` + itoa(jobID) + `,"new_path":"` + newDir + `"}
+	]}`)
+
+	w := httptest.NewRecorder()
+	h.PathRemap(w, newReq(http.MethodPost, "/api/v1/recovery/path-remap", body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Results []struct {
+			Kind    string `json:"kind"`
+			ID      int64  `json:"id"`
+			Applied bool   `json:"applied"`
+			Error   string `json:"error"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Results) != 3 {
+		t.Fatalf("results = %d, want 3: %+v", len(resp.Results), resp.Results)
+	}
+	if resp.Results[0].Applied || resp.Results[0].Error != "only local destinations can be remapped" {
+		t.Errorf("non-local storage remap: %+v", resp.Results[0])
+	}
+	if resp.Results[1].Applied || resp.Results[1].Error != "only folder items can be remapped" {
+		t.Errorf("non-folder item remap: %+v", resp.Results[1])
+	}
+	if resp.Results[2].Applied || resp.Results[2].Error != "could not read item settings" {
+		t.Errorf("corrupt-settings item remap: %+v", resp.Results[2])
+	}
+
+	// Nothing was mutated.
+	dest, err := d.GetStorageDestination(sftpID)
+	if err != nil {
+		t.Fatalf("get sftp dest: %v", err)
+	}
+	if dest.Config != `{"path":"/remote"}` {
+		t.Errorf("sftp config mutated: %s", dest.Config)
+	}
+}
+
 func itoa(n int64) string { return strconv.FormatInt(n, 10) }

--- a/internal/api/handlers/recovery_test.go
+++ b/internal/api/handlers/recovery_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -296,3 +297,206 @@ func min(a, b int) int {
 	}
 	return b
 }
+
+func TestPathAudit(t *testing.T) {
+	d := newTestDB(t)
+	h := NewRecoveryHandler(d, "v1.0.0")
+
+	goodDir := t.TempDir()
+	goodID, err := d.CreateStorageDestination(db.StorageDestination{
+		Name: "good-local", Type: "local", Config: `{"path":"` + goodDir + `"}`,
+	})
+	if err != nil {
+		t.Fatalf("create good dest: %v", err)
+	}
+	badID, err := d.CreateStorageDestination(db.StorageDestination{
+		Name: "bad-local", Type: "local", Config: `{"path":"/mnt/gone/away"}`,
+	})
+	if err != nil {
+		t.Fatalf("create bad dest: %v", err)
+	}
+	// Non-local destinations must not appear in the audit.
+	_, err = d.CreateStorageDestination(db.StorageDestination{
+		Name: "remote-sftp", Type: "sftp", Config: `{"path":"/remote"}`,
+	})
+	if err != nil {
+		t.Fatalf("create sftp dest: %v", err)
+	}
+
+	jobID, err := d.CreateJob(db.Job{
+		Name: "audit-job", Enabled: true, StorageDestID: goodID,
+		BackupTypeChain: "full", Schedule: "@daily",
+	})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	itemID, err := d.AddJobItem(db.JobItem{
+		JobID: jobID, ItemType: "folder", ItemName: "media", ItemID: "media",
+		Settings: `{"path":"/mnt/gone/media"}`,
+	})
+	if err != nil {
+		t.Fatalf("add item: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	h.PathAudit(w, newReq(http.MethodGet, "/api/v1/recovery/path-audit", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Entries []struct {
+			Kind   string `json:"kind"`
+			ID     int64  `json:"id"`
+			JobID  int64  `json:"job_id"`
+			Name   string `json:"name"`
+			Path   string `json:"path"`
+			Exists bool   `json:"exists"`
+		} `json:"entries"`
+		Candidates []string `json:"candidates"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Entries) != 3 {
+		t.Fatalf("entries = %d, want 3: %+v", len(resp.Entries), resp.Entries)
+	}
+	byKey := map[string]bool{}
+	for _, e := range resp.Entries {
+		byKey[e.Kind+":"+e.Path] = e.Exists
+		switch {
+		case e.Kind == "storage" && e.ID == goodID && e.Path != goodDir:
+			t.Errorf("good storage path = %q, want %q", e.Path, goodDir)
+		case e.Kind == "job_item" && e.ID != itemID:
+			t.Errorf("job_item id = %d, want %d", e.ID, itemID)
+		case e.Kind == "job_item" && e.JobID != jobID:
+			t.Errorf("job_item job_id = %d, want %d", e.JobID, jobID)
+		}
+	}
+	if !byKey["storage:"+goodDir] {
+		t.Errorf("existing storage path flagged exists=false")
+	}
+	if byKey["storage:/mnt/gone/away"] {
+		t.Errorf("missing storage path flagged exists=true (id %d)", badID)
+	}
+	if byKey["job_item:/mnt/gone/media"] {
+		t.Errorf("missing folder item path flagged exists=true")
+	}
+}
+
+func TestPathRemap(t *testing.T) {
+	d := newTestDB(t)
+	h := NewRecoveryHandler(d, "v1.0.0")
+
+	destID, err := d.CreateStorageDestination(db.StorageDestination{
+		Name: "remap-dest", Type: "local", Config: `{"path":"/mnt/gone/away"}`,
+	})
+	if err != nil {
+		t.Fatalf("create dest: %v", err)
+	}
+	badDestID, err := d.CreateStorageDestination(db.StorageDestination{
+		Name: "remap-dest-2", Type: "local", Config: `{"path":"/mnt/gone/too"}`,
+	})
+	if err != nil {
+		t.Fatalf("create dest 2: %v", err)
+	}
+	jobID, err := d.CreateJob(db.Job{
+		Name: "remap-job", Enabled: true, StorageDestID: destID,
+		BackupTypeChain: "full", Schedule: "@daily",
+	})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	itemID, err := d.AddJobItem(db.JobItem{
+		JobID: jobID, ItemType: "folder", ItemName: "media", ItemID: "media",
+		Settings: `{"path":"/mnt/gone/media","exclude":"*.tmp"}`,
+	})
+	if err != nil {
+		t.Fatalf("add item: %v", err)
+	}
+
+	newDir := t.TempDir()
+	body := []byte(`{"updates":[
+		{"kind":"storage","id":` + itoa(destID) + `,"new_path":"` + newDir + `"},
+		{"kind":"job_item","id":` + itoa(itemID) + `,"job_id":` + itoa(jobID) + `,"new_path":"` + newDir + `"},
+		{"kind":"storage","id":` + itoa(badDestID) + `,"new_path":"/still/does/not/exist"}
+	]}`)
+
+	w := httptest.NewRecorder()
+	h.PathRemap(w, newReq(http.MethodPost, "/api/v1/recovery/path-remap", body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Results []struct {
+			Kind    string `json:"kind"`
+			ID      int64  `json:"id"`
+			Applied bool   `json:"applied"`
+			Error   string `json:"error"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Results) != 3 {
+		t.Fatalf("results = %d, want 3", len(resp.Results))
+	}
+	if !resp.Results[0].Applied || resp.Results[0].Error != "" {
+		t.Errorf("storage remap: %+v", resp.Results[0])
+	}
+	if !resp.Results[1].Applied || resp.Results[1].Error != "" {
+		t.Errorf("job_item remap: %+v", resp.Results[1])
+	}
+	if resp.Results[2].Applied || resp.Results[2].Error == "" {
+		t.Errorf("bad path should be rejected per-row: %+v", resp.Results[2])
+	}
+
+	// The changes must actually be persisted.
+	dest, err := d.GetStorageDestination(destID)
+	if err != nil {
+		t.Fatalf("get dest: %v", err)
+	}
+	var cfg struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(dest.Config), &cfg); err != nil || cfg.Path != newDir {
+		t.Errorf("dest config = %s, want path %s", dest.Config, newDir)
+	}
+	items, err := d.GetJobItems(jobID)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("get items: %v (%d)", err, len(items))
+	}
+	var settings map[string]any
+	if err := json.Unmarshal([]byte(items[0].Settings), &settings); err != nil {
+		t.Fatalf("settings not JSON: %s", items[0].Settings)
+	}
+	if settings["path"] != newDir {
+		t.Errorf("item path = %v, want %s", settings["path"], newDir)
+	}
+	if settings["exclude"] != "*.tmp" {
+		t.Errorf("other settings clobbered: %s", items[0].Settings)
+	}
+
+	// A bad payload gets a 400, and an unknown kind a per-row error.
+	w = httptest.NewRecorder()
+	h.PathRemap(w, newReq(http.MethodPost, "/api/v1/recovery/path-remap", []byte(`{not json`)))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("bad JSON status = %d, want 400", w.Code)
+	}
+	w = httptest.NewRecorder()
+	h.PathRemap(w, newReq(http.MethodPost, "/api/v1/recovery/path-remap",
+		[]byte(`{"updates":[{"kind":"nope","id":1,"new_path":"`+newDir+`"}]}`)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("unknown kind status = %d", w.Code)
+	}
+	resp.Results = nil
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Results) != 1 || resp.Results[0].Applied || resp.Results[0].Error == "" {
+		t.Errorf("unknown kind: %+v", resp.Results)
+	}
+}
+
+func itoa(n int64) string { return strconv.FormatInt(n, 10) }

--- a/internal/api/handlers/restoredb_errors_test.go
+++ b/internal/api/handlers/restoredb_errors_test.go
@@ -40,7 +40,7 @@ func TestRestoreDB_InMemoryDatabaseRejected(t *testing.T) {
 	hub := ws.NewHub()
 	go hub.Run()
 	r := runner.New(d, hub, serverKey)
-	h := NewStorageHandler(d, r)
+	h := NewStorageHandler(d, r, serverKey)
 
 	// Write a valid db file at the storage path.
 	srcDBPath := filepath.Join(t.TempDir(), "src.db")

--- a/internal/api/handlers/restoredb_review_test.go
+++ b/internal/api/handlers/restoredb_review_test.go
@@ -1,0 +1,145 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+)
+
+// writePlaintextDBFixture builds a valid vault DB and copies it to
+// <storageDir>/<relPath>. Returns relPath.
+func writePlaintextDBFixture(t *testing.T, storageDir, relPath string) string {
+	t.Helper()
+	srcPath := filepath.Join(t.TempDir(), "fixture.db")
+	fd, err := db.Open(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fd.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	full := filepath.Join(storageDir, relPath)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return relPath
+}
+
+// A failure after h.db.Close() must restore the file AND reopen the handle —
+// otherwise the daemon fails every request until a manual restart.
+func TestRestoreDB_SwapFailureReopensDB(t *testing.T) {
+	h, destID, storageDir := newFileBackedStorageHandler(t)
+	snapPath := writePlaintextDBFixture(t, storageDir, "_vault/vault.db.latest.db")
+
+	// Plant a non-empty directory at the .bak path: os.Remove can't clear it
+	// and os.Rename(current, bak) can't replace it, forcing a failure on the
+	// post-Close swap path.
+	bakPath := h.db.Path() + ".bak"
+	if err := os.MkdirAll(filepath.Join(bakPath, "keep"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	body := fmt.Sprintf(`{"storage_path": %q}`, snapPath)
+	w := httptest.NewRecorder()
+	h.RestoreDB(w, reqWithID(http.MethodPost, "/storage/{id}/restore-db",
+		strconv.FormatInt(destID, 10), []byte(body)))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body = %s", w.Code, w.Body.String())
+	}
+	if err := h.db.Ping(); err != nil {
+		t.Fatalf("DB handle unusable after failed restore: %v", err)
+	}
+}
+
+// An adapter List error that is NOT "directory missing" must surface as an
+// error, not as an empty backup list (which reads as "no backups exist").
+func TestListDBBackupsAdapterError(t *testing.T) {
+	h, destID, storageDir := newFileBackedStorageHandler(t)
+	// A regular FILE named _vault makes os.ReadDir fail with ENOTDIR — a real
+	// adapter error, not "no backups yet".
+	if err := os.WriteFile(filepath.Join(storageDir, "_vault"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	w := httptest.NewRecorder()
+	h.ListDBBackups(w, reqWithID(http.MethodGet, "/storage/{id}/db-backups",
+		strconv.FormatInt(destID, 10), nil))
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body = %s", w.Code, w.Body.String())
+	}
+}
+
+// verify_only on a plaintext file must actually validate the payload.
+func TestRestoreDBVerifyOnlyPlaintextGarbage(t *testing.T) {
+	h, destID, storageDir := newFileBackedStorageHandler(t)
+	vdir := filepath.Join(storageDir, "_vault")
+	if err := os.MkdirAll(vdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(vdir, "vault.db.latest.db"),
+		[]byte("definitely not a sqlite database"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"storage_path": "_vault/vault.db.latest.db", "verify_only": true}`
+	w := httptest.NewRecorder()
+	h.RestoreDB(w, reqWithID(http.MethodPost, "/storage/{id}/restore-db",
+		strconv.FormatInt(destID, 10), []byte(body)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "doesn't look like") {
+		t.Fatalf("body = %s, want friendly not-a-backup message", w.Body.String())
+	}
+	if err := h.db.Ping(); err != nil {
+		t.Fatalf("working DB unusable after verify_only: %v", err)
+	}
+}
+
+func TestRestoreDBVerifyOnlyPlaintextValid(t *testing.T) {
+	h, destID, storageDir := newFileBackedStorageHandler(t)
+	snapPath := writePlaintextDBFixture(t, storageDir, "_vault/vault.db.latest.db")
+
+	body := fmt.Sprintf(`{"storage_path": %q, "verify_only": true}`, snapPath)
+	w := httptest.NewRecorder()
+	h.RestoreDB(w, reqWithID(http.MethodPost, "/storage/{id}/restore-db",
+		strconv.FormatInt(destID, 10), []byte(body)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"valid":true`) {
+		t.Fatalf("body = %s, want valid:true", w.Body.String())
+	}
+	if err := h.db.Ping(); err != nil {
+		t.Fatalf("working DB unusable after verify_only: %v", err)
+	}
+}
+
+// Concurrent restores are serialized: a second request gets 409 instead of
+// racing the file swap.
+func TestRestoreDBConflictWhenRestoreInProgress(t *testing.T) {
+	h, destID, _ := newFileBackedStorageHandler(t)
+	h.restoreMu.Lock()
+	defer h.restoreMu.Unlock()
+
+	body := `{"storage_path": "_vault/vault.db.latest.db"}`
+	w := httptest.NewRecorder()
+	h.RestoreDB(w, reqWithID(http.MethodPost, "/storage/{id}/restore-db",
+		strconv.FormatInt(destID, 10), []byte(body)))
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body = %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/handlers/restoredb_review_test.go
+++ b/internal/api/handlers/restoredb_review_test.go
@@ -65,6 +65,42 @@ func TestRestoreDB_SwapFailureReopensDB(t *testing.T) {
 	}
 }
 
+// A backup that opens but fails PRAGMA integrity_check must be rejected
+// before the live DB is touched. db.Open may catch some corruption first —
+// either failure mode is a 400 with the working DB untouched.
+func TestRestoreDB_CorruptBackupRejected(t *testing.T) {
+	h, destID, storageDir := newFileBackedStorageHandler(t)
+	snapPath := writePlaintextDBFixture(t, storageDir, "_vault/vault.db.latest.db")
+
+	// Corrupt a page past the header: the SQLite magic stays intact, so only
+	// open-time validation or the integrity check can catch it.
+	full := filepath.Join(storageDir, snapPath)
+	data, err := os.ReadFile(full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) < 8192 {
+		t.Fatalf("fixture too small to corrupt a page: %d bytes", len(data))
+	}
+	for i := 4096; i < 8192; i++ {
+		data[i] ^= 0xff
+	}
+	if err := os.WriteFile(full, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	body := fmt.Sprintf(`{"storage_path": %q}`, snapPath)
+	w := httptest.NewRecorder()
+	h.RestoreDB(w, reqWithID(http.MethodPost, "/storage/{id}/restore-db",
+		strconv.FormatInt(destID, 10), []byte(body)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", w.Code, w.Body.String())
+	}
+	if err := h.db.Ping(); err != nil {
+		t.Fatalf("working DB touched by rejected restore: %v", err)
+	}
+}
+
 // An adapter List error that is NOT "directory missing" must surface as an
 // error, not as an empty backup list (which reads as "no backups exist").
 func TestListDBBackupsAdapterError(t *testing.T) {

--- a/internal/api/handlers/restoredb_test.go
+++ b/internal/api/handlers/restoredb_test.go
@@ -256,6 +256,8 @@ func TestRestoreDBReopensAndReseals(t *testing.T) {
 	h, destID, storageDir := newFileBackedStorageHandler(t)
 	reloads := 0
 	h.SetScheduleReloadHook(func() error { reloads++; return nil })
+	configFlushes := 0
+	h.SetConfigChangeHook(func() { configFlushes++ })
 
 	const pass = "correct horse battery"
 	hash, err := crypto.HashPassphrase(pass)
@@ -302,6 +304,11 @@ func TestRestoreDBReopensAndReseals(t *testing.T) {
 
 	if reloads != 1 {
 		t.Fatalf("scheduler reloads = %d, want 1", reloads)
+	}
+	// The restored DB must be flushed to flash right away — a power loss
+	// before the next periodic flush would otherwise revert the restore.
+	if configFlushes != 1 {
+		t.Fatalf("config-change hook calls = %d, want 1", configFlushes)
 	}
 }
 

--- a/internal/api/handlers/restoredb_test.go
+++ b/internal/api/handlers/restoredb_test.go
@@ -335,6 +335,63 @@ func TestRestoreDBEncryptedNeedsPassphrase(t *testing.T) {
 	}
 }
 
+func TestListDBBackups(t *testing.T) {
+	h, destID, storageDir := newFileBackedStorageHandler(t)
+	vdir := filepath.Join(storageDir, "_vault")
+	if err := os.MkdirAll(filepath.Join(vdir, "somedir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{
+		"vault.db.latest.age",
+		"vault.db.2026-07-10T04-00-00.age",
+		"vault.db.2026-07-11T04-00-00.age",
+		"unrelated.txt",
+	} {
+		if err := os.WriteFile(filepath.Join(vdir, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	w := httptest.NewRecorder()
+	h.ListDBBackups(w, reqWithID(http.MethodGet, "/storage/{id}/db-backups", strconv.FormatInt(destID, 10), nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var entries []struct {
+		Path      string `json:"path"`
+		Name      string `json:"name"`
+		Encrypted bool   `json:"encrypted"`
+		IsLatest  bool   `json:"is_latest"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("got %d entries, want 3: %+v", len(entries), entries)
+	}
+	if !entries[0].IsLatest || entries[0].Name != "vault.db.latest.age" {
+		t.Fatalf("first entry should be latest, got %+v", entries[0])
+	}
+	if entries[1].Name != "vault.db.2026-07-11T04-00-00.age" {
+		t.Fatalf("timestamped order wrong: %+v", entries)
+	}
+	if !entries[0].Encrypted {
+		t.Fatal("encrypted flag missing on .age entry")
+	}
+}
+
+func TestListDBBackupsEmpty(t *testing.T) {
+	h, destID, _ := newFileBackedStorageHandler(t)
+	w := httptest.NewRecorder()
+	h.ListDBBackups(w, reqWithID(http.MethodGet, "/storage/{id}/db-backups", strconv.FormatInt(destID, 10), nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if got := strings.TrimSpace(w.Body.String()); got != "[]" {
+		t.Fatalf("body = %q, want []", got)
+	}
+}
+
 func TestRestoreDBVerifyOnly(t *testing.T) {
 	h, destID, storageDir := newFileBackedStorageHandler(t)
 	snapPath := writeEncryptedDBFixture(t, storageDir, "verify-me", nil)

--- a/internal/api/handlers/restoredb_test.go
+++ b/internal/api/handlers/restoredb_test.go
@@ -49,7 +49,7 @@ func newFileBackedStorageHandler(t *testing.T) (*StorageHandler, int64, string) 
 	go hub.Run()
 	r := runner.New(d, hub, serverKey)
 
-	return NewStorageHandler(d, r), destID, storageDir
+	return NewStorageHandler(d, r, serverKey), destID, storageDir
 }
 
 func TestRestoreDB_InvalidID(t *testing.T) {
@@ -249,6 +249,59 @@ func TestRestoreDBEncrypted(t *testing.T) {
 	got, _ := restored.GetSetting("restore_marker", "")
 	if got != "from-backup" {
 		t.Fatalf("restore_marker = %q, want from-backup", got)
+	}
+}
+
+func TestRestoreDBReopensAndReseals(t *testing.T) {
+	h, destID, storageDir := newFileBackedStorageHandler(t)
+	reloads := 0
+	h.SetScheduleReloadHook(func() error { reloads++; return nil })
+
+	const pass = "correct horse battery"
+	hash, err := crypto.HashPassphrase(pass)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapPath := writeEncryptedDBFixture(t, storageDir, pass, func(fd *db.DB) {
+		// The backup contains the hash plus a seal made with the OLD
+		// server's key — unusable on this "new" server.
+		if err := fd.SetSetting("encryption_passphrase_hash", hash); err != nil {
+			t.Fatal(err)
+		}
+		if err := fd.SetSetting("encryption_passphrase_sealed", "stale-old-server-seal"); err != nil {
+			t.Fatal(err)
+		}
+		if err := fd.SetSetting("restore_marker", "from-backup"); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	body := fmt.Sprintf(`{"storage_path": %q, "passphrase": %q}`, snapPath, pass)
+	w := httptest.NewRecorder()
+	h.RestoreDB(w, reqWithID(http.MethodPost, "/storage/{id}/restore-db", strconv.FormatInt(destID, 10), []byte(body)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"resealed":true`) {
+		t.Fatalf("body = %s, want resealed:true", w.Body.String())
+	}
+
+	// Reopen happened in-process: the SAME handle sees restored data.
+	got, err := h.db.GetSetting("restore_marker", "")
+	if err != nil || got != "from-backup" {
+		t.Fatalf("marker via original handle = %q (err %v), want from-backup", got, err)
+	}
+
+	// Re-seal used the current server key (0xcd repeated — see helper).
+	sealed, _ := h.db.GetSetting("encryption_passphrase_sealed", "")
+	serverKey := bytes.Repeat([]byte{0xcd}, 32)
+	unsealed, err := crypto.Unseal(serverKey, sealed)
+	if err != nil || unsealed != pass {
+		t.Fatalf("unsealed = %q (err %v), want %q", unsealed, err, pass)
+	}
+
+	if reloads != 1 {
+		t.Fatalf("scheduler reloads = %d, want 1", reloads)
 	}
 }
 

--- a/internal/api/handlers/restoredb_test.go
+++ b/internal/api/handlers/restoredb_test.go
@@ -333,6 +333,9 @@ func TestRestoreDBEncryptedNeedsPassphrase(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body = %s", w.Code, w.Body.String())
 	}
+	if err := h.db.Ping(); err != nil {
+		t.Fatalf("working DB unusable after failed restore: %v", err)
+	}
 }
 
 func TestListDBBackups(t *testing.T) {

--- a/internal/api/handlers/restoredb_test.go
+++ b/internal/api/handlers/restoredb_test.go
@@ -3,14 +3,17 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/ruaan-deysel/vault/internal/crypto"
 	"github.com/ruaan-deysel/vault/internal/db"
 	"github.com/ruaan-deysel/vault/internal/runner"
 	"github.com/ruaan-deysel/vault/internal/ws"
@@ -179,3 +182,120 @@ func TestRestoreDB_SuccessSwapsDB(t *testing.T) {
 // keep io.Copy referenced (used inside RestoreDB) so the test file is
 // future-proof if direct imports shift.
 var _ = io.Copy
+
+// writeEncryptedDBFixture builds a valid vault DB, optionally customizes it
+// via prep, encrypts it with the passphrase, and writes it to
+// <storageDir>/_vault/vault.db.latest.age. Returns the storage-relative path.
+func writeEncryptedDBFixture(t *testing.T, storageDir, passphrase string, prep func(*db.DB)) string {
+	t.Helper()
+	srcPath := filepath.Join(t.TempDir(), "fixture.db")
+	fd, err := db.Open(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prep != nil {
+		prep(fd)
+	}
+	if err := fd.Close(); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	enc, err := crypto.EncryptReader(passphrase, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer enc.Close()
+	if err := os.MkdirAll(filepath.Join(storageDir, "_vault"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dst, err := os.Create(filepath.Join(storageDir, "_vault", "vault.db.latest.age"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(dst, enc); err != nil {
+		t.Fatal(err)
+	}
+	if err := dst.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return "_vault/vault.db.latest.age"
+}
+
+func TestRestoreDBEncrypted(t *testing.T) {
+	h, destID, storageDir := newFileBackedStorageHandler(t)
+	snapPath := writeEncryptedDBFixture(t, storageDir, "correct horse battery", func(fd *db.DB) {
+		if err := fd.SetSetting("restore_marker", "from-backup"); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	body := fmt.Sprintf(`{"storage_path": %q, "passphrase": "correct horse battery"}`, snapPath)
+	w := httptest.NewRecorder()
+	h.RestoreDB(w, reqWithID(http.MethodPost, "/storage/{id}/restore-db", strconv.FormatInt(destID, 10), []byte(body)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	// The handler closed h.db before swapping; open the swapped file directly.
+	restored, err := db.Open(h.db.Path())
+	if err != nil {
+		t.Fatalf("opening restored DB: %v", err)
+	}
+	defer restored.Close()
+	got, _ := restored.GetSetting("restore_marker", "")
+	if got != "from-backup" {
+		t.Fatalf("restore_marker = %q, want from-backup", got)
+	}
+}
+
+func TestRestoreDBWrongPassphrase(t *testing.T) {
+	h, destID, storageDir := newFileBackedStorageHandler(t)
+	snapPath := writeEncryptedDBFixture(t, storageDir, "right-passphrase", nil)
+
+	body := fmt.Sprintf(`{"storage_path": %q, "passphrase": "wrong-passphrase"}`, snapPath)
+	w := httptest.NewRecorder()
+	h.RestoreDB(w, reqWithID(http.MethodPost, "/storage/{id}/restore-db", strconv.FormatInt(destID, 10), []byte(body)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "incorrect passphrase") {
+		t.Fatalf("body = %s, want mention of incorrect passphrase", w.Body.String())
+	}
+	if err := h.db.Ping(); err != nil {
+		t.Fatalf("working DB unusable after failed restore: %v", err)
+	}
+}
+
+func TestRestoreDBEncryptedNeedsPassphrase(t *testing.T) {
+	h, destID, storageDir := newFileBackedStorageHandler(t)
+	snapPath := writeEncryptedDBFixture(t, storageDir, "any", nil)
+
+	body := fmt.Sprintf(`{"storage_path": %q}`, snapPath)
+	w := httptest.NewRecorder()
+	h.RestoreDB(w, reqWithID(http.MethodPost, "/storage/{id}/restore-db", strconv.FormatInt(destID, 10), []byte(body)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRestoreDBVerifyOnly(t *testing.T) {
+	h, destID, storageDir := newFileBackedStorageHandler(t)
+	snapPath := writeEncryptedDBFixture(t, storageDir, "verify-me", nil)
+
+	body := fmt.Sprintf(`{"storage_path": %q, "passphrase": "verify-me", "verify_only": true}`, snapPath)
+	w := httptest.NewRecorder()
+	h.RestoreDB(w, reqWithID(http.MethodPost, "/storage/{id}/restore-db", strconv.FormatInt(destID, 10), []byte(body)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"valid":true`) {
+		t.Fatalf("body = %s, want valid:true", w.Body.String())
+	}
+	if err := h.db.Ping(); err != nil {
+		t.Fatalf("working DB closed by verify_only: %v", err)
+	}
+}

--- a/internal/api/handlers/storage.go
+++ b/internal/api/handlers/storage.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ruaan-deysel/vault/internal/crypto"
@@ -29,6 +30,11 @@ type StorageHandler struct {
 	serverKey      []byte
 	schedReload    ScheduleReloader
 	onConfigChange ConfigChangeHook
+
+	// restoreMu serializes RestoreDB: the close→swap→reopen sequence must
+	// never run concurrently. A field (not package-level) so tests with
+	// separate handlers don't contend.
+	restoreMu sync.Mutex
 }
 
 // NewStorageHandler creates a storage destinations handler. serverKey is
@@ -517,6 +523,10 @@ func (h *StorageHandler) Import(w http.ResponseWriter, r *http.Request) {
 // storage and replaces the current database file.
 //
 //	POST /api/v1/storage/{id}/restore-db
+//
+// sqliteMagic is the 16-byte header every SQLite 3 database file starts with.
+const sqliteMagic = "SQLite format 3\x00"
+
 func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseID(w, r, "id")
 	if !ok {
@@ -546,6 +556,14 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, "invalid storage_path")
 		return
 	}
+
+	// Serialize restores: the close→swap→reopen sequence must never race
+	// another restore (verify_only requests also queue here — they're quick).
+	if !h.restoreMu.TryLock() {
+		respondError(w, http.StatusConflict, "a database restore is already in progress")
+		return
+	}
+	defer h.restoreMu.Unlock()
 
 	adapter, err := storage.NewAdapter(dest.Type, dest.Config)
 	if err != nil {
@@ -592,8 +610,14 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.VerifyOnly {
-		// The age header was parsed (and the passphrase checked) when the
-		// decrypt reader was constructed — nothing more to do.
+		// A wrong passphrase on .age already errored above. Now confirm the
+		// (decrypted) payload actually is a SQLite database — otherwise a
+		// plaintext verify validates nothing.
+		header := make([]byte, len(sqliteMagic))
+		if _, rerr := io.ReadFull(src, header); rerr != nil || string(header) != sqliteMagic {
+			respondError(w, http.StatusBadRequest, "that file doesn't look like a Vault database backup")
+			return
+		}
 		respondJSON(w, http.StatusOK, map[string]any{"valid": true})
 		return
 	}
@@ -645,18 +669,25 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 	backupPath := currentPath + ".bak"
 	_ = os.Remove(backupPath) // clear any stale backup
 	backupExists := false
+	// restoreBackup undoes a failed swap: put the original file back (when we
+	// got far enough to move it) AND reopen the handle — otherwise the daemon
+	// keeps a closed DB and fails every request until a manual restart.
+	restoreBackup := func() {
+		if backupExists {
+			_ = os.Rename(backupPath, currentPath)
+		}
+		if err := h.db.Reopen(); err != nil {
+			log.Printf("RestoreDB: reopening DB after failed restore: %v — restart Vault from the plugin page", err)
+		}
+	}
 	if _, statErr := os.Stat(currentPath); statErr == nil {
 		if err := os.Rename(currentPath, backupPath); err != nil {
+			restoreBackup()
 			_ = os.Remove(tmpPath)
 			respondInternalError(w, fmt.Errorf("backup current DB: %w", err))
 			return
 		}
 		backupExists = true
-	}
-	restoreBackup := func() {
-		if backupExists {
-			_ = os.Rename(backupPath, currentPath)
-		}
 	}
 
 	srcFile, err := os.Open(tmpPath) // #nosec G304 — tmpPath is os.CreateTemp result, vault-controlled
@@ -743,6 +774,16 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// A plaintext restore can't re-seal: warn when the restored DB carries a
+	// seal made with the OLD server's vault.key, which this server can't open.
+	if req.Passphrase == "" && len(h.serverKey) > 0 {
+		if sealed, _ := h.db.GetSetting("encryption_passphrase_sealed", ""); sealed != "" {
+			if _, err := crypto.Unseal(h.serverKey, sealed); err != nil {
+				log.Printf("RestoreDB: restored DB has a sealed passphrase that cannot be unsealed with this server's key — re-enter it in Settings → Encryption")
+			}
+		}
+	}
+
 	if h.schedReload != nil {
 		if err := h.schedReload(); err != nil {
 			log.Printf("RestoreDB: scheduler reload after restore failed: %v", err)
@@ -788,7 +829,13 @@ func (h *StorageHandler) ListDBBackups(w http.ResponseWriter, r *http.Request) {
 
 	files, err := adapter.List("_vault")
 	if err != nil {
-		respondJSON(w, http.StatusOK, []dbBackupEntry{})
+		if storage.IsNotExist(err) {
+			// A destination that never held a DB backup is normal.
+			respondJSON(w, http.StatusOK, []dbBackupEntry{})
+			return
+		}
+		log.Printf("ListDBBackups: listing _vault on destination %d: %v", id, err)
+		respondError(w, http.StatusBadGateway, "could not read your backup storage — check the connection and try again")
 		return
 	}
 

--- a/internal/api/handlers/storage.go
+++ b/internal/api/handlers/storage.go
@@ -32,9 +32,17 @@ type StorageHandler struct {
 	onConfigChange ConfigChangeHook
 
 	// restoreMu serializes RestoreDB: the close→swap→reopen sequence must
-	// never run concurrently. A field (not package-level) so tests with
-	// separate handlers don't contend.
+	// never run concurrently. A field (not package-level) so this package's
+	// parallel tests with separate handlers don't contend. Production shares
+	// this instance with RecoveryHandler.PathRemap via MaintenanceLock so a
+	// remap can never commit mid-swap and be lost.
 	restoreMu sync.Mutex
+}
+
+// MaintenanceLock exposes the restore lifecycle lock so other handlers
+// (PathRemap) can coordinate with in-flight database restores.
+func (h *StorageHandler) MaintenanceLock() *sync.Mutex {
+	return &h.restoreMu
 }
 
 // NewStorageHandler creates a storage destinations handler. serverKey is
@@ -589,7 +597,14 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 
 	rc, err := adapter.Read(dbPath)
 	if err != nil {
-		respondError(w, http.StatusNotFound, "no Vault backup found at "+dbPath+" — look for a folder named _vault on your backup storage")
+		// Only a genuine not-found reads as "no backup" — a transport or
+		// auth failure must not send a DR user hunting for a missing file.
+		if storage.IsNotExist(err) {
+			respondError(w, http.StatusNotFound, "no Vault backup found at "+dbPath+" — look for a folder named _vault on your backup storage")
+			return
+		}
+		log.Printf("RestoreDB: reading %s from destination %d: %v", dbPath, id, err) // #nosec G706 //nolint:gosec // id is int64 from URL param, err is from an admin-configured adapter
+		respondError(w, http.StatusBadGateway, "could not read your backup storage — check the connection and try again")
 		return
 	}
 	defer rc.Close()

--- a/internal/api/handlers/storage.go
+++ b/internal/api/handlers/storage.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ruaan-deysel/vault/internal/crypto"
 	"github.com/ruaan-deysel/vault/internal/db"
 	"github.com/ruaan-deysel/vault/internal/runner"
 	"github.com/ruaan-deysel/vault/internal/storage"
@@ -519,6 +520,8 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 
 	var req struct {
 		StoragePath string `json:"storage_path"`
+		Passphrase  string `json:"passphrase"`
+		VerifyOnly  bool   `json:"verify_only"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		respondError(w, http.StatusBadRequest, "invalid JSON")
@@ -540,13 +543,57 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dbPath := strings.TrimPrefix(cleanedStoragePath, "/") + "/vault.db"
+	dbPath := strings.TrimPrefix(cleanedStoragePath, "/")
+	if !strings.HasSuffix(dbPath, ".db") && !strings.HasSuffix(dbPath, ".age") {
+		// Legacy form: storage_path is a directory containing a plaintext vault.db.
+		dbPath += "/vault.db"
+	}
+	encrypted := strings.HasSuffix(dbPath, ".age")
+
+	if encrypted && req.Passphrase == "" {
+		respondError(w, http.StatusBadRequest, "this backup is encrypted — enter your backup password")
+		return
+	}
+	// When the current DB already has a passphrase hash (restoring over a
+	// live config), check the password before downloading. On a fresh
+	// install there is no hash — the decryption attempt below is the check.
+	if req.Passphrase != "" {
+		if hash, _ := h.db.GetSetting("encryption_passphrase_hash", ""); hash != "" {
+			if crypto.VerifyPassphrase(req.Passphrase, hash) != nil {
+				respondError(w, http.StatusBadRequest, "incorrect passphrase — this is the encryption password from Settings → Encryption")
+				return
+			}
+		}
+	}
+
 	rc, err := adapter.Read(dbPath)
 	if err != nil {
-		respondError(w, http.StatusNotFound, "vault.db not found at "+dbPath)
+		respondError(w, http.StatusNotFound, "no Vault backup found at "+dbPath+" — look for a folder named _vault on your backup storage")
 		return
 	}
 	defer rc.Close()
+
+	var src io.Reader = rc
+	if encrypted {
+		dec, derr := crypto.DecryptReader(req.Passphrase, rc)
+		if derr != nil {
+			if crypto.IsWrongPassphrase(derr) {
+				respondError(w, http.StatusBadRequest, "incorrect passphrase — check for typos; this is the encryption password you chose in Settings → Encryption on your old server")
+				return
+			}
+			respondInternalError(w, derr)
+			return
+		}
+		defer dec.Close()
+		src = dec
+	}
+
+	if req.VerifyOnly {
+		// The age header was parsed (and the passphrase checked) when the
+		// decrypt reader was constructed — nothing more to do.
+		respondJSON(w, http.StatusOK, map[string]any{"valid": true})
+		return
+	}
 
 	// Write to a temporary file first.
 	tmpFile, err := os.CreateTemp("", "vault-restore-*.db")
@@ -556,7 +603,7 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 	}
 	tmpPath := tmpFile.Name()
 
-	if _, err := io.Copy(tmpFile, rc); err != nil {
+	if _, err := io.Copy(tmpFile, src); err != nil {
 		_ = tmpFile.Close()
 		_ = os.Remove(tmpPath)
 		respondInternalError(w, err)

--- a/internal/api/handlers/storage.go
+++ b/internal/api/handlers/storage.go
@@ -848,7 +848,7 @@ func (h *StorageHandler) ListDBBackups(w http.ResponseWriter, r *http.Request) {
 			respondJSON(w, http.StatusOK, []dbBackupEntry{})
 			return
 		}
-		log.Printf("ListDBBackups: listing _vault on destination %d: %v", id, err)
+		log.Printf("ListDBBackups: listing _vault on destination %d: %v", id, err) // #nosec G706 //nolint:gosec // id is int64 from URL param, err is from an admin-configured adapter
 		respondError(w, http.StatusBadGateway, "could not read your backup storage — check the connection and try again")
 		return
 	}

--- a/internal/api/handlers/storage.go
+++ b/internal/api/handlers/storage.go
@@ -25,11 +25,20 @@ import (
 type StorageHandler struct {
 	db             *db.DB
 	runner         *runner.Runner
+	serverKey      []byte
+	schedReload    ScheduleReloader
 	onConfigChange ConfigChangeHook
 }
 
-func NewStorageHandler(database *db.DB, r *runner.Runner) *StorageHandler {
-	return &StorageHandler{db: database, runner: r}
+// NewStorageHandler creates a storage destinations handler. serverKey is
+// used to re-seal the encryption passphrase after a database restore.
+func NewStorageHandler(database *db.DB, r *runner.Runner, serverKey []byte) *StorageHandler {
+	return &StorageHandler{db: database, runner: r, serverKey: serverKey}
+}
+
+// SetScheduleReloadHook installs the scheduler reload used after a DB restore.
+func (h *StorageHandler) SetScheduleReloadHook(reload ScheduleReloader) {
+	h.schedReload = reload
 }
 
 // SetConfigChangeHook registers a function called after storage mutations
@@ -712,8 +721,37 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 	_ = os.Remove(currentPath + "-wal")
 	_ = os.Remove(currentPath + "-shm")
 
+	// Reopen in-process so the daemon keeps working without a restart.
+	if err := h.db.Reopen(); err != nil {
+		log.Printf("RestoreDB: reopen after restore failed: %v", err)
+		respondError(w, http.StatusInternalServerError,
+			"database restored, but the daemon could not reload it — restart Vault from the plugin page to finish")
+		return
+	}
+
+	// The restored DB's sealed passphrase used the old server's vault.key.
+	// Re-seal with the current key so scheduled DB backups stay encrypted.
+	resealed := false
+	if req.Passphrase != "" && len(h.serverKey) > 0 {
+		if hash, _ := h.db.GetSetting("encryption_passphrase_hash", ""); hash != "" &&
+			crypto.VerifyPassphrase(req.Passphrase, hash) == nil {
+			if sealed, err := crypto.Seal(h.serverKey, req.Passphrase); err == nil {
+				if err := h.db.SetSetting("encryption_passphrase_sealed", sealed); err == nil {
+					resealed = true
+				}
+			}
+		}
+	}
+
+	if h.schedReload != nil {
+		if err := h.schedReload(); err != nil {
+			log.Printf("RestoreDB: scheduler reload after restore failed: %v", err)
+		}
+	}
+
 	respondJSON(w, http.StatusOK, map[string]any{
-		"message": "Database restored successfully. Please restart the Vault daemon.",
+		"message":  "Database restored successfully.",
+		"resealed": resealed,
 	})
 }
 

--- a/internal/api/handlers/storage.go
+++ b/internal/api/handlers/storage.go
@@ -552,6 +552,7 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 		respondInternalError(w, err)
 		return
 	}
+	defer storage.CloseAdapter(adapter)
 
 	dbPath := strings.TrimPrefix(cleanedStoragePath, "/")
 	if !strings.HasSuffix(dbPath, ".db") && !strings.HasSuffix(dbPath, ".age") {

--- a/internal/api/handlers/storage.go
+++ b/internal/api/handlers/storage.go
@@ -753,6 +753,9 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 	// fails, .bak is the pre-restore DB and the only rollback artifact left.
 	if err := h.db.Reopen(); err != nil {
 		log.Printf("RestoreDB: reopen after restore failed: %v — pre-restore DB kept at %s", err, backupPath)
+		// The temp file is the decrypted DB copy — don't leave it in the
+		// temp dir. The .bak safety copy stays.
+		_ = os.Remove(tmpPath)
 		respondError(w, http.StatusInternalServerError,
 			"database restored, but the daemon could not reload it — restart Vault from the plugin page to finish")
 		return

--- a/internal/api/handlers/storage.go
+++ b/internal/api/handlers/storage.go
@@ -638,11 +638,19 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = tmpFile.Close()
 
-	// Validate the downloaded database.
+	// Validate the downloaded database. Open catches gross damage; the
+	// integrity check catches corrupt pages that still open fine.
 	testDB, err := db.Open(tmpPath)
 	if err != nil {
 		_ = os.Remove(tmpPath)
 		respondError(w, http.StatusBadRequest, "downloaded file is not a valid Vault database: "+err.Error())
+		return
+	}
+	if err := testDB.IntegrityCheck(); err != nil {
+		_ = testDB.Close()
+		_ = os.Remove(tmpPath)
+		log.Printf("RestoreDB: candidate DB failed integrity check: %v", err)
+		respondError(w, http.StatusBadRequest, "that backup file failed the database integrity check")
 		return
 	}
 	_ = testDB.Close()
@@ -736,23 +744,25 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Success — drop backup and temp.
-	if backupExists {
-		_ = os.Remove(backupPath)
-	}
-	_ = os.Remove(tmpPath)
-
 	// Remove WAL and SHM files (stale after replacement).
 	_ = os.Remove(currentPath + "-wal")
 	_ = os.Remove(currentPath + "-shm")
 
-	// Reopen in-process so the daemon keeps working without a restart.
+	// Reopen in-process so the daemon keeps working without a restart. The
+	// .bak safety copy is only dropped once the reopen succeeds — if it
+	// fails, .bak is the pre-restore DB and the only rollback artifact left.
 	if err := h.db.Reopen(); err != nil {
-		log.Printf("RestoreDB: reopen after restore failed: %v", err)
+		log.Printf("RestoreDB: reopen after restore failed: %v — pre-restore DB kept at %s", err, backupPath)
 		respondError(w, http.StatusInternalServerError,
 			"database restored, but the daemon could not reload it — restart Vault from the plugin page to finish")
 		return
 	}
+
+	// Success — drop the safety copy and temp.
+	if backupExists {
+		_ = os.Remove(backupPath)
+	}
+	_ = os.Remove(tmpPath)
 
 	// The restored DB's sealed passphrase used the old server's vault.key.
 	// Re-seal with the current key so scheduled DB backups stay encrypted.
@@ -789,6 +799,10 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 			log.Printf("RestoreDB: scheduler reload after restore failed: %v", err)
 		}
 	}
+
+	// Flush the restored DB to the cache snapshot + USB shadow now — a power
+	// loss before the next periodic flush would revert the restore at boot.
+	h.notifyConfigChange()
 
 	respondJSON(w, http.StatusOK, map[string]any{
 		"message":  "Database restored successfully.",

--- a/internal/api/handlers/storage.go
+++ b/internal/api/handlers/storage.go
@@ -563,17 +563,9 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, "this backup is encrypted — enter your backup password")
 		return
 	}
-	// When the current DB already has a passphrase hash (restoring over a
-	// live config), check the password before downloading. On a fresh
-	// install there is no hash — the decryption attempt below is the check.
-	if req.Passphrase != "" {
-		if hash, _ := h.db.GetSetting("encryption_passphrase_hash", ""); hash != "" {
-			if crypto.VerifyPassphrase(req.Passphrase, hash) != nil {
-				respondError(w, http.StatusBadRequest, "incorrect passphrase — this is the encryption password from Settings → Encryption")
-				return
-			}
-		}
-	}
+	// No pre-check against the CURRENT db's passphrase hash here: the age
+	// header parse in DecryptReader below is the authoritative check, and a
+	// pre-check would hard-lock restores after a passphrase rotation.
 
 	rc, err := adapter.Read(dbPath)
 	if err != nil {

--- a/internal/api/handlers/storage.go
+++ b/internal/api/handlers/storage.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -745,6 +746,75 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 		"message":  "Database restored successfully.",
 		"resealed": resealed,
 	})
+}
+
+type dbBackupEntry struct {
+	Path      string    `json:"path"`
+	Name      string    `json:"name"`
+	Timestamp time.Time `json:"timestamp"`
+	Size      int64     `json:"size"`
+	Encrypted bool      `json:"encrypted"`
+	IsLatest  bool      `json:"is_latest"`
+}
+
+// ListDBBackups lists vault.db snapshots in _vault/ on a destination,
+// newest first with the latest pointer on top. Absent _vault/ is an empty
+// list, not an error — a destination that never held a DB backup is normal.
+//
+//	GET /api/v1/storage/{id}/db-backups
+func (h *StorageHandler) ListDBBackups(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r, "id")
+	if !ok {
+		return
+	}
+	dest, err := h.db.GetStorageDestination(id)
+	if err != nil {
+		respondError(w, http.StatusNotFound, "storage destination not found")
+		return
+	}
+	adapter, err := storage.NewAdapter(dest.Type, dest.Config)
+	if err != nil {
+		respondInternalError(w, err)
+		return
+	}
+	defer storage.CloseAdapter(adapter)
+
+	files, err := adapter.List("_vault")
+	if err != nil {
+		respondJSON(w, http.StatusOK, []dbBackupEntry{})
+		return
+	}
+
+	entries := []dbBackupEntry{}
+	for _, f := range files {
+		name := path.Base(f.Path)
+		if f.IsDir || !strings.HasPrefix(name, "vault.db.") {
+			continue
+		}
+		e := dbBackupEntry{
+			Path:      "_vault/" + name,
+			Name:      name,
+			Timestamp: f.ModTime,
+			Size:      f.Size,
+			Encrypted: strings.HasSuffix(name, ".age"),
+			IsLatest:  strings.HasPrefix(name, "vault.db.latest"),
+		}
+		if !e.IsLatest {
+			stamp := strings.TrimPrefix(name, "vault.db.")
+			stamp = strings.TrimSuffix(strings.TrimSuffix(stamp, ".age"), ".db")
+			if ts, perr := time.Parse("2006-01-02T15-04-05", stamp); perr == nil {
+				e.Timestamp = ts
+			}
+		}
+		entries = append(entries, e)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].IsLatest != entries[j].IsLatest {
+			return entries[i].IsLatest
+		}
+		return entries[i].Timestamp.After(entries[j].Timestamp)
+	})
+	respondJSON(w, http.StatusOK, entries)
 }
 
 // DependentJobs returns the list of jobs that reference a storage destination

--- a/internal/api/handlers/storage.go
+++ b/internal/api/handlers/storage.go
@@ -728,10 +728,16 @@ func (h *StorageHandler) RestoreDB(w http.ResponseWriter, r *http.Request) {
 	if req.Passphrase != "" && len(h.serverKey) > 0 {
 		if hash, _ := h.db.GetSetting("encryption_passphrase_hash", ""); hash != "" &&
 			crypto.VerifyPassphrase(req.Passphrase, hash) == nil {
-			if sealed, err := crypto.Seal(h.serverKey, req.Passphrase); err == nil {
-				if err := h.db.SetSetting("encryption_passphrase_sealed", sealed); err == nil {
-					resealed = true
-				}
+			sealed, err := crypto.Seal(h.serverKey, req.Passphrase)
+			if err == nil {
+				err = h.db.SetSetting("encryption_passphrase_sealed", sealed)
+			}
+			if err == nil {
+				resealed = true
+			} else {
+				// Not fatal, but future DB backups would use the stale seal
+				// (plaintext fallback) — make the failure findable in logs.
+				log.Printf("RestoreDB: re-sealing passphrase failed: %v", err)
 			}
 		}
 	}

--- a/internal/api/handlers/storage_test.go
+++ b/internal/api/handlers/storage_test.go
@@ -71,7 +71,7 @@ func newDedupStorageHandler(t *testing.T, dedupEnabled bool) (*StorageHandler, i
 		storage.CloseAdapter(adapter)
 	}
 
-	return NewStorageHandler(d, r), destID
+	return NewStorageHandler(d, r, serverKey), destID
 }
 
 // reqWithID is a small helper that attaches an `id` URL parameter to a
@@ -999,7 +999,7 @@ func TestStorageSetConfigChangeHook(t *testing.T) {
 func TestStorageBroadcastConfigChange_NilRunner(t *testing.T) {
 	t.Parallel()
 	// Handler with nil runner should not panic.
-	h := NewStorageHandler(newTestDB(t), nil)
+	h := NewStorageHandler(newTestDB(t), nil, nil)
 	h.broadcastConfigChange("storage") // should not panic
 }
 

--- a/internal/api/handlers/validation_conflict_test.go
+++ b/internal/api/handlers/validation_conflict_test.go
@@ -167,5 +167,5 @@ func newStorageHandlerForTest(t *testing.T) *StorageHandler {
 	hub := ws.NewHub()
 	go hub.Run()
 	r := runner.New(d, hub, bytes.Repeat([]byte{0xcd}, 32))
-	return NewStorageHandler(d, r)
+	return NewStorageHandler(d, r, bytes.Repeat([]byte{0xcd}, 32))
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -114,6 +114,7 @@ func (s *Server) setupRoutes() *chi.Mux {
 			r.Post("/{id}/scan", storageH.Scan)
 			r.Post("/{id}/import", storageH.Import)
 			r.Post("/{id}/restore-db", storageH.RestoreDB)
+			r.Get("/{id}/db-backups", storageH.ListDBBackups)
 			r.Get("/{id}/jobs", storageH.DependentJobs)
 			r.Get("/{id}/list", storageH.ListFiles)
 			r.Get("/{id}/files", storageH.DownloadFile)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -236,6 +236,8 @@ func (s *Server) setupRoutes() *chi.Mux {
 
 		recoveryH := handlers.NewRecoveryHandler(s.db, s.config.Version)
 		r.Get("/recovery/plan", recoveryH.GetPlan)
+		r.Get("/recovery/path-audit", recoveryH.PathAudit)
+		r.Post("/recovery/path-remap", recoveryH.PathRemap)
 
 		// MCP is only available in daemon mode.
 		if !s.config.ReadOnly {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -244,7 +244,11 @@ func (s *Server) setupRoutes() *chi.Mux {
 		recoveryH := handlers.NewRecoveryHandler(s.db, s.config.Version)
 		r.Get("/recovery/plan", recoveryH.GetPlan)
 		r.Get("/recovery/path-audit", recoveryH.PathAudit)
-		r.Post("/recovery/path-remap", recoveryH.PathRemap)
+		if s.config.ReadOnly {
+			r.With(ReadOnlyGuard).Post("/recovery/path-remap", recoveryH.PathRemap)
+		} else {
+			r.Post("/recovery/path-remap", recoveryH.PathRemap)
+		}
 
 		// MCP is only available in daemon mode.
 		if !s.config.ReadOnly {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -86,8 +86,14 @@ func (s *Server) setupRoutes() *chi.Mux {
 			r.Get("/latest", releaseH.Latest)
 		})
 
-		storageH := handlers.NewStorageHandler(s.db, s.runner)
+		storageH := handlers.NewStorageHandler(s.db, s.runner, s.config.ServerKey)
 		s.storageHandler = storageH
+		storageH.SetScheduleReloadHook(func() error {
+			if s.schedReload != nil {
+				return s.schedReload()
+			}
+			return nil
+		})
 		r.Route("/storage", func(r chi.Router) {
 			// Storage CRUD is allowed in replica mode — replicas need
 			// storage destinations configured for replication targets.

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -113,7 +113,13 @@ func (s *Server) setupRoutes() *chi.Mux {
 			r.Post("/{id}/gc", storageH.RunDedupGC)
 			r.Post("/{id}/scan", storageH.Scan)
 			r.Post("/{id}/import", storageH.Import)
-			r.Post("/{id}/restore-db", storageH.RestoreDB)
+			// Restoring the DB is a full-config overwrite — blocked on
+			// replicas like the other write endpoints (see path-remap).
+			if s.config.ReadOnly {
+				r.With(ReadOnlyGuard).Post("/{id}/restore-db", storageH.RestoreDB)
+			} else {
+				r.Post("/{id}/restore-db", storageH.RestoreDB)
+			}
 			r.Get("/{id}/db-backups", storageH.ListDBBackups)
 			r.Get("/{id}/jobs", storageH.DependentJobs)
 			r.Get("/{id}/list", storageH.ListFiles)
@@ -242,6 +248,7 @@ func (s *Server) setupRoutes() *chi.Mux {
 		r.Get("/destinations/{id}/capacity-trajectory", anomalyH.GetTrajectory)
 
 		recoveryH := handlers.NewRecoveryHandler(s.db, s.config.Version)
+		s.recoveryHandler = recoveryH
 		r.Get("/recovery/plan", recoveryH.GetPlan)
 		r.Get("/recovery/path-audit", recoveryH.PathAudit)
 		if s.config.ReadOnly {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -249,6 +249,9 @@ func (s *Server) setupRoutes() *chi.Mux {
 
 		recoveryH := handlers.NewRecoveryHandler(s.db, s.config.Version)
 		s.recoveryHandler = recoveryH
+		// Share the restore lifecycle lock: a path remap must never commit
+		// while restore-db is swapping the database file out from under it.
+		recoveryH.SetMaintenanceLock(storageH.MaintenanceLock())
 		r.Get("/recovery/plan", recoveryH.GetPlan)
 		r.Get("/recovery/path-audit", recoveryH.PathAudit)
 		if s.config.ReadOnly {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -44,6 +44,7 @@ type Server struct {
 	storageHandler     *handlers.StorageHandler
 	replicationHandler *handlers.ReplicationHandler
 	anomalyHandler     *handlers.AnomalyHandler
+	recoveryHandler    *handlers.RecoveryHandler
 
 	// configChangeHook is called after any handler mutates persistent
 	// configuration. It flushes the DB to USB flash.
@@ -126,6 +127,9 @@ func (s *Server) SetConfigChangeHook(fn handlers.ConfigChangeHook) {
 	}
 	if s.replicationHandler != nil {
 		s.replicationHandler.SetConfigChangeHook(fn)
+	}
+	if s.recoveryHandler != nil {
+		s.recoveryHandler.SetConfigChangeHook(fn)
 	}
 }
 

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -171,3 +171,35 @@ func TestUnsealTooShort(t *testing.T) {
 		t.Error("expected too-short error")
 	}
 }
+
+func TestIsWrongPassphrase(t *testing.T) {
+	enc, err := EncryptReader("correct-passphrase", strings.NewReader("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ciphertext, err := io.ReadAll(enc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = enc.Close()
+
+	_, err = DecryptReader("wrong-passphrase", bytes.NewReader(ciphertext))
+	if err == nil {
+		t.Fatal("expected error for wrong passphrase")
+	}
+	if !IsWrongPassphrase(err) {
+		t.Fatalf("expected wrong-passphrase detection, got: %v", err)
+	}
+
+	_, err = DecryptReader("whatever", strings.NewReader("not an age file"))
+	if err == nil {
+		t.Fatal("expected error for garbage input")
+	}
+	if IsWrongPassphrase(err) {
+		t.Fatal("garbage input must not read as wrong passphrase")
+	}
+
+	if IsWrongPassphrase(nil) {
+		t.Fatal("nil must not read as wrong passphrase")
+	}
+}

--- a/internal/crypto/decrypt.go
+++ b/internal/crypto/decrypt.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -26,4 +27,13 @@ func DecryptReader(passphrase string, src io.Reader) (io.ReadCloser, error) {
 	}
 
 	return io.NopCloser(r), nil
+}
+
+// IsWrongPassphrase reports whether err (from DecryptReader) means the
+// supplied passphrase does not match the age file. age returns
+// *NoIdentityMatchError from header parsing, before any payload is read,
+// and DecryptReader wraps it with %w, so errors.As sees through the chain.
+func IsWrongPassphrase(err error) bool {
+	var nim *age.NoIdentityMatchError
+	return errors.As(err, &nim)
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,19 +1,69 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	_ "modernc.org/sqlite"
 )
 
 var ErrNotFound = errors.New("not found")
 
+// DB wraps *sql.DB behind an atomic pointer so Reopen can swap the handle
+// in place without a data race against concurrent queries. All query
+// methods forward to the current handle.
 type DB struct {
-	*sql.DB
-	path string
+	handle atomic.Pointer[sql.DB]
+	path   string
 }
+
+// sql returns the current underlying handle.
+func (d *DB) sql() *sql.DB { return d.handle.Load() }
+
+// Thin forwarders for the *sql.DB methods the codebase calls. They keep
+// every existing call site compiling unchanged now that the handle is no
+// longer an embedded field.
+
+func (d *DB) Exec(query string, args ...any) (sql.Result, error) {
+	return d.sql().Exec(query, args...)
+}
+
+func (d *DB) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return d.sql().ExecContext(ctx, query, args...)
+}
+
+func (d *DB) Query(query string, args ...any) (*sql.Rows, error) {
+	return d.sql().Query(query, args...)
+}
+
+func (d *DB) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return d.sql().QueryContext(ctx, query, args...)
+}
+
+func (d *DB) QueryRow(query string, args ...any) *sql.Row {
+	return d.sql().QueryRow(query, args...)
+}
+
+func (d *DB) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return d.sql().QueryRowContext(ctx, query, args...)
+}
+
+func (d *DB) Begin() (*sql.Tx, error) { return d.sql().Begin() }
+
+func (d *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	return d.sql().BeginTx(ctx, opts)
+}
+
+func (d *DB) Ping() error { return d.sql().Ping() }
+
+func (d *DB) PingContext(ctx context.Context) error { return d.sql().PingContext(ctx) }
+
+func (d *DB) Conn(ctx context.Context) (*sql.Conn, error) { return d.sql().Conn(ctx) }
+
+func (d *DB) Close() error { return d.sql().Close() }
 
 // Path returns the filesystem path of the database.
 func (d *DB) Path() string {
@@ -58,7 +108,8 @@ func Open(path string) (*DB, error) {
 		_, _ = sqlDB.Exec(m) //nolint:errcheck // duplicate column errors expected
 	}
 
-	d := &DB{DB: sqlDB, path: path}
+	d := &DB{path: path}
+	d.handle.Store(sqlDB)
 	if err := d.insertDefaultSettings(); err != nil {
 		_ = sqlDB.Close()
 		return nil, fmt.Errorf("seed default settings: %w", err)
@@ -66,20 +117,25 @@ func Open(path string) (*DB, error) {
 	return d, nil
 }
 
-// Reopen re-opens the database at the same path and swaps the embedded
-// handle in place. Every component (server, scheduler, runner, hub) shares
-// this *DB pointer, so after Reopen they all see the new database. Used
-// after RestoreDB swaps the file on disk, so the daemon keeps running
-// without a restart.
-// ponytail: the Close→Reopen window can surface "database is closed" errors
-// to concurrent queries — an availability blip during deliberate maintenance,
-// not corruption. Fallback if this misbehaves in practice: a restart endpoint.
+// Reopen re-opens the database at the same path and atomically swaps the
+// underlying handle in place. Every component (server, scheduler, runner,
+// hub) shares this *DB pointer, so after Reopen they all see the new
+// database. Used after RestoreDB swaps the file on disk, so the daemon
+// keeps running without a restart.
+// ponytail: concurrent queries during the Close→Reopen window can still see
+// transient "database is closed" errors — an availability blip during
+// deliberate maintenance, not corruption and not a data race (the swap is
+// atomic). Fallback if this misbehaves in practice: a restart endpoint.
 func (d *DB) Reopen() error {
 	nd, err := Open(d.path)
 	if err != nil {
 		return fmt.Errorf("reopening database: %w", err)
 	}
-	d.DB = nd.DB
+	// Close the old handle; sql.DB.Close is idempotent, so this is safe
+	// even when the caller (restore flow) already closed it.
+	if old := d.handle.Swap(nd.handle.Load()); old != nil {
+		_ = old.Close()
+	}
 	return nil
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -66,6 +66,23 @@ func Open(path string) (*DB, error) {
 	return d, nil
 }
 
+// Reopen re-opens the database at the same path and swaps the embedded
+// handle in place. Every component (server, scheduler, runner, hub) shares
+// this *DB pointer, so after Reopen they all see the new database. Used
+// after RestoreDB swaps the file on disk, so the daemon keeps running
+// without a restart.
+// ponytail: the Close→Reopen window can surface "database is closed" errors
+// to concurrent queries — an availability blip during deliberate maintenance,
+// not corruption. Fallback if this misbehaves in practice: a restart endpoint.
+func (d *DB) Reopen() error {
+	nd, err := Open(d.path)
+	if err != nil {
+		return fmt.Errorf("reopening database: %w", err)
+	}
+	d.DB = nd.DB
+	return nil
+}
+
 // Vacuum reclaims free space in the database file.
 func (d *DB) Vacuum() error {
 	_, err := d.Exec("VACUUM")

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 	"sync/atomic"
 
 	_ "modernc.org/sqlite"
@@ -76,6 +77,8 @@ func Open(path string) (*DB, error) {
 	// params were silently ignored, leaving fresh databases in rollback
 	// journal mode with no busy timeout. DSN pragmas apply to every
 	// connection database/sql opens, unlike a one-off Exec.
+	// journal_size_limit bounds how large the WAL file stays after
+	// checkpoints; it can still grow past it during long transactions.
 	sqlDB, err := sql.Open("sqlite", path+"?_txlock=immediate"+
 		"&_pragma=busy_timeout(30000)"+
 		"&_pragma=journal_mode(WAL)"+
@@ -94,8 +97,13 @@ func Open(path string) (*DB, error) {
 		return nil, fmt.Errorf("ping database: %w", err)
 	}
 
-	// foreign_keys and journal_size_limit (64 MiB WAL cap) are set via DSN
-	// pragmas above so they survive connection recreation by database/sql.
+	// The journal_mode pragma reports the resulting mode instead of erroring
+	// when WAL can't be enabled (e.g. a filesystem without shared-memory
+	// support), and the driver discards that result — so check explicitly.
+	var mode string
+	if err := sqlDB.QueryRow("PRAGMA journal_mode").Scan(&mode); err == nil && mode != "wal" {
+		log.Printf("Warning: database %s runs in journal_mode=%s — WAL is unavailable on this filesystem; access under contention will be slower", path, mode)
+	}
 
 	if _, err := sqlDB.Exec(schema); err != nil {
 		_ = sqlDB.Close()

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -71,7 +71,16 @@ func (d *DB) Path() string {
 }
 
 func Open(path string) (*DB, error) {
-	sqlDB, err := sql.Open("sqlite", path+"?_journal_mode=WAL&_busy_timeout=30000&_txlock=immediate")
+	// modernc.org/sqlite only understands the _pragma=name(value) DSN form
+	// (plus _txlock/_time_format). The old _journal_mode=/_busy_timeout=
+	// params were silently ignored, leaving fresh databases in rollback
+	// journal mode with no busy timeout. DSN pragmas apply to every
+	// connection database/sql opens, unlike a one-off Exec.
+	sqlDB, err := sql.Open("sqlite", path+"?_txlock=immediate"+
+		"&_pragma=busy_timeout(30000)"+
+		"&_pragma=journal_mode(WAL)"+
+		"&_pragma=foreign_keys(ON)"+
+		"&_pragma=journal_size_limit(67108864)")
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
@@ -85,18 +94,8 @@ func Open(path string) (*DB, error) {
 		return nil, fmt.Errorf("ping database: %w", err)
 	}
 
-	if _, err := sqlDB.Exec("PRAGMA foreign_keys = ON"); err != nil {
-		_ = sqlDB.Close()
-		return nil, fmt.Errorf("enable foreign keys: %w", err)
-	}
-
-	// Bound the WAL file size between checkpoints so a write burst does
-	// not leave a permanently-large WAL on disk. 64 MiB is comfortable
-	// for Vault's write rate.
-	if _, err := sqlDB.Exec(`PRAGMA journal_size_limit = 67108864`); err != nil {
-		_ = sqlDB.Close()
-		return nil, fmt.Errorf("setting journal_size_limit: %w", err)
-	}
+	// foreign_keys and journal_size_limit (64 MiB WAL cap) are set via DSN
+	// pragmas above so they survive connection recreation by database/sql.
 
 	if _, err := sqlDB.Exec(schema); err != nil {
 		_ = sqlDB.Close()

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -129,8 +129,8 @@ func Open(path string) (*DB, error) {
 // hub) shares this *DB pointer, so after Reopen they all see the new
 // database. Used after RestoreDB swaps the file on disk, so the daemon
 // keeps running without a restart.
-// ponytail: concurrent queries during the Close→Reopen window can still see
-// transient "database is closed" errors — an availability blip during
+// Known limitation: concurrent queries during the Close→Reopen window can
+// see transient "database is closed" errors — an availability blip during
 // deliberate maintenance, not corruption and not a data race (the swap is
 // atomic). Fallback if this misbehaves in practice: a restart endpoint.
 func (d *DB) Reopen() error {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -146,18 +146,32 @@ func TestReopenConcurrentAccess(t *testing.T) {
 	}
 	defer d.Close()
 
+	// The reader loops until stopped rather than a fixed count: each Reopen
+	// takes long enough (schema migrations) that a bounded reader would
+	// finish before the first swap and never exercise the race window.
+	stop := make(chan struct{})
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		for i := 0; i < 50; i++ {
-			_, _ = d.GetSetting("reopen_marker", "")
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_, _ = d.GetSetting("reopen_marker", "")
+			}
 		}
 	}()
 	for i := 0; i < 10; i++ {
+		// Close first, as the real restore flow does. Skipping the Close
+		// leaves the reader's connection holding a read lock on the file,
+		// and Reopen's schema writes then fail with SQLITE_BUSY.
+		_ = d.Close()
 		if err := d.Reopen(); err != nil {
 			t.Fatalf("Reopen #%d: %v", i, err)
 		}
 	}
+	close(stop)
 	<-done
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -78,6 +78,58 @@ func TestDedupSchemaMigration(t *testing.T) {
 	}
 }
 
+// TestReopen verifies that Reopen() swaps the embedded *sql.DB handle in
+// place after Close(), so the same *DB pointer works again and sees data
+// written before the close. This mirrors the restore-db handler flow: close,
+// swap the file on disk, reopen — all without restarting the daemon.
+func TestReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vault.db")
+	d, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.SetSetting("reopen_marker", "1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Reopen(); err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	got, err := d.GetSetting("reopen_marker", "")
+	if err != nil {
+		t.Fatalf("query after reopen: %v", err)
+	}
+	if got != "1" {
+		t.Fatalf("marker = %q, want 1", got)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestReopenError verifies that Reopen() returns an error when the
+// database path is no longer openable (e.g. its parent directory was
+// removed).
+func TestReopenError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vault.db")
+	d, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Reopen(); err == nil {
+		t.Fatal("Reopen() error = nil, want error for missing directory")
+	}
+}
+
 // columnExists returns true if the named column is present on the
 // given table according to PRAGMA table_info.
 func columnExists(t *testing.T, d *DB, table, column string) bool {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -78,22 +78,46 @@ func TestDedupSchemaMigration(t *testing.T) {
 	}
 }
 
-// TestReopen verifies that Reopen() swaps the embedded *sql.DB handle in
-// place after Close(), so the same *DB pointer works again and sees data
-// written before the close. This mirrors the restore-db handler flow: close,
-// swap the file on disk, reopen — all without restarting the daemon.
+// TestReopen mirrors the real restore-db flow: close the handle, swap a
+// DIFFERENT valid database file over the same path (removing stale WAL/SHM
+// sidecars), then Reopen and verify the same *DB pointer sees the NEW
+// file's data — all without restarting the daemon.
 func TestReopen(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "vault.db")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vault.db")
 	d, err := Open(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := d.SetSetting("reopen_marker", "1"); err != nil {
+	if err := d.SetSetting("reopen_marker", "old"); err != nil {
 		t.Fatal(err)
 	}
 	if err := d.Close(); err != nil {
 		t.Fatal(err)
 	}
+
+	// Build a second, different database and swap it over the same path,
+	// as the restore handler does after downloading a snapshot.
+	otherPath := filepath.Join(dir, "restored.db")
+	other, err := Open(otherPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := other.SetSetting("reopen_marker", "new"); err != nil {
+		t.Fatal(err)
+	}
+	if err := other.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for _, sidecar := range []string{path + "-wal", path + "-shm"} {
+		if err := os.Remove(sidecar); err != nil && !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Rename(otherPath, path); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := d.Reopen(); err != nil {
 		t.Fatalf("Reopen: %v", err)
 	}
@@ -101,12 +125,40 @@ func TestReopen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("query after reopen: %v", err)
 	}
-	if got != "1" {
-		t.Fatalf("marker = %q, want 1", got)
+	if got != "new" {
+		t.Fatalf("marker = %q, want %q (swapped-in file's data)", got, "new")
 	}
 	if err := d.Close(); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// TestReopenConcurrentAccess is a race-detector regression test: queries on
+// the shared *DB must not race with Reopen's handle swap. Readers may see
+// transient "database is closed" errors mid-swap — that is the documented
+// availability blip and is deliberately ignored; the test only guards
+// against memory-model violations (meaningful under -race).
+func TestReopenConcurrentAccess(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vault.db")
+	d, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 50; i++ {
+			_, _ = d.GetSetting("reopen_marker", "")
+		}
+	}()
+	for i := 0; i < 10; i++ {
+		if err := d.Reopen(); err != nil {
+			t.Fatalf("Reopen #%d: %v", i, err)
+		}
+	}
+	<-done
 }
 
 // TestReopenError verifies that Reopen() returns an error when the

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -223,3 +223,43 @@ func columnExists(t *testing.T, d *DB, table, column string) bool {
 	}
 	return false
 }
+
+func TestConnectionPragmas(t *testing.T) {
+	d, err := Open(filepath.Join(t.TempDir(), "vault.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	var busy int
+	if err := d.QueryRow("PRAGMA busy_timeout").Scan(&busy); err != nil {
+		t.Fatal(err)
+	}
+	if busy != 30000 {
+		t.Errorf("busy_timeout = %d, want 30000", busy)
+	}
+
+	var mode string
+	if err := d.QueryRow("PRAGMA journal_mode").Scan(&mode); err != nil {
+		t.Fatal(err)
+	}
+	if mode != "wal" {
+		t.Errorf("journal_mode = %q, want wal (fresh DBs must not run in rollback mode)", mode)
+	}
+
+	var fk int
+	if err := d.QueryRow("PRAGMA foreign_keys").Scan(&fk); err != nil {
+		t.Fatal(err)
+	}
+	if fk != 1 {
+		t.Errorf("foreign_keys = %d, want 1", fk)
+	}
+
+	var jsl int
+	if err := d.QueryRow("PRAGMA journal_size_limit").Scan(&jsl); err != nil {
+		t.Fatal(err)
+	}
+	if jsl != 67108864 {
+		t.Errorf("journal_size_limit = %d, want 67108864", jsl)
+	}
+}

--- a/internal/db/job_repo.go
+++ b/internal/db/job_repo.go
@@ -204,6 +204,19 @@ func (d *DB) GetJobItems(jobID int64) ([]JobItem, error) {
 	return items, rows.Err()
 }
 
+// UpdateJobItemSettings replaces the settings JSON of one job item. Used by
+// the DR path-remap endpoint; there is deliberately no full UpdateJobItem.
+func (d *DB) UpdateJobItemSettings(id int64, settings string) error {
+	res, err := d.Exec(`UPDATE job_items SET settings = ? WHERE id = ?`, settings, id)
+	if err != nil {
+		return fmt.Errorf("updating job item settings: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (d *DB) DeleteJobItems(jobID int64) error {
 	_, err := d.Exec("DELETE FROM job_items WHERE job_id = ?", jobID)
 	return err

--- a/internal/db/job_repo_test.go
+++ b/internal/db/job_repo_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -642,5 +643,31 @@ func TestPurgeEligibleRuns(t *testing.T) {
 	}
 	if n, _ := d.PurgeEligibleRuns(0); n != 0 {
 		t.Errorf("keepDays=0 purged %d, want 0", n)
+	}
+}
+
+func TestUpdateJobItemSettings(t *testing.T) {
+	d := setupTestDB(t)
+	destID, _ := d.CreateStorageDestination(StorageDestination{Name: "settings-dest", Type: "local", Config: "{}"})
+	jobID, err := d.CreateJob(Job{Name: "settings-job", StorageDestID: destID, BackupTypeChain: "full"})
+	if err != nil {
+		t.Fatalf("CreateJob error = %v", err)
+	}
+	itemID, err := d.AddJobItem(JobItem{JobID: jobID, ItemType: "folder", ItemName: "docs", ItemID: "docs", Settings: `{"path":"/old/path"}`})
+	if err != nil {
+		t.Fatalf("AddJobItem error = %v", err)
+	}
+	if err := d.UpdateJobItemSettings(itemID, `{"path":"/new/path"}`); err != nil {
+		t.Fatalf("UpdateJobItemSettings error = %v", err)
+	}
+	items, err := d.GetJobItems(jobID)
+	if err != nil {
+		t.Fatalf("GetJobItems error = %v", err)
+	}
+	if len(items) != 1 || items[0].Settings != `{"path":"/new/path"}` {
+		t.Fatalf("settings = %+v", items)
+	}
+	if err := d.UpdateJobItemSettings(999999, `{}`); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
 	}
 }

--- a/internal/db/snapshot.go
+++ b/internal/db/snapshot.go
@@ -198,7 +198,7 @@ func (sm *SnapshotManager) SaveSnapshot() error {
 	// path. Failure is logged but does not block the snapshot — the
 	// Online Backup API copies WAL frames correctly even without an
 	// explicit checkpoint.
-	if conn, cerr := sm.db.DB.Conn(context.Background()); cerr == nil {
+	if conn, cerr := sm.db.Conn(context.Background()); cerr == nil {
 		if _, ckErr := conn.ExecContext(context.Background(), `PRAGMA wal_checkpoint(TRUNCATE)`); ckErr != nil {
 			log.Printf("snapshot: wal_checkpoint(TRUNCATE) failed: %v (continuing)", ckErr)
 		}
@@ -337,7 +337,7 @@ func (sm *SnapshotManager) backupWorkingDBToPath(dest string) error {
 	tmp := dest + ".tmp"
 	_ = os.Remove(tmp)
 
-	conn, err := sm.db.DB.Conn(context.Background())
+	conn, err := sm.db.Conn(context.Background())
 	if err != nil {
 		return fmt.Errorf("acquire connection: %w", err)
 	}
@@ -395,7 +395,7 @@ func (sm *SnapshotManager) RestoreFromSnapshot() error {
 		return nil
 	}
 
-	conn, err := sm.db.DB.Conn(context.Background())
+	conn, err := sm.db.Conn(context.Background())
 	if err != nil {
 		return fmt.Errorf("acquire connection: %w", err)
 	}
@@ -535,7 +535,7 @@ func (sm *SnapshotManager) RestoreFromPath(sourcePath string) error {
 		return fmt.Errorf("snapshot file does not exist: %s", validPath)
 	}
 
-	conn, err := sm.db.DB.Conn(context.Background())
+	conn, err := sm.db.Conn(context.Background())
 	if err != nil {
 		return fmt.Errorf("acquire connection: %w", err)
 	}

--- a/internal/db/validation.go
+++ b/internal/db/validation.go
@@ -33,7 +33,7 @@ func (d *DB) ValidateHasConfiguration(ctx context.Context) (*ConfigurationSummar
 
 	count := func(table string) (int, error) {
 		var n int
-		row := d.DB.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table)) // #nosec G201 — table names are compile-time constants below
+		row := d.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table)) // #nosec G201 — table names are compile-time constants below
 		if err := row.Scan(&n); err != nil {
 			return 0, fmt.Errorf("counting %s: %w", table, err)
 		}

--- a/internal/runner/db_backup.go
+++ b/internal/runner/db_backup.go
@@ -45,7 +45,7 @@ func (r *Runner) backupDatabase(ctx context.Context, jobDest db.StorageDestinati
 	// it byte-by-byte. Best-effort: a busy checkpoint is fine, the file is
 	// still readable via SQLite's recovery on the destination side, just
 	// slightly larger.
-	if conn, err := r.db.DB.Conn(context.Background()); err == nil {
+	if conn, err := r.db.Conn(context.Background()); err == nil {
 		if _, ckErr := conn.ExecContext(context.Background(), `PRAGMA wal_checkpoint(TRUNCATE)`); ckErr != nil {
 			log.Printf("db_backup: wal_checkpoint failed: %v (continuing)", ckErr)
 		}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,12 +42,12 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
-  - How Backup Works: how-backup-works.md
   - Guides:
       - Backup Jobs: guides/backup-jobs.md
       - Storage Destinations: guides/storage-destinations.md
       - Anomaly Detection: guides/anomaly-detection.md
       - Disaster Recovery: guides/disaster-recovery.md
+  - How Backup Works: how-backup-works.md
   - Settings Reference:
       - App / Daemon Settings: reference/app-settings.md
       - Job Configuration: reference/job-config.md
@@ -62,5 +62,5 @@ nav:
   - API & MCP:
       - REST API: api.md
       - MCP Server: mcp.md
-  - Changelog: changelog.md
   - FAQ: faq.md
+  - Changelog: changelog.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Backup Jobs: guides/backup-jobs.md
       - Storage Destinations: guides/storage-destinations.md
       - Anomaly Detection: guides/anomaly-detection.md
+      - Disaster Recovery: guides/disaster-recovery.md
   - Settings Reference:
       - App / Daemon Settings: reference/app-settings.md
       - Job Configuration: reference/job-config.md

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -15,6 +15,7 @@
   import Settings from './pages/Settings.svelte'
   import Replication from './pages/Replication.svelte'
   import Recovery from './pages/Recovery.svelte'
+  import RecoverWizard from './pages/RecoverWizard.svelte'
   import Anomalies from './pages/Anomalies.svelte'
   import Spinner from './components/Spinner.svelte'
   import CommandPalette from './components/CommandPalette.svelte'
@@ -240,6 +241,8 @@
         <Replication />
       {:else if getRoute() === '/recovery'}
         <Recovery />
+      {:else if getRoute() === '/recover'}
+        <RecoverWizard />
       {:else if getRoute() === '/anomalies'}
         <Anomalies />
       {:else if getRoute() === '/settings'}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -88,6 +88,7 @@
     const route = getRoute()
     if (route === '/anomalies' && !getAnomalyEnabled()) navigate('/')
     else if (route === '/replication' && !replicaMode && !getReplicationEnabled()) navigate('/')
+    else if (route === '/recover' && replicaMode) navigate('/')
   })
 
   let ready = $state(false)

--- a/web/src/components/StorageForm.svelte
+++ b/web/src/components/StorageForm.svelte
@@ -42,9 +42,11 @@
 
   // `initial` is deliberately read once at mount: the host remounts this
   // component each time the modal opens, so the form never needs to track
-  // later changes to the prop.
+  // later changes to the prop. Consumers that can change `initial` while the
+  // component stays mounted must remount it instead (wrap in {#key}).
   // svelte-ignore state_referenced_locally
-  let form = $state(initForm(initial))
+  const init = initial
+  let form = $state(initForm(init))
   let saving = $state(false)
 
   async function saveStorage() {
@@ -64,8 +66,8 @@
         backup_database_enabled: !!form.backup_database_enabled,
       }
       let result
-      if (initial) {
-        result = await api.updateStorage(initial.id, payload)
+      if (init) {
+        result = await api.updateStorage(init.id, payload)
       } else {
         result = await api.createStorage(payload)
       }
@@ -455,7 +457,7 @@
       <input
         type="checkbox"
         bind:checked={form.dedup_enabled}
-        disabled={initial !== null}
+        disabled={init !== null}
         class="accent-vault mt-1"
       />
       <span class="flex-1">
@@ -463,7 +465,7 @@
         <span class="block text-xs text-text-muted mt-0.5">
           Stores only changed data blocks across snapshots and jobs targeting this destination. Recommended for backups containing similar data (Immich, Nextcloud, container volumes). <strong>Cannot be changed after creating the destination.</strong>
         </span>
-        {#if initial !== null}
+        {#if init !== null}
           <span class="block text-xs text-warning mt-1 italic">
             Dedup mode is locked at creation time. Create a new destination to switch.
           </span>

--- a/web/src/components/StorageForm.svelte
+++ b/web/src/components/StorageForm.svelte
@@ -1,0 +1,503 @@
+<script>
+  import { api } from '../lib/api.js'
+  import { parseConfig } from '../lib/utils.js'
+  import PathBrowser from './PathBrowser.svelte'
+  import Tooltip from './Tooltip.svelte'
+
+  let {
+    initial = null, // existing destination object when editing, null when adding
+    submitLabel = 'Add Storage',
+    onsaved = () => {}, // called with the created/updated destination
+    oncancel = () => {},
+    ontoast = () => {}, // (message, type) — routed to the host page's Toast
+  } = $props()
+
+  function defaultForm() {
+    return {
+      name: '',
+      type: 'local',
+      config: { path: '' },
+      dedup_enabled: false,
+    }
+  }
+
+  function initForm(dest) {
+    if (!dest) return defaultForm()
+    const cfg = parseConfig(dest.config)
+    // Migrate legacy "path" → "base_path" for SFTP/SMB configs.
+    if ((dest.type === 'sftp' || dest.type === 'smb') && cfg.base_path === undefined) {
+      cfg.base_path = cfg.path ?? ''
+    }
+    return {
+      name: dest.name,
+      type: dest.type,
+      config: cfg,
+      dedup_enabled: !!dest.dedup_enabled,
+      // Carry the DB-backup fan-out flag through the modal save so editing
+      // an unrelated field doesn't reset it. The dedicated row toggle on
+      // the card is still the primary control.
+      backup_database_enabled: !!dest.backup_database_enabled,
+    }
+  }
+
+  // `initial` is deliberately read once at mount: the host remounts this
+  // component each time the modal opens, so the form never needs to track
+  // later changes to the prop.
+  // svelte-ignore state_referenced_locally
+  let form = $state(initForm(initial))
+  let saving = $state(false)
+
+  async function saveStorage() {
+    if (saving) return
+    saving = true
+    try {
+      const payload = {
+        name: form.name,
+        type: form.type,
+        config: JSON.stringify(form.config),
+        // Top-level: stored as its own column on storage_destinations.
+        // Immutable after creation (UI gates the toggle when editing).
+        dedup_enabled: !!form.dedup_enabled,
+        // Preserve the current DB fan-out value through modal saves so
+        // editing other fields doesn't accidentally disable it. New
+        // destinations default to false.
+        backup_database_enabled: !!form.backup_database_enabled,
+      }
+      let result
+      if (initial) {
+        result = await api.updateStorage(initial.id, payload)
+      } else {
+        result = await api.createStorage(payload)
+      }
+      onsaved(result)
+    } catch (e) {
+      ontoast(e.message, 'error')
+    } finally {
+      saving = false
+    }
+  }
+
+  function applyType(nextType) {
+    const defaults = {
+      local: { path: '' },
+      sftp: { host: '', port: 22, user: '', password: '', base_path: '', bandwidth_limit_mbps: 0 },
+      smb: { host: '', share: '', user: '', password: '', base_path: '', bandwidth_limit_mbps: 0 },
+      nfs: { host: '', export: '', base_path: '', version: '4', options: '', bandwidth_limit_mbps: 0 },
+      webdav: { url: '', username: '', password: '', base_path: '', insecure_skip_verify: false, timeout_seconds: 0, stall_timeout_seconds: 300, chunk_size_mb: 0, bandwidth_limit_mbps: 0 },
+      s3: { bucket: '', region: '', access_key: '', secret_key: '', endpoint: '', base_path: '', force_path_style: false, upload_timeout_minutes: 0, part_size_mb: 0, bandwidth_limit_mbps: 0 },
+    }
+    // Reassign the full form object so Svelte always re-renders the keyed
+    // config block when switching destination type.
+    form = {
+      ...form,
+      type: nextType,
+      config: defaults[nextType] || {},
+    }
+    formTestResult = null
+  }
+
+  // Backend types offered in the add/edit picker (issue #206 / E8).
+  const storageTypes = [
+    { value: 'local', label: 'Local Path' },
+    { value: 'sftp', label: 'SFTP' },
+    { value: 'smb', label: 'SMB / CIFS' },
+    { value: 'nfs', label: 'NFS' },
+    { value: 'webdav', label: 'WebDAV' },
+    { value: 's3', label: 'S3 / S3-Compatible' },
+  ]
+
+  // Quick-select S3 providers — prefill endpoint/region hints. Placeholders with
+  // <angle-brackets> mark values the user must fill in (account-specific hosts).
+  const s3Presets = [
+    { label: 'AWS S3', endpoint: '', region: 'us-east-1', forcePathStyle: false },
+    { label: 'Backblaze B2', endpoint: 'https://s3.us-west-002.backblazeb2.com', region: 'us-west-002', forcePathStyle: false },
+    { label: 'Cloudflare R2', endpoint: 'https://<accountid>.r2.cloudflarestorage.com', region: 'auto', forcePathStyle: false },
+    { label: 'Wasabi', endpoint: 'https://s3.wasabisys.com', region: 'us-east-1', forcePathStyle: false },
+    { label: 'MinIO', endpoint: 'http://<host>:9000', region: 'us-east-1', forcePathStyle: true },
+    { label: 'IDrive E2', endpoint: 'https://<region>.idrivee2-XX.com', region: 'us-east-1', forcePathStyle: false },
+    { label: 'MEGA S4', endpoint: 'https://s3.g.s4.mega.io', region: 'g', forcePathStyle: false },
+  ]
+  function applyS3Preset(p) {
+    form.config = { ...form.config, endpoint: p.endpoint, region: p.region, force_path_style: p.forcePathStyle }
+    formTestResult = null
+  }
+
+  // Test the current (unsaved) form config before saving.
+  let formTesting = $state(false)
+  /** @type {{ success: boolean, error?: string } | null} */
+  let formTestResult = $state(null)
+  // A test result only describes the config it ran against — invalidate it as
+  // soon as any config field changes so a stale "Connection OK" can't linger.
+  // Tracks form.config only (not formTesting), so completing a test — which
+  // doesn't mutate config — never re-runs this and wipes the fresh result.
+  $effect(() => {
+    JSON.stringify(form.config) // track all nested config fields
+    formTestResult = null
+  })
+  async function testFormConnection() {
+    formTesting = true
+    formTestResult = null
+    // Snapshot the config under test so a result that lands after the user has
+    // since edited the form is dropped, rather than showing a stale result for
+    // the old config (the invalidation $effect can't undo an in-flight test).
+    const testedKey = JSON.stringify({ type: form.type, config: form.config })
+    const isStale = () => JSON.stringify({ type: form.type, config: form.config }) !== testedKey
+    try {
+      const result = await api.testStorageConfig({ type: form.type, config: JSON.stringify(form.config) })
+      if (isStale()) return
+      formTestResult = result
+      ontoast(result.success ? 'Connection successful!' : `Connection failed: ${result.error || 'unknown error'}`, result.success ? 'success' : 'error')
+    } catch (e) {
+      if (isStale()) return
+      const msg = e?.message || 'Connection test failed'
+      formTestResult = { success: false, error: msg }
+      ontoast(msg, 'error')
+    } finally {
+      formTesting = false
+    }
+  }
+
+  const storageIcons = {
+    local: 'M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z',
+    sftp: 'M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z',
+    smb: 'M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z',
+    nfs: 'M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z',
+    webdav: 'M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z',
+    s3: 'M5 19a2 2 0 01-2-2V7a2 2 0 012-2h3.586a1 1 0 01.707.293l1.414 1.414A1 1 0 0011.414 7H19a2 2 0 012 2v8a2 2 0 01-2 2H5z',
+  }
+
+  const storageColors = {
+    local: 'text-blue-400',
+    sftp: 'text-emerald-400',
+    smb: 'text-purple-400',
+    nfs: 'text-amber-400',
+    webdav: 'text-cyan-400',
+    s3: 'text-orange-400',
+  }
+</script>
+
+<form onsubmit={(e) => { e.preventDefault(); saveStorage() }} class="space-y-5">
+  <div>
+    <label for="sname" class="block text-sm font-medium text-text-muted mb-1.5">Name</label>
+    <input id="sname" type="text" bind:value={form.name} required
+      class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" placeholder="My Backup Target" />
+  </div>
+
+  <div>
+    <span class="block text-sm font-medium text-text-muted mb-1.5">Type</span>
+    <div role="group" aria-label="Storage type" class="grid grid-cols-2 sm:grid-cols-3 gap-2">
+      {#each storageTypes as t (t.value)}
+        <button type="button" aria-pressed={form.type === t.value}
+          onclick={() => applyType(t.value)}
+          class="flex items-center gap-2 px-3 py-2.5 rounded-lg border text-sm text-left transition-colors
+            {form.type === t.value ? 'border-vault bg-vault/10 text-text' : 'border-border bg-surface-3 text-text-muted hover:border-border-hover hover:text-text'}">
+          <svg aria-hidden="true" class="w-5 h-5 shrink-0 {storageColors[t.value] || 'text-text-muted'}" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d={storageIcons[t.value]}/></svg>
+          <span class="font-medium truncate">{t.label}</span>
+        </button>
+      {/each}
+    </div>
+  </div>
+
+  <!-- Dynamic config fields per type -->
+  {#key form.type}
+  {#if form.type === 'local'}
+    <div>
+      <span class="block text-sm font-medium text-text-muted mb-1.5">Path</span>
+      <PathBrowser bind:value={form.config.path} />
+    </div>
+  {:else if form.type === 'sftp'}
+    <div class="grid grid-cols-3 gap-3">
+      <div class="col-span-2">
+        <label for="cfg_host" class="block text-sm font-medium text-text-muted mb-1.5">Host</label>
+        <input id="cfg_host" type="text" bind:value={form.config.host}
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" placeholder="192.168.1.100" />
+      </div>
+      <div>
+        <label for="cfg_port" class="block text-sm font-medium text-text-muted mb-1.5">Port</label>
+        <input id="cfg_port" type="number" min="1" max="65535" bind:value={form.config.port}
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text" placeholder="22" />
+      </div>
+    </div>
+    <div class="grid grid-cols-2 gap-3">
+      <div>
+        <label for="cfg_user" class="block text-sm font-medium text-text-muted mb-1.5">Username</label>
+        <input id="cfg_user" type="text" bind:value={form.config.user}
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+      </div>
+      <div>
+        <label for="cfg_pass" class="block text-sm font-medium text-text-muted mb-1.5">Password</label>
+        <input id="cfg_pass" type="password" autocomplete="off" bind:value={form.config.password}
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+      </div>
+    </div>
+    <div>
+      <label for="cfg_spath" class="block text-sm font-medium text-text-muted mb-1.5">Remote Path <Tooltip text="Absolute path on the SFTP server where Vault will store backups. The directory must exist and the user must have write permission." /></label>
+      <input id="cfg_spath" type="text" bind:value={form.config.base_path}
+        class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text font-mono placeholder-text-dim" placeholder="/backups/vault" />
+    </div>
+  {:else if form.type === 'smb'}
+    <div class="grid grid-cols-2 gap-3">
+      <div>
+        <label for="cfg_smbhost" class="block text-sm font-medium text-text-muted mb-1.5">Host</label>
+        <input id="cfg_smbhost" type="text" bind:value={form.config.host}
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" placeholder="192.168.1.100" />
+      </div>
+      <div>
+        <label for="cfg_share" class="block text-sm font-medium text-text-muted mb-1.5">Share <Tooltip text="The top-level SMB share name as configured on the server (e.g. Backups). Use the Path field below for a sub-folder within the share." /></label>
+        <input id="cfg_share" type="text" bind:value={form.config.share}
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" placeholder="Backups" />
+      </div>
+    </div>
+    <div class="grid grid-cols-2 gap-3">
+      <div>
+        <label for="cfg_smbuser" class="block text-sm font-medium text-text-muted mb-1.5">Username</label>
+        <input id="cfg_smbuser" type="text" bind:value={form.config.user}
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+      </div>
+      <div>
+        <label for="cfg_smbpass" class="block text-sm font-medium text-text-muted mb-1.5">Password</label>
+        <input id="cfg_smbpass" type="password" autocomplete="off" bind:value={form.config.password}
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+      </div>
+    </div>
+    <div>
+      <label for="cfg_smbpath" class="block text-sm font-medium text-text-muted mb-1.5">Path</label>
+      <input id="cfg_smbpath" type="text" bind:value={form.config.base_path}
+        class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text font-mono placeholder-text-dim" placeholder="vault" />
+    </div>
+  {:else if form.type === 'nfs'}
+    <div class="grid grid-cols-2 gap-3">
+      <div class="col-span-2">
+        <label for="nfs_host" class="block text-sm font-medium text-text-muted mb-1.5">NFS Host</label>
+        <input id="nfs_host" type="text" bind:value={form.config.host} placeholder="192.168.1.100"
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+      </div>
+      <div class="col-span-2">
+        <label for="nfs_export" class="block text-sm font-medium text-text-muted mb-1.5">Export Path <Tooltip text="The path the NFS server exports – matches the entry in /etc/exports on the server (e.g. /mnt/user/backups). This is what gets mounted, not a sub-path within it." /></label>
+        <input id="nfs_export" type="text" bind:value={form.config.export} placeholder="/mnt/user/backups"
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+      </div>
+      <div>
+        <label for="nfs_base" class="block text-sm font-medium text-text-muted mb-1.5">Base Path <Tooltip text="Optional sub-directory within the mounted export where Vault will write its data. Leave blank to use the export root directly." /></label>
+        <input id="nfs_base" type="text" bind:value={form.config.base_path} placeholder="vault"
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+      </div>
+      <div>
+        <label for="nfs_version" class="block text-sm font-medium text-text-muted mb-1.5">NFS Version <Tooltip text="NFSv3: wider compatibility, simpler setup. NFSv4: better security and performance, but may require DNS and auth configuration." /></label>
+        <select id="nfs_version" bind:value={form.config.version}
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text">
+          <option value="3">NFSv3</option>
+          <option value="4">NFSv4</option>
+        </select>
+      </div>
+      <div class="col-span-2">
+        <label for="nfs_options" class="block text-sm font-medium text-text-muted mb-1.5">Mount Options <Tooltip text="Optional NFS mount flags such as rw, sync, hard, soft, or nolock. Leave blank for sensible defaults." /></label>
+        <input id="nfs_options" type="text" bind:value={form.config.options} placeholder="Optional: rw,sync"
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+      </div>
+    </div>
+  {:else if form.type === 'webdav'}
+    <div>
+      <label for="dav_url" class="block text-sm font-medium text-text-muted mb-1.5">Server URL <Tooltip text="Full URL to the WebDAV endpoint, e.g. https://nextcloud.example.com/remote.php/dav/files/username/" /></label>
+      <input id="dav_url" type="url" bind:value={form.config.url} placeholder="https://webdav.example.com/"
+        class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text font-mono placeholder-text-dim" />
+    </div>
+    <div class="grid grid-cols-2 gap-3">
+      <div>
+        <label for="dav_user" class="block text-sm font-medium text-text-muted mb-1.5">Username</label>
+        <input id="dav_user" type="text" bind:value={form.config.username}
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+      </div>
+      <div>
+        <label for="dav_pass" class="block text-sm font-medium text-text-muted mb-1.5">Password / App Token</label>
+        <input id="dav_pass" type="password" autocomplete="off" bind:value={form.config.password}
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+      </div>
+    </div>
+    <div>
+      <label for="dav_base" class="block text-sm font-medium text-text-muted mb-1.5">Base Path <Tooltip text="Optional sub-folder under the server URL where Vault will write its data." /></label>
+      <input id="dav_base" type="text" bind:value={form.config.base_path} placeholder="vault"
+        class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+    </div>
+    <label class="flex items-center gap-2 text-sm text-text-muted">
+      <input type="checkbox" bind:checked={form.config.insecure_skip_verify} class="accent-vault" />
+      Allow self-signed TLS certificates
+      <Tooltip text="Skip TLS certificate validation. Only enable for trusted private servers using self-signed certificates." />
+    </label>
+    <details class="group">
+      <summary class="text-sm font-medium text-text-muted hover:text-text cursor-pointer select-none">
+        Advanced &middot; Transfer
+      </summary>
+      <div class="flex flex-col gap-3 mt-3">
+        <div>
+          <label for="dav_chunk" class="block text-sm font-medium text-text-muted mb-1.5">
+            Chunk size (MiB)
+            <Tooltip text="Splits large uploads into separate pieces so one dropped connection doesn't restart the whole file. Recommended: leave at 0 (uses 50 MiB pieces). Use -1 only if your server rejects chunked uploads." />
+          </label>
+          <input id="dav_chunk" type="number" bind:value={form.config.chunk_size_mb} placeholder="0 (50 MiB)" min="-1"
+            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+        </div>
+        <div>
+          <label for="dav_stall" class="block text-sm font-medium text-text-muted mb-1.5">
+            Stall timeout (seconds)
+            <Tooltip text="Gives up on an upload if no data moves for this many seconds – catches a silently stalled connection. The timer resets whenever data flows, so even huge files finish fine. Recommended: 300 (5 min); use -1 to disable." />
+          </label>
+          <input id="dav_stall" type="number" bind:value={form.config.stall_timeout_seconds} placeholder="300" min="-1"
+            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+        </div>
+        <div>
+          <label for="dav_overall" class="block text-sm font-medium text-text-muted mb-1.5">
+            Overall request timeout (seconds)
+            <Tooltip text="A hard time limit on every request, including a whole file upload. Set too low, it cuts off large uploads. Recommended: leave at 0 (no limit) – the stall timeout above already handles dead connections." />
+          </label>
+          <input id="dav_overall" type="number" bind:value={form.config.timeout_seconds} placeholder="0 (unlimited)" min="0"
+            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+        </div>
+      </div>
+    </details>
+  {:else if form.type === 's3'}
+    <div>
+      <span class="block text-sm font-medium text-text-muted mb-1.5">Provider preset <Tooltip text="Prefills endpoint and region for common S3 providers. You can still edit any field. Placeholders in <angle-brackets> must be filled in with your account details." /></span>
+      <div class="flex flex-wrap gap-2">
+        {#each s3Presets as p (p.label)}
+          <button type="button" onclick={() => applyS3Preset(p)}
+            class="px-2.5 py-1 text-xs font-medium rounded-full border border-border bg-surface-3 text-text-muted hover:border-vault/40 hover:text-text transition-colors">
+            {p.label}
+          </button>
+        {/each}
+      </div>
+    </div>
+    <div class="grid grid-cols-2 gap-3">
+      <div>
+        <label for="s3_bucket" class="block text-sm font-medium text-text-muted mb-1.5">Bucket</label>
+        <input id="s3_bucket" type="text" bind:value={form.config.bucket} placeholder="my-vault-backups"
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+      </div>
+      <div>
+        <label for="s3_region" class="block text-sm font-medium text-text-muted mb-1.5">Region <Tooltip text="AWS region code, e.g. us-east-1. For S3-compatible providers, use the region required by the provider." /></label>
+        <input id="s3_region" type="text" bind:value={form.config.region} placeholder="us-east-1"
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+      </div>
+    </div>
+    <div class="grid grid-cols-2 gap-3">
+      <div>
+        <label for="s3_ak" class="block text-sm font-medium text-text-muted mb-1.5">Access Key ID</label>
+        <input id="s3_ak" type="text" bind:value={form.config.access_key} autocomplete="off"
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text font-mono placeholder-text-dim" />
+      </div>
+      <div>
+        <label for="s3_sk" class="block text-sm font-medium text-text-muted mb-1.5">Secret Access Key</label>
+        <input id="s3_sk" type="password" bind:value={form.config.secret_key} autocomplete="off"
+          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text font-mono placeholder-text-dim" />
+      </div>
+    </div>
+    <div>
+      <label for="s3_endpoint" class="block text-sm font-medium text-text-muted mb-1.5">Endpoint <Tooltip text="Optional. Required for S3-compatible providers like Backblaze B2, MinIO, Cloudflare R2 or Wasabi. Leave blank for AWS S3." /></label>
+      <input id="s3_endpoint" type="text" bind:value={form.config.endpoint} placeholder="https://s3.us-west-002.backblazeb2.com"
+        class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text font-mono placeholder-text-dim" />
+    </div>
+    <div>
+      <label for="s3_base" class="block text-sm font-medium text-text-muted mb-1.5">Base Path <Tooltip text="Optional key prefix prepended to every object Vault writes." /></label>
+      <input id="s3_base" type="text" bind:value={form.config.base_path} placeholder="vault"
+        class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+    </div>
+    <label class="flex items-center gap-2 text-sm text-text-muted">
+      <input type="checkbox" bind:checked={form.config.force_path_style} class="accent-vault" />
+      Force path-style addressing
+      <Tooltip text="Puts the bucket name in the URL path instead of the hostname. Some older or self-hosted S3 servers (e.g. older MinIO) need this. Recommended: leave off for AWS S3 and most modern providers." />
+    </label>
+    <details class="group">
+      <summary class="text-sm font-medium text-text-muted hover:text-text cursor-pointer select-none">
+        Advanced &middot; Transfer
+      </summary>
+      <div class="flex flex-col gap-3 mt-3">
+        <div>
+          <label for="s3_upload_timeout" class="block text-sm font-medium text-text-muted mb-1.5">
+            Upload timeout (minutes)
+            <Tooltip text="The longest a single file's upload may take before Vault gives up. Too low and large files on slow links get cut off. Recommended: leave at 0 (defaults to 240 min / 4 h); raise it only for very large files over slow connections." />
+          </label>
+          <input id="s3_upload_timeout" type="number" bind:value={form.config.upload_timeout_minutes} placeholder="240 (default)" min="0"
+            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+        </div>
+        <div>
+          <label for="s3_part_size" class="block text-sm font-medium text-text-muted mb-1.5">
+            Part size (MiB)
+            <Tooltip text="Splits large uploads into parts so one network drop doesn't restart the whole transfer. Bigger parts allow bigger single files. Recommended: leave at 0 (64 MiB, handles files up to ~640 GB); raise only for larger files – 256 → ~2.5 TB, 1024 → ~10 TB. Range 5-5120." />
+          </label>
+          <input id="s3_part_size" type="number" bind:value={form.config.part_size_mb} placeholder="0 (64 MiB)" min="0" max="5120"
+            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+        </div>
+      </div>
+    </details>
+  {/if}
+  {/key}
+
+  <!-- Universal (remote only): bandwidth throttling. Local destinations
+       talk directly to the host's filesystem; there is no upstream link
+       to protect, so the field is hidden + the backend factory skips the
+       throttle wrapper for `type === 'local'`. -->
+  {#if form.type !== 'local'}
+    <div>
+      <label for="bandwidth_limit_mbps" class="block text-sm font-medium text-text-muted mb-1.5">
+        Bandwidth limit (Mbps)
+        <Tooltip text="Limits how much bandwidth this destination may use, in megabits per second, so backups don't saturate a shared internet line. Recommended: 0 (unlimited) on a dedicated link; set a cap if backups slow down other traffic." />
+      </label>
+      <input id="bandwidth_limit_mbps" type="number" bind:value={form.config.bandwidth_limit_mbps} min="0" placeholder="0 (unlimited)"
+        class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+    </div>
+  {/if}
+
+  <!-- Universal: deduplication. Top-level column on storage_destinations.
+       Immutable after creation – backend ignores any update attempt and
+       the UI disables the toggle when editing. -->
+  <div class="border-t border-border pt-4">
+    <label class="flex items-start gap-2 text-sm">
+      <input
+        type="checkbox"
+        bind:checked={form.dedup_enabled}
+        disabled={initial !== null}
+        class="accent-vault mt-1"
+      />
+      <span class="flex-1">
+        <span class="block font-medium text-text">Enable deduplication</span>
+        <span class="block text-xs text-text-muted mt-0.5">
+          Stores only changed data blocks across snapshots and jobs targeting this destination. Recommended for backups containing similar data (Immich, Nextcloud, container volumes). <strong>Cannot be changed after creating the destination.</strong>
+        </span>
+        {#if initial !== null}
+          <span class="block text-xs text-warning mt-1 italic">
+            Dedup mode is locked at creation time. Create a new destination to switch.
+          </span>
+        {/if}
+      </span>
+    </label>
+  </div>
+
+  <div class="flex items-center justify-between gap-3 pt-4 border-t border-border">
+    <button type="button" onclick={testFormConnection} disabled={formTesting || saving}
+      class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg border transition-colors disabled:opacity-50 disabled:cursor-not-allowed
+        {formTestResult?.success === true ? 'border-success text-success bg-success/10'
+         : formTestResult?.success === false ? 'border-danger text-danger bg-danger/10'
+         : 'border-vault/50 text-vault-text hover:bg-vault/10'}">
+      {#if formTesting}
+        <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+        Testing…
+      {:else if formTestResult?.success === true}
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+        Connection OK
+      {:else if formTestResult?.success === false}
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+        Failed — retry
+      {:else}
+        Test connection
+      {/if}
+    </button>
+    <div class="flex gap-3">
+      <button type="button" onclick={() => oncancel()} class="px-4 py-2 text-sm font-medium text-text-muted hover:text-text bg-surface-3 hover:bg-surface-4 rounded-lg transition-colors">
+        Cancel
+      </button>
+      <button type="submit" disabled={saving || formTesting} class="px-4 py-2 text-sm font-medium text-white bg-vault hover:bg-vault-dark rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+        {#if saving}Saving...{:else}{submitLabel}{/if}
+      </button>
+    </div>
+  </div>
+</form>

--- a/web/src/components/StorageForm.svelte
+++ b/web/src/components/StorageForm.svelte
@@ -23,7 +23,9 @@
 
   function initForm(dest) {
     if (!dest) return defaultForm()
-    const cfg = parseConfig(dest.config)
+    // Deep-clone: parseConfig returns object inputs as-is, and form bindings
+    // must never mutate the caller's destination (cancel would leak edits).
+    const cfg = JSON.parse(JSON.stringify(parseConfig(dest.config)))
     // Migrate legacy "path" → "base_path" for SFTP/SMB configs.
     if ((dest.type === 'sftp' || dest.type === 'smb') && cfg.base_path === undefined) {
       cfg.base_path = cfg.path ?? ''
@@ -80,6 +82,8 @@
   }
 
   function applyType(nextType) {
+    // Re-clicking the selected type must not wipe entered credentials.
+    if (nextType === form.type) return
     const defaults = {
       local: { path: '' },
       sftp: { host: '', port: 22, user: '', password: '', base_path: '', bandwidth_limit_mbps: 0 },
@@ -494,7 +498,7 @@
       {/if}
     </button>
     <div class="flex gap-3">
-      <button type="button" onclick={() => oncancel()} class="px-4 py-2 text-sm font-medium text-text-muted hover:text-text bg-surface-3 hover:bg-surface-4 rounded-lg transition-colors">
+      <button type="button" onclick={() => oncancel()} disabled={saving} class="px-4 py-2 text-sm font-medium text-text-muted hover:text-text bg-surface-3 hover:bg-surface-4 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
         Cancel
       </button>
       <button type="submit" disabled={saving || formTesting} class="px-4 py-2 text-sm font-medium text-white bg-vault hover:bg-vault-dark rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed">

--- a/web/src/components/Welcome.svelte
+++ b/web/src/components/Welcome.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** @type {{ onstart?: (e: MouseEvent) => void }} */
-  let { onstart = () => {} } = $props()
+  /** @type {{ onstart?: (e: MouseEvent) => void, onrecover?: (e: MouseEvent) => void }} */
+  let { onstart = () => {}, onrecover = () => {} } = $props()
 </script>
 
 <div class="flex flex-col items-center justify-center min-h-[60vh] text-center px-4">
@@ -36,7 +36,11 @@
     </div>
   </div>
 
-  <button onclick={onstart} class="btn btn-primary text-base px-8 py-3">
-    Get Started
-  </button>
+  <div class="flex flex-col sm:flex-row gap-3 justify-center items-center">
+    <button onclick={onstart} class="btn btn-primary text-base px-8 py-3">Get Started</button>
+    <button onclick={onrecover} class="btn btn-secondary text-base px-6 py-3">Recover from a backup</button>
+  </div>
+  <p class="text-xs text-text-dim mt-3">
+    Had Vault before? "Recover from a backup" brings your jobs, storage and history back.
+  </p>
 </div>

--- a/web/src/components/Welcome.svelte
+++ b/web/src/components/Welcome.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** @type {{ onstart?: (e: MouseEvent) => void, onrecover?: (e: MouseEvent) => void }} */
-  let { onstart = () => {}, onrecover = () => {} } = $props()
+  /** @type {{ onstart?: (e: MouseEvent) => void, onrecover?: ((e: MouseEvent) => void) | null }} */
+  let { onstart = () => {}, onrecover = null } = $props()
 </script>
 
 <div class="flex flex-col items-center justify-center min-h-[60vh] text-center px-4">
@@ -38,9 +38,13 @@
 
   <div class="flex flex-col sm:flex-row gap-3 justify-center items-center">
     <button onclick={onstart} class="btn btn-primary text-base px-8 py-3">Get Started</button>
-    <button onclick={onrecover} class="btn btn-secondary text-base px-6 py-3">Recover from a backup</button>
+    {#if onrecover}
+      <button onclick={onrecover} class="btn btn-secondary text-base px-6 py-3">Recover from a backup</button>
+    {/if}
   </div>
-  <p class="text-xs text-text-dim mt-3">
-    Had Vault before? "Recover from a backup" brings your jobs, storage and history back.
-  </p>
+  {#if onrecover}
+    <p class="text-xs text-text-dim mt-3">
+      Had Vault before? "Recover from a backup" brings your jobs, storage and history back.
+    </p>
+  {/if}
 </div>

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -79,7 +79,16 @@ export const api = {
   closeBreaker: (id) => request('POST', `/storage/${id}/breaker/close`),
   scanStorage: (id, path = '') => request('POST', `/storage/${id}/scan${path ? '?path=' + encodeURIComponent(path) : ''}`),
   importBackups: (id, backups) => request('POST', `/storage/${id}/import`, { backups }),
-  restoreDB: (id, storagePath) => request('POST', `/storage/${id}/restore-db`, { storage_path: storagePath }),
+  // Restore the Vault database from a backup on this destination. With
+  // verifyOnly the server only checks the file (and passphrase, when
+  // encrypted) without touching the live DB.
+  restoreDB: (id, storagePath, passphrase = '', verifyOnly = false) =>
+    request('POST', `/storage/${id}/restore-db`,
+      { storage_path: storagePath, passphrase, verify_only: verifyOnly },
+      { timeoutMs: TEST_TIMEOUT_MS }),
+  // List database backups found under _vault on this destination, latest
+  // first then newest→oldest.
+  listDBBackups: (id) => request('GET', `/storage/${id}/db-backups`),
   getDependentJobs: (id) => request('GET', `/storage/${id}/jobs`),
 
   // Jobs
@@ -206,6 +215,10 @@ export const api = {
 
   // Recovery
   getRecoveryPlan: () => request('GET', '/recovery/plan'),
+  // Disaster recovery: audit configured storage/job-item paths against this
+  // server's filesystem, then remap the ones that no longer exist.
+  pathAudit: () => request('GET', '/recovery/path-audit'),
+  pathRemap: (updates) => request('POST', '/recovery/path-remap', { updates }),
 
   // Anomalies
   listAnomalies: (filter = {}) => {

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -85,7 +85,9 @@ export const api = {
   restoreDB: (id, storagePath, passphrase = '', verifyOnly = false) =>
     request('POST', `/storage/${id}/restore-db`,
       { storage_path: storagePath, passphrase, verify_only: verifyOnly },
-      { timeoutMs: TEST_TIMEOUT_MS }),
+      // A real restore downloads + swaps the whole DB — give it 10 minutes
+      // so a slow remote doesn't abort the request client-side mid-restore.
+      { timeoutMs: verifyOnly ? TEST_TIMEOUT_MS : 600000 }),
   // List database backups found under _vault on this destination, latest
   // first then newest→oldest.
   listDBBackups: (id) => request('GET', `/storage/${id}/db-backups`),

--- a/web/src/pages/Dashboard.svelte
+++ b/web/src/pages/Dashboard.svelte
@@ -1344,7 +1344,7 @@
       <span class="text-sm">{error}</span>
     </div>
   {:else if storage.length === 0 && jobs.length === 0}
-    <Welcome onstart={() => navigate('/storage')} />
+    <Welcome onstart={() => navigate('/storage')} onrecover={() => navigate('/recover')} />
   {:else}
     <!-- Getting Started Guide (shown when no storage or no jobs) -->
     {#if storage.length === 0 || jobs.length === 0}

--- a/web/src/pages/Dashboard.svelte
+++ b/web/src/pages/Dashboard.svelte
@@ -1344,7 +1344,7 @@
       <span class="text-sm">{error}</span>
     </div>
   {:else if storage.length === 0 && jobs.length === 0}
-    <Welcome onstart={() => navigate('/storage')} onrecover={() => navigate('/recover')} />
+    <Welcome onstart={() => navigate('/storage')} onrecover={isReplicaMode() ? undefined : () => navigate('/recover')} />
   {:else}
     <!-- Getting Started Guide (shown when no storage or no jobs) -->
     {#if storage.length === 0 || jobs.length === 0}

--- a/web/src/pages/RecoverWizard.svelte
+++ b/web/src/pages/RecoverWizard.svelte
@@ -39,6 +39,7 @@
 
   async function onDestinationSaved(newDest) {
     dest = newDest
+    noBackups = false
     try {
       backups = await api.listDBBackups(dest.id)
     } catch (e) {
@@ -52,7 +53,6 @@
       showToast("We couldn't find a Vault backup here. Look for a folder named _vault on your backup storage.", 'warning')
       return
     }
-    noBackups = false
     selected = backups[0]
     step = latestEncrypted ? 2 : 3
   }
@@ -93,7 +93,9 @@
       step = 4
       showToast('Your settings are back.', 'success')
     } catch (e) {
-      showToast(e.message || 'Restore failed — nothing was changed.', 'error')
+      // A client-side timeout doesn't mean the server stopped — don't claim
+      // nothing changed.
+      showToast(e.message || 'The restore did not finish — check the Dashboard before retrying.', 'error')
     } finally {
       restoring = false
       confirmRestore = false

--- a/web/src/pages/RecoverWizard.svelte
+++ b/web/src/pages/RecoverWizard.svelte
@@ -230,6 +230,12 @@
       <p class="text-sm text-text-muted mb-4">
         The most recent backup is already selected — that's the right choice for almost everyone.
       </p>
+      {#if !latestEncrypted}
+        <p class="text-xs text-text-dim mb-4">
+          These backups aren't encrypted, so no password is needed. To encrypt future
+          backups, set a backup password in Settings → Encryption after you finish.
+        </p>
+      {/if}
       <fieldset class="space-y-2">
         <legend class="sr-only">Backups found on your storage</legend>
         {#each backups as b (b.path)}

--- a/web/src/pages/RecoverWizard.svelte
+++ b/web/src/pages/RecoverWizard.svelte
@@ -1,0 +1,339 @@
+<script>
+  import { api } from '../lib/api.js'
+  import { navigate } from '../lib/router.svelte.js'
+  import StorageForm from '../components/StorageForm.svelte'
+  import Toast from '../components/Toast.svelte'
+  import InlineSpinner from '../components/InlineSpinner.svelte'
+
+  const STEPS = [
+    { n: 1, label: 'Connect storage' },
+    { n: 2, label: 'Backup password' },
+    { n: 3, label: 'Restore' },
+    { n: 4, label: 'Check paths' },
+    { n: 5, label: 'Done' },
+  ]
+
+  let step = $state(1)
+  let dest = $state(null)
+  let backups = $state([])
+  let noBackups = $state(false)
+  let selected = $state(null)
+  let passphrase = $state('')
+  let showPass = $state(false)
+  let verifying = $state(false)
+  let passError = $state('')
+  let restoring = $state(false)
+  let confirmRestore = $state(false)
+  let audit = $state(null)
+  let remapDraft = $state({})
+  let remapping = $state(false)
+  let remapResults = $state(null)
+  let summary = $state({ jobs: 0, storage: 0 })
+  let toast = $state({ message: '', type: 'info', key: 0 })
+  const showToast = (message, type = 'info') => (toast = { message, type, key: toast.key + 1 })
+
+  const latestEncrypted = $derived(backups.length > 0 && backups[0].encrypted)
+  const brokenEntries = $derived(audit ? audit.entries.filter((e) => !e.exists) : [])
+  const remapError = (e) =>
+    remapResults?.find((r) => r.kind === e.kind && r.id === e.id && !r.applied)?.error
+
+  async function onDestinationSaved(newDest) {
+    dest = newDest
+    try {
+      backups = await api.listDBBackups(dest.id)
+    } catch {
+      backups = []
+    }
+    if (backups.length === 0) {
+      noBackups = true
+      showToast("We couldn't find a Vault backup here. Look for a folder named _vault on your backup storage.", 'warning')
+      return
+    }
+    noBackups = false
+    selected = backups[0]
+    step = latestEncrypted ? 2 : 3
+  }
+
+  async function verifyPassword() {
+    passError = ''
+    verifying = true
+    try {
+      await api.restoreDB(dest.id, selected.path, passphrase, true)
+      step = 3
+    } catch (e) {
+      passError = e.message || "That password didn't match. Check for typos — this is the encryption password you chose in Settings → Encryption on your old server."
+    } finally {
+      verifying = false
+    }
+  }
+
+  function startRestore() {
+    // A snapshot picked by hand can be encrypted even when the latest one
+    // wasn't — route through the password step instead of failing later.
+    if (selected.encrypted && !passphrase) {
+      step = 2
+      return
+    }
+    confirmRestore = true
+  }
+
+  async function doRestore() {
+    restoring = true
+    try {
+      await api.restoreDB(dest.id, selected.path, selected.encrypted ? passphrase : '')
+      const [jobs, storage] = await Promise.all([
+        api.listJobs().catch(() => []),
+        api.listStorage().catch(() => []),
+      ])
+      summary = { jobs: jobs.length, storage: storage.length }
+      audit = await api.pathAudit().catch(() => null)
+      step = 4
+      showToast('Your settings are back.', 'success')
+    } catch (e) {
+      showToast(e.message || 'Restore failed — nothing was changed.', 'error')
+    } finally {
+      restoring = false
+      confirmRestore = false
+    }
+  }
+
+  async function applyRemap() {
+    const updates = brokenEntries
+      .filter((e) => remapDraft[`${e.kind}-${e.id}`])
+      .map((e) => ({ kind: e.kind, id: e.id, job_id: e.job_id || 0, new_path: remapDraft[`${e.kind}-${e.id}`] }))
+    if (updates.length === 0) {
+      step = 5
+      return
+    }
+    remapping = true
+    try {
+      const res = await api.pathRemap(updates)
+      remapResults = res.results
+      audit = await api.pathAudit().catch(() => audit)
+      const failed = res.results.filter((r) => !r.applied)
+      if (failed.length === 0) showToast('Paths updated.', 'success')
+      else showToast(`${failed.length} path(s) could not be updated — see the rows below.`, 'warning')
+    } catch (e) {
+      showToast(e.message || 'Updating paths failed.', 'error')
+    } finally {
+      remapping = false
+    }
+  }
+
+  function goBack() {
+    if (step === 2) step = 1
+    else if (step === 3) step = latestEncrypted ? 2 : 1
+    else if (step === 4) step = 3
+  }
+
+  function fmtWhen(ts) {
+    const d = new Date(ts)
+    const days = Math.round((Date.now() - d.getTime()) / 86400000)
+    const rel = days <= 0 ? 'today' : days === 1 ? 'yesterday' : `${days} days ago`
+    return `${d.toLocaleString()} (${rel})`
+  }
+</script>
+
+<div class="max-w-3xl mx-auto p-4 sm:p-6">
+  <h1 class="text-2xl font-bold text-text">Recover Vault</h1>
+  <p class="text-sm text-text-muted mt-1 mb-6">
+    Bring back your jobs, storage and history from a backup. You'll need access to your backup storage
+    and your backup password — nothing from the old server.
+  </p>
+
+  <!-- Step indicator -->
+  <div class="flex items-center gap-2 mb-6">
+    {#each STEPS as s (s.n)}
+      <div class="flex items-center gap-2 {s.n <= step ? '' : 'opacity-40'}">
+        <div class="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold transition-colors {s.n <= step ? 'bg-vault text-white' : 'bg-surface-3 text-text-muted'}">
+          {#if s.n < step}
+            <svg aria-hidden="true" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"/></svg>
+          {:else}
+            {s.n}
+          {/if}
+        </div>
+        <span class="text-xs font-medium {s.n === step ? 'text-text' : 'text-text-muted'} hidden sm:inline">{s.label}</span>
+      </div>
+      {#if s.n < 5}
+        <div class="flex-1 h-px {s.n < step ? 'bg-vault' : 'bg-border'}"></div>
+      {/if}
+    {/each}
+  </div>
+
+  {#if step === 1}
+    <div class="bg-surface-2 border border-border rounded-xl p-5">
+      <h2 class="text-base font-semibold text-text mb-1">Connect the storage that holds your backups</h2>
+      <p class="text-sm text-text-muted mb-4">
+        Point Vault at the place your old server sent its backups — the same share, server or bucket
+        you used before. Use "Test connection" to make sure it works before continuing.
+      </p>
+      {#if noBackups}
+        <div class="bg-warning/10 border border-warning/30 rounded-lg p-3 mb-4 text-sm text-text">
+          We couldn't find a Vault backup on this storage. Look for a folder named
+          <code class="font-mono">_vault</code> on your backup storage — that's where your settings
+          backups live. Check the connection details below (especially the path) and press Connect again.
+        </div>
+      {/if}
+      <!-- Remount the form once a destination exists so re-submitting updates it
+           instead of creating a duplicate (StorageForm reads `initial` at mount). -->
+      {#key dest?.id}
+        <StorageForm
+          initial={dest}
+          submitLabel="Connect"
+          onsaved={onDestinationSaved}
+          oncancel={() => navigate('/recovery')}
+          ontoast={showToast}
+        />
+      {/key}
+    </div>
+
+  {:else if step === 2}
+    <div class="bg-surface-2 border border-border rounded-xl p-5">
+      <h2 class="text-base font-semibold text-text mb-1">Enter your backup password</h2>
+      <p class="text-sm text-text-muted mb-4">
+        This is the encryption password you chose when you set up encryption on your old server
+        (Settings → Encryption). It's the only thing you need from before.
+      </p>
+      <form onsubmit={(e) => { e.preventDefault(); if (passphrase && !verifying) verifyPassword() }}>
+        <label for="recover-pass" class="block text-sm font-medium text-text-muted mb-1.5">Your backup password</label>
+        <div class="flex gap-2">
+          <input id="recover-pass" type={showPass ? 'text' : 'password'} bind:value={passphrase} autocomplete="off"
+            class="flex-1 px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
+          <button type="button" class="btn btn-secondary" onclick={() => (showPass = !showPass)}>
+            {showPass ? 'Hide' : 'Show'}
+          </button>
+        </div>
+        {#if passError}
+          <p class="text-sm text-danger mt-2">{passError}</p>
+        {/if}
+        {#if verifying}
+          <p class="text-sm text-text-muted mt-2">Checking your password — this takes a few seconds by design.</p>
+        {/if}
+        <div class="flex items-center justify-between mt-5 pt-4 border-t border-border">
+          <button type="button" class="btn btn-ghost" onclick={goBack}>Back</button>
+          <button type="submit" class="btn btn-primary" disabled={!passphrase || verifying}>
+            {#if verifying}<InlineSpinner /> Checking…{:else}Continue{/if}
+          </button>
+        </div>
+      </form>
+    </div>
+
+  {:else if step === 3}
+    <div class="bg-surface-2 border border-border rounded-xl p-5">
+      <h2 class="text-base font-semibold text-text mb-1">Choose which backup to restore</h2>
+      <p class="text-sm text-text-muted mb-4">
+        The most recent backup is already selected — that's the right choice for almost everyone.
+      </p>
+      <fieldset class="space-y-2">
+        <legend class="sr-only">Backups found on your storage</legend>
+        {#each backups as b (b.path)}
+          <label class="flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors
+            {selected === b ? 'border-vault bg-vault/10' : 'border-border bg-surface-3 hover:border-border-hover'}">
+            <input type="radio" name="recover-snapshot" class="accent-vault mt-1" value={b} bind:group={selected} />
+            <span class="min-w-0">
+              <span class="block text-sm font-medium text-text">{b.is_latest ? 'Most recent backup' : fmtWhen(b.timestamp)}</span>
+              <span class="block text-xs text-text-muted mt-0.5 truncate">{b.name} · {(b.size / 1024).toFixed(0)} KB{b.encrypted ? ' · encrypted' : ''}</span>
+            </span>
+          </label>
+        {/each}
+      </fieldset>
+
+      {#if confirmRestore}
+        <div class="bg-warning/10 border border-warning/30 rounded-lg p-4 mt-4">
+          <p class="text-sm text-text mb-3">
+            This replaces this Vault's current (empty) settings with the backup
+            {selected.is_latest ? 'from your most recent backup' : `from ${new Date(selected.timestamp).toLocaleString()}`}.
+            Your backed-up files on storage are not touched.
+          </p>
+          <div class="flex items-center gap-3">
+            <button type="button" class="btn btn-primary" disabled={restoring} onclick={doRestore}>
+              {#if restoring}<InlineSpinner /> Restoring…{:else}Yes, restore my settings{/if}
+            </button>
+            <button type="button" class="btn btn-ghost" disabled={restoring} onclick={() => (confirmRestore = false)}>Cancel</button>
+          </div>
+        </div>
+      {/if}
+
+      <div class="flex items-center justify-between mt-5 pt-4 border-t border-border">
+        <button type="button" class="btn btn-ghost" onclick={goBack}>Back</button>
+        {#if !confirmRestore}
+          <button type="button" class="btn btn-primary" disabled={!selected} onclick={startRestore}>Restore this backup</button>
+        {/if}
+      </div>
+    </div>
+
+  {:else if step === 4}
+    <div class="bg-surface-2 border border-border rounded-xl p-5">
+      <h2 class="text-base font-semibold text-text mb-1">Check your folder paths</h2>
+      {#if audit === null}
+        <p class="text-sm text-text-muted mb-4">
+          We couldn't check your paths automatically. If a backup fails later, review the paths in
+          Jobs and Storage.
+        </p>
+        <div class="flex items-center justify-between pt-4 border-t border-border">
+          <button type="button" class="btn btn-ghost" onclick={goBack}>Back</button>
+          <button type="button" class="btn btn-primary" onclick={() => (step = 5)}>Continue</button>
+        </div>
+      {:else if brokenEntries.length === 0}
+        <p class="text-sm text-success mb-4">✓ All your configured paths exist on this server. Nothing to fix.</p>
+        <div class="flex items-center justify-between pt-4 border-t border-border">
+          <button type="button" class="btn btn-ghost" onclick={goBack}>Back</button>
+          <button type="button" class="btn btn-primary" onclick={() => (step = 5)}>Continue</button>
+        </div>
+      {:else}
+        <p class="text-sm text-text-muted mb-4">
+          Your old server had different drives or shares. These paths from your backup don't exist
+          here — pick where they live now, or skip and fix them later in Jobs/Storage.
+        </p>
+        <datalist id="path-candidates">
+          {#each audit.candidates as c (c)}
+            <option value={c}></option>
+          {/each}
+        </datalist>
+        <div class="space-y-3">
+          {#each brokenEntries as e (`${e.kind}-${e.id}`)}
+            <div class="bg-surface-3 border border-border rounded-lg p-4">
+              <div class="text-xs font-medium text-text-muted">{e.kind === 'storage' ? 'Storage destination' : 'Backup folder'}</div>
+              <div class="text-sm font-medium text-text">{e.name}</div>
+              <div class="text-xs text-text-dim line-through font-mono mt-1">{e.path}</div>
+              <label class="sr-only" for={`remap-${e.kind}-${e.id}`}>New path for {e.name}</label>
+              <input id={`remap-${e.kind}-${e.id}`} type="text" list="path-candidates"
+                bind:value={remapDraft[`${e.kind}-${e.id}`]}
+                placeholder="New path, e.g. /mnt/user/…"
+                class="w-full mt-2 px-3 py-2 bg-surface-2 border border-border rounded-lg text-sm text-text font-mono placeholder-text-dim" />
+              {#if remapError(e)}
+                <p class="text-xs text-danger mt-1">{remapError(e)}</p>
+              {/if}
+            </div>
+          {/each}
+        </div>
+        <div class="flex items-center justify-between mt-5 pt-4 border-t border-border">
+          <button type="button" class="btn btn-ghost" onclick={goBack}>Back</button>
+          <div class="flex items-center gap-3">
+            <button type="button" class="btn btn-secondary" disabled={remapping} onclick={() => (step = 5)}>Skip for now</button>
+            <button type="button" class="btn btn-primary" disabled={remapping} onclick={applyRemap}>
+              {#if remapping}<InlineSpinner /> Updating…{:else}Update paths{/if}
+            </button>
+          </div>
+        </div>
+      {/if}
+    </div>
+
+  {:else if step === 5}
+    <div class="bg-surface-2 border border-border rounded-xl p-8 text-center">
+      <div class="text-4xl mb-3" aria-hidden="true">🎉</div>
+      <h2 class="text-xl font-bold text-text mb-2">Vault is back</h2>
+      <p class="text-sm text-text-muted max-w-md mx-auto mb-6">
+        Recovered {summary.jobs} job(s) and {summary.storage} storage destination(s).
+        To bring files, containers or VMs back, use the normal Restore page. And store your backup
+        password somewhere safe off this server — it's the one thing recovery always needs.
+      </p>
+      <div class="flex items-center justify-center gap-3">
+        <button type="button" class="btn btn-primary" onclick={() => navigate('/restore')}>Go to Restore</button>
+        <button type="button" class="btn btn-secondary" onclick={() => navigate('/')}>Go to Dashboard</button>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<Toast message={toast.message} type={toast.type} key={toast.key} />

--- a/web/src/pages/RecoverWizard.svelte
+++ b/web/src/pages/RecoverWizard.svelte
@@ -40,6 +40,7 @@
     .then(([jobs, storage]) => (current = { jobs: jobs.length, storage: storage.length }))
 
   const latestEncrypted = $derived(backups.length > 0 && backups[0].encrypted)
+  const anyEncrypted = $derived(backups.some((b) => b.encrypted))
   const brokenEntries = $derived(audit ? audit.entries.filter((e) => !e.exists) : [])
   const remapError = (e) =>
     remapResults?.find((r) => r.kind === e.kind && r.id === e.id && !r.applied)?.error
@@ -239,7 +240,7 @@
       <p class="text-sm text-text-muted mb-4">
         The most recent backup is already selected — that's the right choice for almost everyone.
       </p>
-      {#if !latestEncrypted}
+      {#if !anyEncrypted}
         <p class="text-xs text-text-dim mb-4">
           These backups aren't encrypted, so no password is needed. To encrypt future
           backups, set a backup password in Settings → Encryption after you finish.

--- a/web/src/pages/RecoverWizard.svelte
+++ b/web/src/pages/RecoverWizard.svelte
@@ -32,6 +32,13 @@
   let toast = $state({ message: '', type: 'info', key: 0 })
   const showToast = (message, type = 'info') => (toast = { message, type, key: toast.key + 1 })
 
+  // What this Vault holds BEFORE the wizard touches anything (step 1 creates
+  // a destination) — the restore confirmation must not claim the settings are
+  // "(empty)" when the wizard was opened on an already-configured Vault.
+  let current = $state({ jobs: 0, storage: 0 })
+  Promise.all([api.listJobs().catch(() => []), api.listStorage().catch(() => [])])
+    .then(([jobs, storage]) => (current = { jobs: jobs.length, storage: storage.length }))
+
   const latestEncrypted = $derived(backups.length > 0 && backups[0].encrypted)
   const brokenEntries = $derived(audit ? audit.entries.filter((e) => !e.exists) : [])
   const remapError = (e) =>
@@ -255,7 +262,13 @@
       {#if confirmRestore}
         <div class="bg-warning/10 border border-warning/30 rounded-lg p-4 mt-4">
           <p class="text-sm text-text mb-3">
-            This replaces this Vault's current (empty) settings with the backup
+            {#if current.jobs > 0 || current.storage > 0}
+              This replaces this Vault's current settings —
+              <strong>including its {current.jobs} job(s) and {current.storage} storage destination(s)</strong> —
+            {:else}
+              This replaces this Vault's current (empty) settings
+            {/if}
+            with the backup
             {selected.is_latest ? 'from your most recent backup' : `from ${new Date(selected.timestamp).toLocaleString()}`}.
             Your backed-up files on storage are not touched.
           </p>

--- a/web/src/pages/RecoverWizard.svelte
+++ b/web/src/pages/RecoverWizard.svelte
@@ -41,8 +41,11 @@
     dest = newDest
     try {
       backups = await api.listDBBackups(dest.id)
-    } catch {
-      backups = []
+    } catch (e) {
+      // Transport/server failure is not "no backups found" — don't show the
+      // _vault guidance for a timeout or 500; let the user retry.
+      showToast(e.message || 'Could not list backups on this storage.', 'error')
+      return
     }
     if (backups.length === 0) {
       noBackups = true
@@ -122,8 +125,11 @@
 
   function goBack() {
     if (step === 2) step = 1
-    else if (step === 3) step = latestEncrypted ? 2 : 1
-    else if (step === 4) step = 3
+    // passphrase is non-empty iff the password step was actually passed —
+    // accurate even when a hand-picked encrypted snapshot routed through it.
+    else if (step === 3) step = passphrase ? 2 : 1
+    // No Back from step 4: the restore already ran (point of no return), and
+    // re-restoring would silently discard just-applied path remaps.
   }
 
   function fmtWhen(ts) {
@@ -144,7 +150,7 @@
   <!-- Step indicator -->
   <div class="flex items-center gap-2 mb-6">
     {#each STEPS as s (s.n)}
-      <div class="flex items-center gap-2 {s.n <= step ? '' : 'opacity-40'}">
+      <div class="flex items-center gap-2 {s.n <= step ? '' : 'opacity-40'}" aria-current={s.n === step ? 'step' : undefined}>
         <div class="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold transition-colors {s.n <= step ? 'bg-vault text-white' : 'bg-surface-3 text-text-muted'}">
           {#if s.n < step}
             <svg aria-hidden="true" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"/></svg>
@@ -270,14 +276,12 @@
           We couldn't check your paths automatically. If a backup fails later, review the paths in
           Jobs and Storage.
         </p>
-        <div class="flex items-center justify-between pt-4 border-t border-border">
-          <button type="button" class="btn btn-ghost" onclick={goBack}>Back</button>
+        <div class="flex items-center justify-end pt-4 border-t border-border">
           <button type="button" class="btn btn-primary" onclick={() => (step = 5)}>Continue</button>
         </div>
       {:else if brokenEntries.length === 0}
         <p class="text-sm text-success mb-4">✓ All your configured paths exist on this server. Nothing to fix.</p>
-        <div class="flex items-center justify-between pt-4 border-t border-border">
-          <button type="button" class="btn btn-ghost" onclick={goBack}>Back</button>
+        <div class="flex items-center justify-end pt-4 border-t border-border">
           <button type="button" class="btn btn-primary" onclick={() => (step = 5)}>Continue</button>
         </div>
       {:else}
@@ -307,14 +311,11 @@
             </div>
           {/each}
         </div>
-        <div class="flex items-center justify-between mt-5 pt-4 border-t border-border">
-          <button type="button" class="btn btn-ghost" onclick={goBack}>Back</button>
-          <div class="flex items-center gap-3">
-            <button type="button" class="btn btn-secondary" disabled={remapping} onclick={() => (step = 5)}>Skip for now</button>
-            <button type="button" class="btn btn-primary" disabled={remapping} onclick={applyRemap}>
-              {#if remapping}<InlineSpinner /> Updating…{:else}Update paths{/if}
-            </button>
-          </div>
+        <div class="flex items-center justify-end gap-3 mt-5 pt-4 border-t border-border">
+          <button type="button" class="btn btn-secondary" disabled={remapping} onclick={() => (step = 5)}>Skip for now</button>
+          <button type="button" class="btn btn-primary" disabled={remapping} onclick={applyRemap}>
+            {#if remapping}<InlineSpinner /> Updating…{:else}Update paths{/if}
+          </button>
         </div>
       {/if}
     </div>

--- a/web/src/pages/Recovery.svelte
+++ b/web/src/pages/Recovery.svelte
@@ -92,6 +92,16 @@
     <p class="text-sm text-text-muted mt-1">Your disaster recovery plan – what to do if your server dies.</p>
   </div>
 
+  <div class="bg-surface-2 border border-border rounded-xl p-4 mb-6 flex flex-col sm:flex-row sm:items-center gap-3">
+    <div class="flex-1">
+      <h2 class="text-sm font-medium text-text">Recovering after a server rebuild?</h2>
+      <p class="text-xs text-text-muted">
+        The Recover Vault wizard reconnects your backup storage and restores your settings step by step.
+      </p>
+    </div>
+    <button class="btn btn-primary shrink-0" onclick={() => navigate('/recover')}>Recover Vault</button>
+  </div>
+
   {#if loading}
     <Spinner text="Loading recovery plan..." />
   {:else if error}

--- a/web/src/pages/Storage.svelte
+++ b/web/src/pages/Storage.svelte
@@ -8,9 +8,8 @@
   import Toast from '../components/Toast.svelte'
   import Spinner from '../components/Spinner.svelte'
   import EmptyState from '../components/EmptyState.svelte'
-  import PathBrowser from '../components/PathBrowser.svelte'
-  import Tooltip from '../components/Tooltip.svelte'
   import CapacityTrend from '../components/CapacityTrend.svelte'
+  import StorageForm from '../components/StorageForm.svelte'
 
   let loading = $state(true)
   let loadError = $state('')
@@ -18,7 +17,6 @@
   let showModal = $state(false)
   let editing = $state(null)
   let testing = $state(null)
-  let saving = $state(false)
   let testResults = $state(new SvelteMap())
   let toast = $state({ message: '', type: 'info', key: 0 })
   let confirmDelete = $state({ show: false, id: 0, name: '', deleteFiles: false, jobCount: 0 })
@@ -34,8 +32,6 @@
   let selectedBackups = $state(new SvelteSet())
   let vaultDBInfo = $state(null)
   let importing = $state(false)
-
-  let form = $state(defaultForm())
 
   // Per-destination dedup stats, polled every 30s for dedup-enabled
   // destinations. Keyed by destination ID. cleanupBusy / verifyBusy track
@@ -78,15 +74,6 @@
       next.set(id, res?.samples || [])
       trajectories = next
     } catch { /* ignore */ }
-  }
-
-  function defaultForm() {
-    return {
-      name: '',
-      type: 'local',
-      config: { path: '' },
-      dedup_enabled: false,
-    }
   }
 
   function showToast(message, type = 'info') {
@@ -252,62 +239,20 @@
 
   function openCreate() {
     editing = null
-    form = defaultForm()
-    formTestResult = null
     showModal = true
   }
 
   function openEdit(dest) {
     editing = dest
-    const cfg = parseConfig(dest.config)
-    // Migrate legacy "path" → "base_path" for SFTP/SMB configs.
-    if ((dest.type === 'sftp' || dest.type === 'smb') && cfg.base_path === undefined) {
-      cfg.base_path = cfg.path ?? ''
-    }
-    form = {
-      name: dest.name,
-      type: dest.type,
-      config: cfg,
-      dedup_enabled: !!dest.dedup_enabled,
-      // Carry the DB-backup fan-out flag through the modal save so editing
-      // an unrelated field doesn't reset it. The dedicated row toggle on
-      // the card is still the primary control.
-      backup_database_enabled: !!dest.backup_database_enabled,
-    }
-    formTestResult = null
     showModal = true
   }
 
-  async function saveStorage() {
-    if (saving) return
-    saving = true
-    try {
-      const payload = {
-        name: form.name,
-        type: form.type,
-        config: JSON.stringify(form.config),
-        // Top-level: stored as its own column on storage_destinations.
-        // Immutable after creation (UI gates the toggle when editing).
-        dedup_enabled: !!form.dedup_enabled,
-        // Preserve the current DB fan-out value through modal saves so
-        // editing other fields doesn't accidentally disable it. New
-        // destinations default to false.
-        backup_database_enabled: !!form.backup_database_enabled,
-      }
-      if (editing) {
-        await api.updateStorage(editing.id, payload)
-        showToast('Storage updated successfully', 'success')
-      } else {
-        await api.createStorage(payload)
-        showToast('Storage created successfully', 'success')
-      }
-      showModal = false
-      await loadData()
-    } catch (e) {
-      showToast(e.message, 'error')
-    } finally {
-      saving = false
-    }
+  // StorageForm handles create/update itself; on success we show the same
+  // toast copy as before, close the modal and reload the list.
+  async function onFormSaved() {
+    showToast(editing ? 'Storage updated successfully' : 'Storage created successfully', 'success')
+    showModal = false
+    await loadData()
   }
 
   async function deleteStorage(id, name) {
@@ -422,86 +367,6 @@
       testResults.set(id, { success: false, error: e.message })
     } finally {
       testing = null
-    }
-  }
-
-  function applyType(nextType) {
-    const defaults = {
-      local: { path: '' },
-      sftp: { host: '', port: 22, user: '', password: '', base_path: '', bandwidth_limit_mbps: 0 },
-      smb: { host: '', share: '', user: '', password: '', base_path: '', bandwidth_limit_mbps: 0 },
-      nfs: { host: '', export: '', base_path: '', version: '4', options: '', bandwidth_limit_mbps: 0 },
-      webdav: { url: '', username: '', password: '', base_path: '', insecure_skip_verify: false, timeout_seconds: 0, stall_timeout_seconds: 300, chunk_size_mb: 0, bandwidth_limit_mbps: 0 },
-      s3: { bucket: '', region: '', access_key: '', secret_key: '', endpoint: '', base_path: '', force_path_style: false, upload_timeout_minutes: 0, part_size_mb: 0, bandwidth_limit_mbps: 0 },
-    }
-    // Reassign the full form object so Svelte always re-renders the keyed
-    // config block when switching destination type.
-    form = {
-      ...form,
-      type: nextType,
-      config: defaults[nextType] || {},
-    }
-    formTestResult = null
-  }
-
-  // Backend types offered in the add/edit picker (issue #206 / E8).
-  const storageTypes = [
-    { value: 'local', label: 'Local Path' },
-    { value: 'sftp', label: 'SFTP' },
-    { value: 'smb', label: 'SMB / CIFS' },
-    { value: 'nfs', label: 'NFS' },
-    { value: 'webdav', label: 'WebDAV' },
-    { value: 's3', label: 'S3 / S3-Compatible' },
-  ]
-
-  // Quick-select S3 providers — prefill endpoint/region hints. Placeholders with
-  // <angle-brackets> mark values the user must fill in (account-specific hosts).
-  const s3Presets = [
-    { label: 'AWS S3', endpoint: '', region: 'us-east-1', forcePathStyle: false },
-    { label: 'Backblaze B2', endpoint: 'https://s3.us-west-002.backblazeb2.com', region: 'us-west-002', forcePathStyle: false },
-    { label: 'Cloudflare R2', endpoint: 'https://<accountid>.r2.cloudflarestorage.com', region: 'auto', forcePathStyle: false },
-    { label: 'Wasabi', endpoint: 'https://s3.wasabisys.com', region: 'us-east-1', forcePathStyle: false },
-    { label: 'MinIO', endpoint: 'http://<host>:9000', region: 'us-east-1', forcePathStyle: true },
-    { label: 'IDrive E2', endpoint: 'https://<region>.idrivee2-XX.com', region: 'us-east-1', forcePathStyle: false },
-    { label: 'MEGA S4', endpoint: 'https://s3.g.s4.mega.io', region: 'g', forcePathStyle: false },
-  ]
-  function applyS3Preset(p) {
-    form.config = { ...form.config, endpoint: p.endpoint, region: p.region, force_path_style: p.forcePathStyle }
-    formTestResult = null
-  }
-
-  // Test the current (unsaved) form config before saving.
-  let formTesting = $state(false)
-  /** @type {{ success: boolean, error?: string } | null} */
-  let formTestResult = $state(null)
-  // A test result only describes the config it ran against — invalidate it as
-  // soon as any config field changes so a stale "Connection OK" can't linger.
-  // Tracks form.config only (not formTesting), so completing a test — which
-  // doesn't mutate config — never re-runs this and wipes the fresh result.
-  $effect(() => {
-    JSON.stringify(form.config) // track all nested config fields
-    formTestResult = null
-  })
-  async function testFormConnection() {
-    formTesting = true
-    formTestResult = null
-    // Snapshot the config under test so a result that lands after the user has
-    // since edited the form is dropped, rather than showing a stale result for
-    // the old config (the invalidation $effect can't undo an in-flight test).
-    const testedKey = JSON.stringify({ type: form.type, config: form.config })
-    const isStale = () => JSON.stringify({ type: form.type, config: form.config }) !== testedKey
-    try {
-      const result = await api.testStorageConfig({ type: form.type, config: JSON.stringify(form.config) })
-      if (isStale()) return
-      formTestResult = result
-      showToast(result.success ? 'Connection successful!' : `Connection failed: ${result.error || 'unknown error'}`, result.success ? 'success' : 'error')
-    } catch (e) {
-      if (isStale()) return
-      const msg = e?.message || 'Connection test failed'
-      formTestResult = { success: false, error: msg }
-      showToast(msg, 'error')
-    } finally {
-      formTesting = false
     }
   }
 
@@ -837,331 +702,13 @@
 
 <!-- Create/Edit Modal -->
 <Modal show={showModal} title={editing ? 'Edit Storage' : 'Add Storage'} onclose={() => showModal = false}>
-  <form onsubmit={(e) => { e.preventDefault(); saveStorage() }} class="space-y-5">
-    <div>
-      <label for="sname" class="block text-sm font-medium text-text-muted mb-1.5">Name</label>
-      <input id="sname" type="text" bind:value={form.name} required
-        class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" placeholder="My Backup Target" />
-    </div>
-
-    <div>
-      <span class="block text-sm font-medium text-text-muted mb-1.5">Type</span>
-      <div role="group" aria-label="Storage type" class="grid grid-cols-2 sm:grid-cols-3 gap-2">
-        {#each storageTypes as t (t.value)}
-          <button type="button" aria-pressed={form.type === t.value}
-            onclick={() => applyType(t.value)}
-            class="flex items-center gap-2 px-3 py-2.5 rounded-lg border text-sm text-left transition-colors
-              {form.type === t.value ? 'border-vault bg-vault/10 text-text' : 'border-border bg-surface-3 text-text-muted hover:border-border-hover hover:text-text'}">
-            <svg aria-hidden="true" class="w-5 h-5 shrink-0 {storageColors[t.value] || 'text-text-muted'}" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d={storageIcons[t.value]}/></svg>
-            <span class="font-medium truncate">{t.label}</span>
-          </button>
-        {/each}
-      </div>
-    </div>
-
-    <!-- Dynamic config fields per type -->
-    {#key form.type}
-    {#if form.type === 'local'}
-      <div>
-        <span class="block text-sm font-medium text-text-muted mb-1.5">Path</span>
-        <PathBrowser bind:value={form.config.path} />
-      </div>
-    {:else if form.type === 'sftp'}
-      <div class="grid grid-cols-3 gap-3">
-        <div class="col-span-2">
-          <label for="cfg_host" class="block text-sm font-medium text-text-muted mb-1.5">Host</label>
-          <input id="cfg_host" type="text" bind:value={form.config.host}
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" placeholder="192.168.1.100" />
-        </div>
-        <div>
-          <label for="cfg_port" class="block text-sm font-medium text-text-muted mb-1.5">Port</label>
-          <input id="cfg_port" type="number" min="1" max="65535" bind:value={form.config.port}
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text" placeholder="22" />
-        </div>
-      </div>
-      <div class="grid grid-cols-2 gap-3">
-        <div>
-          <label for="cfg_user" class="block text-sm font-medium text-text-muted mb-1.5">Username</label>
-          <input id="cfg_user" type="text" bind:value={form.config.user}
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-        </div>
-        <div>
-          <label for="cfg_pass" class="block text-sm font-medium text-text-muted mb-1.5">Password</label>
-          <input id="cfg_pass" type="password" autocomplete="off" bind:value={form.config.password}
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-        </div>
-      </div>
-      <div>
-        <label for="cfg_spath" class="block text-sm font-medium text-text-muted mb-1.5">Remote Path <Tooltip text="Absolute path on the SFTP server where Vault will store backups. The directory must exist and the user must have write permission." /></label>
-        <input id="cfg_spath" type="text" bind:value={form.config.base_path}
-          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text font-mono placeholder-text-dim" placeholder="/backups/vault" />
-      </div>
-    {:else if form.type === 'smb'}
-      <div class="grid grid-cols-2 gap-3">
-        <div>
-          <label for="cfg_smbhost" class="block text-sm font-medium text-text-muted mb-1.5">Host</label>
-          <input id="cfg_smbhost" type="text" bind:value={form.config.host}
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" placeholder="192.168.1.100" />
-        </div>
-        <div>
-          <label for="cfg_share" class="block text-sm font-medium text-text-muted mb-1.5">Share <Tooltip text="The top-level SMB share name as configured on the server (e.g. Backups). Use the Path field below for a sub-folder within the share." /></label>
-          <input id="cfg_share" type="text" bind:value={form.config.share}
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" placeholder="Backups" />
-        </div>
-      </div>
-      <div class="grid grid-cols-2 gap-3">
-        <div>
-          <label for="cfg_smbuser" class="block text-sm font-medium text-text-muted mb-1.5">Username</label>
-          <input id="cfg_smbuser" type="text" bind:value={form.config.user}
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-        </div>
-        <div>
-          <label for="cfg_smbpass" class="block text-sm font-medium text-text-muted mb-1.5">Password</label>
-          <input id="cfg_smbpass" type="password" autocomplete="off" bind:value={form.config.password}
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-        </div>
-      </div>
-      <div>
-        <label for="cfg_smbpath" class="block text-sm font-medium text-text-muted mb-1.5">Path</label>
-        <input id="cfg_smbpath" type="text" bind:value={form.config.base_path}
-          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text font-mono placeholder-text-dim" placeholder="vault" />
-      </div>
-    {:else if form.type === 'nfs'}
-      <div class="grid grid-cols-2 gap-3">
-        <div class="col-span-2">
-          <label for="nfs_host" class="block text-sm font-medium text-text-muted mb-1.5">NFS Host</label>
-          <input id="nfs_host" type="text" bind:value={form.config.host} placeholder="192.168.1.100"
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-        </div>
-        <div class="col-span-2">
-          <label for="nfs_export" class="block text-sm font-medium text-text-muted mb-1.5">Export Path <Tooltip text="The path the NFS server exports – matches the entry in /etc/exports on the server (e.g. /mnt/user/backups). This is what gets mounted, not a sub-path within it." /></label>
-          <input id="nfs_export" type="text" bind:value={form.config.export} placeholder="/mnt/user/backups"
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-        </div>
-        <div>
-          <label for="nfs_base" class="block text-sm font-medium text-text-muted mb-1.5">Base Path <Tooltip text="Optional sub-directory within the mounted export where Vault will write its data. Leave blank to use the export root directly." /></label>
-          <input id="nfs_base" type="text" bind:value={form.config.base_path} placeholder="vault"
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-        </div>
-        <div>
-          <label for="nfs_version" class="block text-sm font-medium text-text-muted mb-1.5">NFS Version <Tooltip text="NFSv3: wider compatibility, simpler setup. NFSv4: better security and performance, but may require DNS and auth configuration." /></label>
-          <select id="nfs_version" bind:value={form.config.version}
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text">
-            <option value="3">NFSv3</option>
-            <option value="4">NFSv4</option>
-          </select>
-        </div>
-        <div class="col-span-2">
-          <label for="nfs_options" class="block text-sm font-medium text-text-muted mb-1.5">Mount Options <Tooltip text="Optional NFS mount flags such as rw, sync, hard, soft, or nolock. Leave blank for sensible defaults." /></label>
-          <input id="nfs_options" type="text" bind:value={form.config.options} placeholder="Optional: rw,sync"
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-        </div>
-      </div>
-    {:else if form.type === 'webdav'}
-      <div>
-        <label for="dav_url" class="block text-sm font-medium text-text-muted mb-1.5">Server URL <Tooltip text="Full URL to the WebDAV endpoint, e.g. https://nextcloud.example.com/remote.php/dav/files/username/" /></label>
-        <input id="dav_url" type="url" bind:value={form.config.url} placeholder="https://webdav.example.com/"
-          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text font-mono placeholder-text-dim" />
-      </div>
-      <div class="grid grid-cols-2 gap-3">
-        <div>
-          <label for="dav_user" class="block text-sm font-medium text-text-muted mb-1.5">Username</label>
-          <input id="dav_user" type="text" bind:value={form.config.username}
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-        </div>
-        <div>
-          <label for="dav_pass" class="block text-sm font-medium text-text-muted mb-1.5">Password / App Token</label>
-          <input id="dav_pass" type="password" autocomplete="off" bind:value={form.config.password}
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-        </div>
-      </div>
-      <div>
-        <label for="dav_base" class="block text-sm font-medium text-text-muted mb-1.5">Base Path <Tooltip text="Optional sub-folder under the server URL where Vault will write its data." /></label>
-        <input id="dav_base" type="text" bind:value={form.config.base_path} placeholder="vault"
-          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-      </div>
-      <label class="flex items-center gap-2 text-sm text-text-muted">
-        <input type="checkbox" bind:checked={form.config.insecure_skip_verify} class="accent-vault" />
-        Allow self-signed TLS certificates
-        <Tooltip text="Skip TLS certificate validation. Only enable for trusted private servers using self-signed certificates." />
-      </label>
-      <details class="group">
-        <summary class="text-sm font-medium text-text-muted hover:text-text cursor-pointer select-none">
-          Advanced &middot; Transfer
-        </summary>
-        <div class="flex flex-col gap-3 mt-3">
-          <div>
-            <label for="dav_chunk" class="block text-sm font-medium text-text-muted mb-1.5">
-              Chunk size (MiB)
-              <Tooltip text="Splits large uploads into separate pieces so one dropped connection doesn't restart the whole file. Recommended: leave at 0 (uses 50 MiB pieces). Use -1 only if your server rejects chunked uploads." />
-            </label>
-            <input id="dav_chunk" type="number" bind:value={form.config.chunk_size_mb} placeholder="0 (50 MiB)" min="-1"
-              class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-          </div>
-          <div>
-            <label for="dav_stall" class="block text-sm font-medium text-text-muted mb-1.5">
-              Stall timeout (seconds)
-              <Tooltip text="Gives up on an upload if no data moves for this many seconds – catches a silently stalled connection. The timer resets whenever data flows, so even huge files finish fine. Recommended: 300 (5 min); use -1 to disable." />
-            </label>
-            <input id="dav_stall" type="number" bind:value={form.config.stall_timeout_seconds} placeholder="300" min="-1"
-              class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-          </div>
-          <div>
-            <label for="dav_overall" class="block text-sm font-medium text-text-muted mb-1.5">
-              Overall request timeout (seconds)
-              <Tooltip text="A hard time limit on every request, including a whole file upload. Set too low, it cuts off large uploads. Recommended: leave at 0 (no limit) – the stall timeout above already handles dead connections." />
-            </label>
-            <input id="dav_overall" type="number" bind:value={form.config.timeout_seconds} placeholder="0 (unlimited)" min="0"
-              class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-          </div>
-        </div>
-      </details>
-    {:else if form.type === 's3'}
-      <div>
-        <span class="block text-sm font-medium text-text-muted mb-1.5">Provider preset <Tooltip text="Prefills endpoint and region for common S3 providers. You can still edit any field. Placeholders in <angle-brackets> must be filled in with your account details." /></span>
-        <div class="flex flex-wrap gap-2">
-          {#each s3Presets as p (p.label)}
-            <button type="button" onclick={() => applyS3Preset(p)}
-              class="px-2.5 py-1 text-xs font-medium rounded-full border border-border bg-surface-3 text-text-muted hover:border-vault/40 hover:text-text transition-colors">
-              {p.label}
-            </button>
-          {/each}
-        </div>
-      </div>
-      <div class="grid grid-cols-2 gap-3">
-        <div>
-          <label for="s3_bucket" class="block text-sm font-medium text-text-muted mb-1.5">Bucket</label>
-          <input id="s3_bucket" type="text" bind:value={form.config.bucket} placeholder="my-vault-backups"
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-        </div>
-        <div>
-          <label for="s3_region" class="block text-sm font-medium text-text-muted mb-1.5">Region <Tooltip text="AWS region code, e.g. us-east-1. For S3-compatible providers, use the region required by the provider." /></label>
-          <input id="s3_region" type="text" bind:value={form.config.region} placeholder="us-east-1"
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-        </div>
-      </div>
-      <div class="grid grid-cols-2 gap-3">
-        <div>
-          <label for="s3_ak" class="block text-sm font-medium text-text-muted mb-1.5">Access Key ID</label>
-          <input id="s3_ak" type="text" bind:value={form.config.access_key} autocomplete="off"
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text font-mono placeholder-text-dim" />
-        </div>
-        <div>
-          <label for="s3_sk" class="block text-sm font-medium text-text-muted mb-1.5">Secret Access Key</label>
-          <input id="s3_sk" type="password" bind:value={form.config.secret_key} autocomplete="off"
-            class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text font-mono placeholder-text-dim" />
-        </div>
-      </div>
-      <div>
-        <label for="s3_endpoint" class="block text-sm font-medium text-text-muted mb-1.5">Endpoint <Tooltip text="Optional. Required for S3-compatible providers like Backblaze B2, MinIO, Cloudflare R2 or Wasabi. Leave blank for AWS S3." /></label>
-        <input id="s3_endpoint" type="text" bind:value={form.config.endpoint} placeholder="https://s3.us-west-002.backblazeb2.com"
-          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text font-mono placeholder-text-dim" />
-      </div>
-      <div>
-        <label for="s3_base" class="block text-sm font-medium text-text-muted mb-1.5">Base Path <Tooltip text="Optional key prefix prepended to every object Vault writes." /></label>
-        <input id="s3_base" type="text" bind:value={form.config.base_path} placeholder="vault"
-          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-      </div>
-      <label class="flex items-center gap-2 text-sm text-text-muted">
-        <input type="checkbox" bind:checked={form.config.force_path_style} class="accent-vault" />
-        Force path-style addressing
-        <Tooltip text="Puts the bucket name in the URL path instead of the hostname. Some older or self-hosted S3 servers (e.g. older MinIO) need this. Recommended: leave off for AWS S3 and most modern providers." />
-      </label>
-      <details class="group">
-        <summary class="text-sm font-medium text-text-muted hover:text-text cursor-pointer select-none">
-          Advanced &middot; Transfer
-        </summary>
-        <div class="flex flex-col gap-3 mt-3">
-          <div>
-            <label for="s3_upload_timeout" class="block text-sm font-medium text-text-muted mb-1.5">
-              Upload timeout (minutes)
-              <Tooltip text="The longest a single file's upload may take before Vault gives up. Too low and large files on slow links get cut off. Recommended: leave at 0 (defaults to 240 min / 4 h); raise it only for very large files over slow connections." />
-            </label>
-            <input id="s3_upload_timeout" type="number" bind:value={form.config.upload_timeout_minutes} placeholder="240 (default)" min="0"
-              class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-          </div>
-          <div>
-            <label for="s3_part_size" class="block text-sm font-medium text-text-muted mb-1.5">
-              Part size (MiB)
-              <Tooltip text="Splits large uploads into parts so one network drop doesn't restart the whole transfer. Bigger parts allow bigger single files. Recommended: leave at 0 (64 MiB, handles files up to ~640 GB); raise only for larger files – 256 → ~2.5 TB, 1024 → ~10 TB. Range 5-5120." />
-            </label>
-            <input id="s3_part_size" type="number" bind:value={form.config.part_size_mb} placeholder="0 (64 MiB)" min="0" max="5120"
-              class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-          </div>
-        </div>
-      </details>
-    {/if}
-    {/key}
-
-    <!-- Universal (remote only): bandwidth throttling. Local destinations
-         talk directly to the host's filesystem; there is no upstream link
-         to protect, so the field is hidden + the backend factory skips the
-         throttle wrapper for `type === 'local'`. -->
-    {#if form.type !== 'local'}
-      <div>
-        <label for="bandwidth_limit_mbps" class="block text-sm font-medium text-text-muted mb-1.5">
-          Bandwidth limit (Mbps)
-          <Tooltip text="Limits how much bandwidth this destination may use, in megabits per second, so backups don't saturate a shared internet line. Recommended: 0 (unlimited) on a dedicated link; set a cap if backups slow down other traffic." />
-        </label>
-        <input id="bandwidth_limit_mbps" type="number" bind:value={form.config.bandwidth_limit_mbps} min="0" placeholder="0 (unlimited)"
-          class="w-full px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text placeholder-text-dim" />
-      </div>
-    {/if}
-
-    <!-- Universal: deduplication. Top-level column on storage_destinations.
-         Immutable after creation – backend ignores any update attempt and
-         the UI disables the toggle when editing. -->
-    <div class="border-t border-border pt-4">
-      <label class="flex items-start gap-2 text-sm">
-        <input
-          type="checkbox"
-          bind:checked={form.dedup_enabled}
-          disabled={editing !== null}
-          class="accent-vault mt-1"
-        />
-        <span class="flex-1">
-          <span class="block font-medium text-text">Enable deduplication</span>
-          <span class="block text-xs text-text-muted mt-0.5">
-            Stores only changed data blocks across snapshots and jobs targeting this destination. Recommended for backups containing similar data (Immich, Nextcloud, container volumes). <strong>Cannot be changed after creating the destination.</strong>
-          </span>
-          {#if editing !== null}
-            <span class="block text-xs text-warning mt-1 italic">
-              Dedup mode is locked at creation time. Create a new destination to switch.
-            </span>
-          {/if}
-        </span>
-      </label>
-    </div>
-
-    <div class="flex items-center justify-between gap-3 pt-4 border-t border-border">
-      <button type="button" onclick={testFormConnection} disabled={formTesting || saving}
-        class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg border transition-colors disabled:opacity-50 disabled:cursor-not-allowed
-          {formTestResult?.success === true ? 'border-success text-success bg-success/10'
-           : formTestResult?.success === false ? 'border-danger text-danger bg-danger/10'
-           : 'border-vault/50 text-vault-text hover:bg-vault/10'}">
-        {#if formTesting}
-          <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
-          Testing…
-        {:else if formTestResult?.success === true}
-          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
-          Connection OK
-        {:else if formTestResult?.success === false}
-          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
-          Failed — retry
-        {:else}
-          Test connection
-        {/if}
-      </button>
-      <div class="flex gap-3">
-        <button type="button" onclick={() => showModal = false} class="px-4 py-2 text-sm font-medium text-text-muted hover:text-text bg-surface-3 hover:bg-surface-4 rounded-lg transition-colors">
-          Cancel
-        </button>
-        <button type="submit" disabled={saving || formTesting} class="px-4 py-2 text-sm font-medium text-white bg-vault hover:bg-vault-dark rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
-          {#if saving}Saving...{:else}{editing ? 'Save Changes' : 'Add Storage'}{/if}
-        </button>
-      </div>
-    </div>
-  </form>
+  <StorageForm
+    initial={editing}
+    submitLabel={editing ? 'Save Changes' : 'Add Storage'}
+    onsaved={onFormSaved}
+    oncancel={() => showModal = false}
+    ontoast={showToast}
+  />
 </Modal>
 
 <!-- Enhanced Delete Dialog -->


### PR DESCRIPTION
## Summary

Resolves #220 ("Improve Disaster Recovery Procedures"). A user who reinstalls Unraid from scratch can now bring Vault fully back through the UI — no manual `vault.db` surgery, no daemon restart.

- **Recover Vault wizard** (5 steps: Connect storage → Backup password → Restore → Check paths → Done), offered as a welcome fork on fresh installs ("Set up Vault" vs "Recover from a backup") and always reachable from the Recovery page.
- **Encrypted restore fixed**: `restore-db` now decrypts the `.age` DB snapshots Vault writes by default (previously only plaintext `vault.db` restored), verifies the passphrase before touching anything (`verify_only`), runs a SQLite integrity check on the candidate, swaps atomically with `.bak` rollback, **reopens the DB in-process** (race-free `atomic.Pointer` handle swap — no restart), re-seals the passphrase with the new server key, reloads the scheduler, and flushes the restored DB to the snapshot/USB chain.
- **Snapshot listing** (`GET /storage/{id}/db-backups`) and **path audit/remap** (`/recovery/path-audit`, `path-remap`) for rebuilt servers with different array/share layouts.
- **Disaster Recovery guide** in the docs — leading with why hand-copying `vault.db` to flash fails (the reporter's literal dead-end).

## Review hardening

Every task passed two-stage subagent review (spec + quality), then a whole-branch integration review, then **CodeRabbit** and **Codex (GPT-5.6 Terra)** passes. All actionable findings fixed with red-first tests, including: daemon no longer left with a closed DB handle on failed restore; corrupt backups rejected (integrity check proved load-bearing); transport errors no longer masquerade as "no backups"; concurrent restores serialized (409); replica-mode gating for restore/remap; 10-minute restore timeout with honest failure copy.

## Test Plan

- [x] `go test ./...` — all 24 packages green (includes race-tested `Reopen` regression test proven to fail on pre-fix code)
- [x] `cd web && npm run build && npm run test` — build clean, 14/14 vitest
- [x] `make build && make deploy && make verify` — all green against the Unraid host
- [x] **Real DR round-trip on hardware**: fresh database simulated (all snapshot sources + `vault.key` moved aside) → recovered entirely through the wizard → all 6 jobs, 4 destinations, and restore points back; daemon PID unchanged (no restart); original state restored afterwards
- [x] Playwright verification of welcome fork, wizard steps, and Recovery page entry in light + dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided **Recover Vault** wizard for disaster recovery after a server rebuild.
  * Expanded database restore to support **encrypted backups**, **password verification**, and **verify-only** checks.
  * Added **DB snapshot listing** plus **path audit/remap** endpoints to fix restored local/folder paths.
  * Added real-time storage capacity updates and a new **Storage** destination form experience.
* **Bug Fixes**
  * Improved SQLite **WAL** handling, including correct WAL/busy-timeout behaviour and clearer warnings when WAL isn’t available.
* **Documentation**
  * Updated Disaster Recovery and related getting-started/backup guidance for the new workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->