### PR TITLE
fix(backup): propagate exclude_paths from runner

### DIFF
--- a/internal/runner/folder_exclude_paths_test.go
+++ b/internal/runner/folder_exclude_paths_test.go
@@ -171,6 +171,8 @@ func runFolderExclusionCase(t *testing.T, tc folderExclusionCase) {
 	for _, relPath := range tc.wantAbsent {
 		if _, err := os.Stat(filepath.Join(restoreDir, relPath)); err == nil {
 			t.Errorf("expected %s to be absent from restore, but it was present", relPath)
+		} else if !os.IsNotExist(err) {
+			t.Errorf("expected %s to be absent from restore, but stat returned unexpected error: %v", relPath, err)
 		}
 	}
 }

--- a/internal/runner/folder_exclude_paths_test.go
+++ b/internal/runner/folder_exclude_paths_test.go
@@ -1,0 +1,176 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+)
+
+type folderExclusionCase struct {
+	name         string
+	dedup        bool
+	files        map[string]string // relative path -> content
+	excludePaths []string
+	wantPresent  []string
+	wantAbsent   []string
+	omitKey      bool // if true, do not set exclude_paths in settings at all
+}
+
+// TestFolderJobPropagatesExcludePaths verifies that a folder job's
+// exclude_paths setting is copied from the stored item settings into the
+// engine BackupItem, so exclusions are actually applied during the run.
+// Regression test for the runner gap where only containers had this wiring.
+func TestFolderJobPropagatesExcludePaths(t *testing.T) {
+	cases := []folderExclusionCase{
+		{
+			name: "classic tar root globs",
+			files: map[string]string{
+				"keep.txt":  "keep",
+				"app.log":   "noise",
+				"debug.log": "noise",
+			},
+			excludePaths: []string{"*.log"},
+			wantPresent:  []string{"keep.txt"},
+			wantAbsent:   []string{"app.log", "debug.log"},
+		},
+		{
+			name:  "dedup chunked root globs",
+			dedup: true,
+			files: map[string]string{
+				"keep.txt":  "keep",
+				"app.log":   "noise",
+				"debug.log": "noise",
+			},
+			excludePaths: []string{"*.log"},
+			wantPresent:  []string{"keep.txt"},
+			wantAbsent:   []string{"app.log", "debug.log"},
+		},
+		{
+			name: "sub-directory exclusion",
+			files: map[string]string{
+				"keep.txt":       "keep",
+				"data/file.txt":  "keep",
+				"logs/app.log":   "noise",
+				"logs/debug.log": "noise",
+			},
+			excludePaths: []string{"logs"},
+			wantPresent:  []string{"keep.txt", "data/file.txt"},
+			wantAbsent:   []string{"logs"},
+		},
+		{
+			name: "no exclusions preserves all files",
+			files: map[string]string{
+				"keep.txt": "keep",
+				"app.log":  "noise",
+			},
+			omitKey:     true,
+			wantPresent: []string{"keep.txt", "app.log"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runFolderExclusionCase(t, tc)
+		})
+	}
+}
+
+func runFolderExclusionCase(t *testing.T, tc folderExclusionCase) {
+	t.Helper()
+	storageDir := t.TempDir()
+	sourceDir := t.TempDir()
+
+	// Build source tree.
+	for relPath, content := range tc.files {
+		fullPath := filepath.Join(sourceDir, relPath)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatalf("create dir %s: %v", filepath.Dir(fullPath), err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", relPath, err)
+		}
+	}
+
+	r, d := newTestRunner(t)
+	if tc.dedup {
+		r.serverKey = testServerKey()
+	}
+
+	destCfg, err := json.Marshal(map[string]string{"path": storageDir})
+	if err != nil {
+		t.Fatalf("marshal dest config: %v", err)
+	}
+	dest := db.StorageDestination{
+		Name: "test-local", Type: "local", Config: string(destCfg),
+	}
+	if tc.dedup {
+		dest.DedupEnabled = true
+	}
+	destID, err := d.CreateStorageDestination(dest)
+	if err != nil {
+		t.Fatalf("create dest: %v", err)
+	}
+
+	jobID, err := d.CreateJob(db.Job{
+		Name: "test-folder-exclusions", StorageDestID: destID,
+		BackupTypeChain: "full", Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+
+	itemSettingsMap := map[string]any{"path": sourceDir}
+	if !tc.omitKey {
+		itemSettingsMap["exclude_paths"] = tc.excludePaths
+	}
+	itemSettings, err := json.Marshal(itemSettingsMap)
+	if err != nil {
+		t.Fatalf("marshal item settings: %v", err)
+	}
+	if _, err := d.AddJobItem(db.JobItem{
+		JobID: jobID, ItemType: "folder", ItemName: "src",
+		Settings: string(itemSettings),
+	}); err != nil {
+		t.Fatalf("add item: %v", err)
+	}
+
+	r.RunJob(jobID)
+
+	runs, err := d.GetJobRuns(jobID, 5)
+	if err != nil {
+		t.Fatalf("get job runs: %v", err)
+	}
+	if len(runs) == 0 {
+		t.Fatalf("no run record created")
+	}
+	if runs[0].Status != "completed" {
+		t.Fatalf("expected run status completed, got %q", runs[0].Status)
+	}
+
+	rps, err := d.ListRestorePoints(jobID)
+	if err != nil {
+		t.Fatalf("get restore points: %v", err)
+	}
+	if len(rps) != 1 {
+		t.Fatalf("expected 1 restore point, got %d", len(rps))
+	}
+
+	restoreDir := t.TempDir()
+	if err := r.RestoreItem(rps[0], "src", "folder", restoreDir, ""); err != nil {
+		t.Fatalf("restore item: %v", err)
+	}
+
+	for _, relPath := range tc.wantPresent {
+		if _, err := os.Stat(filepath.Join(restoreDir, relPath)); err != nil {
+			t.Errorf("expected %s to be present in restore, got: %v", relPath, err)
+		}
+	}
+	for _, relPath := range tc.wantAbsent {
+		if _, err := os.Stat(filepath.Join(restoreDir, relPath)); err == nil {
+			t.Errorf("expected %s to be absent from restore, but it was present", relPath)
+		}
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1059,6 +1059,9 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 		if item.ItemType == "folder" {
 			backupItem.Settings["path"] = settings["path"]
 			backupItem.Settings["preset"] = settings["preset"]
+			if ep, ok := settings["exclude_paths"]; ok {
+				backupItem.Settings["exclude_paths"] = ep
+			}
 		}
 
 		// ZFS items need the dataset and related metadata from settings.


### PR DESCRIPTION
# Fix folder `exclude_paths` propagation and add regression test

## Problem

Folder backup jobs were silently ignoring the `exclude_paths` setting configured on the item. The runner copied `path` and `preset` into the engine's `BackupItem.Settings`, but it never copied `exclude_paths`. The engine's folder backup code already supports exclusions, but it could only act on settings it received.

Containers already had the same wiring; folders did not, so exclusions worked for containers but not for folders.

## What changed

- `internal/runner/runner.go`: When building a `BackupItem` for an item of type `folder`, copy `exclude_paths` from the stored item settings into `backupItem.Settings`, matching the existing container behavior.
- `internal/runner/folder_exclude_paths_test.go`: Added a regression test that creates a folder job with exclusions, runs the job, restores the restore point, and verifies that excluded files are absent while non-excluded files are present.

## Test cases

| Case | Engine path | Exclusions | Verifies |
|------|-------------|------------|----------|
| `classic_tar_root_globs` | classic tar | `*.log` | root-level glob exclusions apply |
| `dedup_chunked_root_globs` | dedup | `*.log` | exclusions work in chunked/dedup mode |
| `sub-directory_exclusion` | classic tar | `logs` | whole-directory exclusions apply |
| `no_exclusions_preserves_all_files` | classic tar | (none) | omitting `exclude_paths` preserves all files |

## Verification

```bash
go test ./internal/runner -run TestFolderJobPropagatesExcludePaths -v
```
```bash
--- PASS: TestFolderJobPropagatesExcludePaths (0.19s)
    --- PASS: TestFolderJobPropagatesExcludePaths/classic_tar_root_globs (0.07s)
    --- PASS: TestFolderJobPropagatesExcludePaths/dedup_chunked_root_globs (0.04s)
    --- PASS: TestFolderJobPropagatesExcludePaths/sub-directory_exclusion (0.04s)
    --- PASS: TestFolderJobPropagatesExcludePaths/no_exclusions_preserves_all_files (0.04s)
PASS
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Folder backups now correctly apply configured exclusion patterns (for example, excluding `*.log` files and entire directories).
  * Restores of folder items no longer include files that were excluded during the backup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->