### PR TITLE
fix(engine): resolve symlinks in folder backup source paths

### DIFF
--- a/internal/engine/folder.go
+++ b/internal/engine/folder.go
@@ -65,6 +65,20 @@ func (h *FolderHandler) Backup(ctx context.Context, item BackupItem, destDir str
 	}
 
 	srcPath = filepath.Clean(srcPath)
+
+	// Preserve the user-configured path for folder_meta.json so that
+	// restore targets the share path (e.g. /mnt/user/myshare), not the
+	// internally-resolved cache path (e.g. /mnt/cache/myshare).
+	originalPath := srcPath
+
+	// Resolve symlinks so cache-only Unraid shares (which appear as
+	// symlinks under /mnt/user/ pointing to /mnt/cache/) are traversed
+	// correctly by filepath.Walk, which uses os.Lstat and does not follow
+	// symbolic links.
+	if resolved, err := filepath.EvalSymlinks(srcPath); err == nil {
+		srcPath = resolved
+	}
+
 	if _, err := os.Stat(srcPath); err != nil {
 		return nil, fmt.Errorf("source path not accessible: %w", err)
 	}
@@ -126,8 +140,10 @@ func (h *FolderHandler) Backup(ctx context.Context, item BackupItem, destDir str
 	}
 
 	// Store source path metadata so restore knows the original location.
+	// Use the pre-resolution path so restores target the user-configured
+	// share path, not the internal symlink target.
 	metaPath := filepath.Join(destDir, "folder_meta.json")
-	metaJSON := fmt.Sprintf(`{"path":%q,"name":%q}`, srcPath, item.Name)
+	metaJSON := fmt.Sprintf(`{"path":%q,"name":%q}`, originalPath, item.Name)
 	if err := os.WriteFile(metaPath, []byte(metaJSON), 0600); err != nil {
 		return nil, fmt.Errorf("writing folder metadata: %w", err)
 	}
@@ -212,6 +228,14 @@ func (h *FolderHandler) BackupChunked(ctx context.Context, item BackupItem, repo
 	if srcPath == "" {
 		return dedup.ID{}, fmt.Errorf("folder: missing path setting")
 	}
+	srcPath = filepath.Clean(srcPath)
+	// Resolve symlinks so cache-only Unraid shares (symlinks under
+	// /mnt/user/ → /mnt/cache/) are traversed by filepath.Walk which
+	// uses os.Lstat and does not follow symbolic links.
+	if resolved, err := filepath.EvalSymlinks(srcPath); err == nil {
+		srcPath = resolved
+	}
+
 	// Honour user exclusion patterns, matching the classic tar path
 	// (tarDirectoryFiltered). For container volumes these arrive already
 	// mapped to volume-relative paths via mapExclusionsToVolume.

--- a/internal/engine/folder_test.go
+++ b/internal/engine/folder_test.go
@@ -408,3 +408,115 @@ func TestFolderChunkedHonoursExclusions(t *testing.T) {
 		}
 	}
 }
+
+// TestFolderBackupFollowsSymlinkSource verifies that folder backups (both
+// classic tar and dedup/chunked) traverse into a directory that is a symlink.
+// This covers Unraid cache-only shares where /mnt/user/<share> is a symlink
+// to /mnt/cache/<share>. Without EvalSymlinks, filepath.Walk uses os.Lstat
+// on the root, sees a symlink (not a directory), and never descends into
+// the target — producing an empty archive.
+func TestFolderBackupFollowsSymlinkSource(t *testing.T) {
+	t.Parallel()
+
+	// Create a real directory with files.
+	realDir := t.TempDir()
+	mustWrite := func(rel string, data []byte) {
+		p := filepath.Join(realDir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("file1.txt", []byte("hello"))
+	mustWrite("subdir/file2.txt", []byte("world"))
+
+	// Create a symlink pointing to the real directory.
+	linkDir := filepath.Join(t.TempDir(), "linked_folder")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skip("filesystem does not support symlinks")
+	}
+
+	h := &FolderHandler{}
+	ctx := context.Background()
+	progress := func(string, int, string) {}
+
+	// Test classic tar path (Backup).
+	t.Run("classic_tar", func(t *testing.T) {
+		t.Parallel()
+		dest := t.TempDir()
+		item := BackupItem{
+			Name:        "symlink-folder",
+			Type:        "folder",
+			Settings:    map[string]any{"path": linkDir},
+			Compression: CompressionGzip,
+		}
+		res, err := h.Backup(ctx, item, dest, progress)
+		if err != nil {
+			t.Fatalf("backup: %v", err)
+		}
+		if !res.Success {
+			t.Fatal("expected success")
+		}
+
+		// Verify folder_meta.json stores the original symlink path, not the
+		// resolved target.
+		metaData, err := os.ReadFile(filepath.Join(dest, "folder_meta.json"))
+		if err != nil {
+			t.Fatalf("reading folder_meta.json: %v", err)
+		}
+		if !bytes.Contains(metaData, []byte(linkDir)) {
+			t.Errorf("folder_meta.json should contain original path %q, got %s", linkDir, metaData)
+		}
+
+		// Verify the archive contains files (not empty).
+		restoreDest := t.TempDir()
+		if err := h.Restore(ctx, BackupItem{
+			Name:     "symlink-folder",
+			Type:     "folder",
+			Settings: map[string]any{"restore_destination": restoreDest},
+		}, dest, progress); err != nil {
+			t.Fatalf("restore: %v", err)
+		}
+
+		if _, err := os.Stat(filepath.Join(restoreDest, "file1.txt")); err != nil {
+			t.Errorf("missing file1.txt after restore: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(restoreDest, "subdir/file2.txt")); err != nil {
+			t.Errorf("missing subdir/file2.txt after restore: %v", err)
+		}
+	})
+
+	// Test dedup/chunked path (BackupChunked).
+	t.Run("chunked", func(t *testing.T) {
+		t.Parallel()
+		r, _, cleanup := dedup.NewTestRepoForEngine(t)
+		defer cleanup()
+
+		item := BackupItem{
+			Name:     "symlink-folder",
+			Type:     "folder",
+			Settings: map[string]any{"path": linkDir},
+		}
+		manifestID, err := h.BackupChunked(ctx, item, r, nil)
+		if err != nil {
+			t.Fatalf("chunked backup: %v", err)
+		}
+		if err := r.Flush(); err != nil {
+			t.Fatal(err)
+		}
+
+		m, err := r.GetManifest(manifestID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, ok := m.Files["file1.txt"]; !ok {
+			t.Errorf("manifest missing file1.txt")
+		}
+		if _, ok := m.Files["subdir/file2.txt"]; !ok {
+			t.Errorf("manifest missing subdir/file2.txt")
+		}
+	})
+}

--- a/internal/engine/listing.go
+++ b/internal/engine/listing.go
@@ -24,6 +24,11 @@ const ListingSuffix = ".listing.json"
 // ignore failures; without a listing, chain restore simply skips the prune
 // pass (its prior behaviour).
 func WriteEffectiveListing(srcPath, archivePath string, exclusions []string) error {
+	// Resolve symlinks so cache-only Unraid shares are traversed correctly.
+	if resolved, err := filepath.EvalSymlinks(srcPath); err == nil {
+		srcPath = resolved
+	}
+
 	idx := TarIndex{Version: tarIndexVersion, Archive: filepath.Base(archivePath)}
 
 	err := filepath.Walk(srcPath, func(p string, info os.FileInfo, walkErr error) error {


### PR DESCRIPTION
Cache-only Unraid shares appear as symlinks under `/mnt/user/` pointing to `/mnt/cache/`. `filepath.Walk` uses `os.Lstat` which does not follow symbolic links, so when the source path is a symlink to a directory, the walk sees a non-directory root and never descends, producing an empty archive.

Add `filepath.EvalSymlinks` resolution before `filepath.Walk` in:
- `folder.Backup()` (classic tar path)
- `folder.BackupChunked()` (dedup/chunked path)
- `listing.WriteEffectiveListing()` (point-in-time listing sidecar)

`EvalSymlinks` failure is silently ignored (non-fatal) so that paths that aren't symlinks or where resolution fails for other reasons fall through to the existing `os.Stat` accessibility check, which provides the actual error.

A small change has also been made to preserve the original user-configured path in folder metadata so that restores target the correct share location.

Regression test: `TestFolderBackupFollowsSymlinkSource` creates a real directory with files, symlinks a folder to it, and verifies both the classic tar and dedup backup paths capture the files through the symlink.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved folder backups for symlinked share paths, including cache-backed directories.
  - Ensured backups include files from the resolved source directory.
  - Preserved the configured share path so restores target the expected location.
  - Improved file listing generation when source paths use symlinks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->