### PR TITLE
fix(engine): honor changed_since in chunked/dedup backup path

### DIFF
--- a/internal/engine/container.go
+++ b/internal/engine/container.go
@@ -1373,6 +1373,7 @@ func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, r
 	// (shouldExcludeMount) and surviving mounts get their patterns mapped to
 	// volume-relative paths (mapExclusionsToVolume) for the chunked walk.
 	exclusions := containerExclusions(item.Settings)
+	changedSince, hasChangedSince := parseChangedSince(item.Settings)
 	if progress != nil {
 		progress(item.Name, 50, "backing up volumes")
 	}
@@ -1403,6 +1404,20 @@ func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, r
 			m.Files[key] = dedup.ManifestEntry{Size: volumeSkippedSize}
 			continue
 		}
+		// For differential backups, skip volumes whose entire tree is
+		// unchanged since the reference time. Mirrors the classic Backup
+		// path's pathChangedSince check.
+		if hasChangedSince {
+			changed, err := pathChangedSince(mnt.Source, changedSince)
+			if err != nil {
+				return dedup.ID{}, fmt.Errorf("checking volume %s changes: %w", mnt.Source, err)
+			}
+			if !changed {
+				log.Printf("engine: chunked: skipping volume %s for %s: unchanged since reference", mnt.Source, item.Name)
+				m.Files[key] = dedup.ManifestEntry{Size: volumeSkippedSize}
+				continue
+			}
+		}
 		volItem := BackupItem{
 			Name: mnt.Destination,
 			Type: "folder",
@@ -1410,6 +1425,11 @@ func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, r
 				"path":          mnt.Source,
 				"exclude_paths": mapExclusionsToVolume(exclusions, mnt.Destination),
 			},
+		}
+		// Propagate changed_since for per-file filtering inside
+		// FolderHandler.BackupChunked (Task 1).
+		if hasChangedSince {
+			volItem.Settings["changed_since"] = item.Settings["changed_since"]
 		}
 		volManifestID, vErr := fh.BackupChunked(ctx, volItem, repo, progress)
 		if vErr != nil {

--- a/internal/engine/folder.go
+++ b/internal/engine/folder.go
@@ -240,6 +240,7 @@ func (h *FolderHandler) BackupChunked(ctx context.Context, item BackupItem, repo
 	// (tarDirectoryFiltered). For container volumes these arrive already
 	// mapped to volume-relative paths via mapExclusionsToVolume.
 	exclusions := extractExcludePaths(item.Settings)
+	changedSince, hasChangedSince := parseChangedSince(item.Settings)
 	chunker, err := dedup.NewChunker(repo.SplitterSecret())
 	if err != nil {
 		return dedup.ID{}, err
@@ -300,6 +301,11 @@ func (h *FolderHandler) BackupChunked(ctx context.Context, item BackupItem, repo
 		}
 		if !info.Mode().IsRegular() {
 			log.Printf("engine: skipping non-regular file %s (mode %v)", rel, info.Mode())
+			return nil
+		}
+		// Skip files whose mtime is before the changed_since reference.
+		// Directory entries are still recorded above for restore structure.
+		if hasChangedSince && !info.ModTime().After(changedSince) {
 			return nil
 		}
 		warnIfSparse(rel, info)

--- a/internal/engine/folder.go
+++ b/internal/engine/folder.go
@@ -303,7 +303,8 @@ func (h *FolderHandler) BackupChunked(ctx context.Context, item BackupItem, repo
 			log.Printf("engine: skipping non-regular file %s (mode %v)", rel, info.Mode())
 			return nil
 		}
-		// Skip files whose mtime is before the changed_since reference.
+		// Skip files whose mtime is not after the changed_since reference.
+		// Consistent with pathChangedSince and tarDirectoryFiltered.
 		// Directory entries are still recorded above for restore structure.
 		if hasChangedSince && !info.ModTime().After(changedSince) {
 			return nil

--- a/internal/engine/folder_chunked_changed_since_test.go
+++ b/internal/engine/folder_chunked_changed_since_test.go
@@ -1,0 +1,172 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ruaan-deysel/vault/internal/dedup"
+)
+
+// TestFolderBackupChunked_ChangedSinceSkipsOldFiles verifies that
+// BackupChunked skips files whose mtime is before changed_since.
+func TestFolderBackupChunked_ChangedSinceSkipsOldFiles(t *testing.T) {
+	t.Parallel()
+
+	src := t.TempDir()
+
+	// Create an "old" file and set its mtime to 3 hours ago.
+	oldFile := filepath.Join(src, "old.txt")
+	if err := os.WriteFile(oldFile, []byte("old data"), 0o600); err != nil {
+		t.Fatalf("write old: %v", err)
+	}
+	past := time.Now().Add(-3 * time.Hour)
+	if err := os.Chtimes(oldFile, past, past); err != nil {
+		t.Fatalf("chtimes old: %v", err)
+	}
+
+	// Create a "new" file with current mtime.
+	newFile := filepath.Join(src, "new.txt")
+	if err := os.WriteFile(newFile, []byte("new data"), 0o600); err != nil {
+		t.Fatalf("write new: %v", err)
+	}
+
+	// Create a subdirectory with an old file.
+	subDir := filepath.Join(src, "subdir")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	subOldFile := filepath.Join(subDir, "sub_old.txt")
+	if err := os.WriteFile(subOldFile, []byte("sub old"), 0o600); err != nil {
+		t.Fatalf("write sub old: %v", err)
+	}
+	if err := os.Chtimes(subOldFile, past, past); err != nil {
+		t.Fatalf("chtimes sub old: %v", err)
+	}
+
+	// Open repo using the shared test helper.
+	repo, _, cleanup := dedup.NewTestRepoForEngine(t)
+	defer cleanup()
+
+	// Backup with changed_since = 1 hour ago.
+	changedSince := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+	h := &FolderHandler{}
+	manifestID, err := h.BackupChunked(context.Background(), BackupItem{
+		Name: "test-folder",
+		Type: "folder",
+		Settings: map[string]any{
+			"path":          src,
+			"changed_since": changedSince,
+		},
+	}, repo, func(string, int, string) {})
+	if err != nil {
+		t.Fatalf("BackupChunked: %v", err)
+	}
+	if err := repo.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	// Retrieve manifest and verify only the new file is present.
+	m, err := repo.GetManifest(manifestID)
+	if err != nil {
+		t.Fatalf("GetManifest: %v", err)
+	}
+
+	// new.txt should be in the manifest.
+	if _, ok := m.Files["new.txt"]; !ok {
+		t.Error("expected new.txt in manifest")
+	}
+
+	// old.txt and subdir/sub_old.txt should NOT be in the manifest.
+	if _, ok := m.Files["old.txt"]; ok {
+		t.Error("expected old.txt to be skipped (mtime before changed_since)")
+	}
+	if _, ok := m.Files[filepath.Join("subdir", "sub_old.txt")]; ok {
+		t.Error("expected subdir/sub_old.txt to be skipped (mtime before changed_since)")
+	}
+
+	// The subdir entry itself should still be recorded (directory structure preserved).
+	if _, ok := m.Files["subdir"]; !ok {
+		t.Error("expected subdir directory entry in manifest")
+	}
+}
+
+// TestFolderBackupChunked_NoChangedSinceBacksUpAll verifies that
+// omitting changed_since produces a full backup (all files in manifest).
+func TestFolderBackupChunked_NoChangedSinceBacksUpAll(t *testing.T) {
+	t.Parallel()
+
+	src := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(src, "a.txt"), []byte("aaa"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	repo, _, cleanup := dedup.NewTestRepoForEngine(t)
+	defer cleanup()
+
+	h := &FolderHandler{}
+	manifestID, err := h.BackupChunked(context.Background(), BackupItem{
+		Name: "all-files",
+		Type: "folder",
+		Settings: map[string]any{
+			"path": src,
+		},
+	}, repo, func(string, int, string) {})
+	if err != nil {
+		t.Fatalf("BackupChunked: %v", err)
+	}
+	if err := repo.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	m, err := repo.GetManifest(manifestID)
+	if err != nil {
+		t.Fatalf("GetManifest: %v", err)
+	}
+	if _, ok := m.Files["a.txt"]; !ok {
+		t.Error("expected a.txt in manifest (no changed_since filter)")
+	}
+}
+
+// TestFolderBackupChunked_InvalidChangedSinceFallsBackToFull verifies
+// that a malformed changed_since value is silently ignored (same behaviour
+// as the classic tar path).
+func TestFolderBackupChunked_InvalidChangedSinceFallsBackToFull(t *testing.T) {
+	t.Parallel()
+
+	src := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(src, "b.txt"), []byte("bbb"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	repo, _, cleanup := dedup.NewTestRepoForEngine(t)
+	defer cleanup()
+
+	h := &FolderHandler{}
+	manifestID, err := h.BackupChunked(context.Background(), BackupItem{
+		Name: "garbage-changed-since",
+		Type: "folder",
+		Settings: map[string]any{
+			"path":          src,
+			"changed_since": "not-rfc3339",
+		},
+	}, repo, func(string, int, string) {})
+	if err != nil {
+		t.Fatalf("BackupChunked: %v", err)
+	}
+	if err := repo.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	m, err := repo.GetManifest(manifestID)
+	if err != nil {
+		t.Fatalf("GetManifest: %v", err)
+	}
+	if _, ok := m.Files["b.txt"]; !ok {
+		t.Error("expected b.txt in manifest (invalid changed_since should fall back to full)")
+	}
+}

--- a/internal/engine/folder_chunked_changed_since_test.go
+++ b/internal/engine/folder_chunked_changed_since_test.go
@@ -10,163 +10,146 @@ import (
 	"github.com/ruaan-deysel/vault/internal/dedup"
 )
 
-// TestFolderBackupChunked_ChangedSinceSkipsOldFiles verifies that
-// BackupChunked skips files whose mtime is before changed_since.
-func TestFolderBackupChunked_ChangedSinceSkipsOldFiles(t *testing.T) {
+// TestFolderBackupChunked_ChangedSince verifies that BackupChunked
+// honours the changed_since setting for differential backups.
+//
+// Boundary convention: a file whose mtime equals changed_since is
+// treated as "not changed" (skipped). This matches pathChangedSince
+// and tarDirectoryFiltered in the classic tar path.
+func TestFolderBackupChunked_ChangedSince(t *testing.T) {
 	t.Parallel()
 
-	src := t.TempDir()
+	// Use a fixed reference timestamp well in the past so we can
+	// place files at "older", "equal", and "newer" offsets.
+	changedSince := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
 
-	// Create an "old" file and set its mtime to 3 hours ago.
-	oldFile := filepath.Join(src, "old.txt")
-	if err := os.WriteFile(oldFile, []byte("old data"), 0o600); err != nil {
-		t.Fatalf("write old: %v", err)
-	}
-	past := time.Now().Add(-3 * time.Hour)
-	if err := os.Chtimes(oldFile, past, past); err != nil {
-		t.Fatalf("chtimes old: %v", err)
-	}
-
-	// Create a "new" file with current mtime.
-	newFile := filepath.Join(src, "new.txt")
-	if err := os.WriteFile(newFile, []byte("new data"), 0o600); err != nil {
-		t.Fatalf("write new: %v", err)
-	}
-
-	// Create a subdirectory with an old file.
-	subDir := filepath.Join(src, "subdir")
-	if err := os.MkdirAll(subDir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	subOldFile := filepath.Join(subDir, "sub_old.txt")
-	if err := os.WriteFile(subOldFile, []byte("sub old"), 0o600); err != nil {
-		t.Fatalf("write sub old: %v", err)
-	}
-	if err := os.Chtimes(subOldFile, past, past); err != nil {
-		t.Fatalf("chtimes sub old: %v", err)
-	}
-
-	// Open repo using the shared test helper.
-	repo, _, cleanup := dedup.NewTestRepoForEngine(t)
-	defer cleanup()
-
-	// Backup with changed_since = 1 hour ago.
-	changedSince := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
-	h := &FolderHandler{}
-	manifestID, err := h.BackupChunked(context.Background(), BackupItem{
-		Name: "test-folder",
-		Type: "folder",
-		Settings: map[string]any{
-			"path":          src,
-			"changed_since": changedSince,
+	tests := []struct {
+		name           string
+		settings       map[string]any
+		files          []testFile
+		wantInManifest []string
+		wantExcluded   []string
+	}{
+		{
+			name: "skips old files, includes new files and directory entries",
+			settings: map[string]any{
+				"changed_since": changedSince.Format(time.RFC3339),
+			},
+			files: []testFile{
+				{name: "old.txt", content: "old", offset: -3 * time.Hour},
+				{name: "new.txt", content: "new", offset: +2 * time.Hour},
+				{name: "subdir/sub_old.txt", content: "sub old", offset: -3 * time.Hour},
+			},
+			wantInManifest: []string{"new.txt", "subdir"},
+			wantExcluded:   []string{"old.txt", filepath.Join("subdir", "sub_old.txt")},
 		},
-	}, repo, func(string, int, string) {})
-	if err != nil {
-		t.Fatalf("BackupChunked: %v", err)
-	}
-	if err := repo.Flush(); err != nil {
-		t.Fatalf("Flush: %v", err)
+		{
+			name:     "omitting changed_since produces a full backup",
+			settings: map[string]any{},
+			files: []testFile{
+				{name: "a.txt", content: "aaa", offset: -3 * time.Hour},
+			},
+			wantInManifest: []string{"a.txt"},
+		},
+		{
+			name: "malformed changed_since falls back to full backup",
+			settings: map[string]any{
+				"changed_since": "not-rfc3339",
+			},
+			files: []testFile{
+				{name: "b.txt", content: "bbb", offset: -3 * time.Hour},
+			},
+			wantInManifest: []string{"b.txt"},
+		},
+		{
+			name: "file with mtime equal to changed_since is excluded",
+			settings: map[string]any{
+				"changed_since": changedSince.Format(time.RFC3339),
+			},
+			files: []testFile{
+				{name: "boundary.txt", content: "equal", atExact: changedSince},
+				{name: "after.txt", content: "after", offset: +1 * time.Hour},
+			},
+			wantInManifest: []string{"after.txt"},
+			wantExcluded:   []string{"boundary.txt"},
+		},
 	}
 
-	// Retrieve manifest and verify only the new file is present.
-	m, err := repo.GetManifest(manifestID)
-	if err != nil {
-		t.Fatalf("GetManifest: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// new.txt should be in the manifest.
-	if _, ok := m.Files["new.txt"]; !ok {
-		t.Error("expected new.txt in manifest")
-	}
+			src := t.TempDir()
+			for _, tf := range tt.files {
+				tf.write(t, src, changedSince)
+			}
 
-	// old.txt and subdir/sub_old.txt should NOT be in the manifest.
-	if _, ok := m.Files["old.txt"]; ok {
-		t.Error("expected old.txt to be skipped (mtime before changed_since)")
-	}
-	if _, ok := m.Files[filepath.Join("subdir", "sub_old.txt")]; ok {
-		t.Error("expected subdir/sub_old.txt to be skipped (mtime before changed_since)")
-	}
+			repo, _, cleanup := dedup.NewTestRepoForEngine(t)
+			defer cleanup()
 
-	// The subdir entry itself should still be recorded (directory structure preserved).
-	if _, ok := m.Files["subdir"]; !ok {
-		t.Error("expected subdir directory entry in manifest")
+			tt.settings["path"] = src
+
+			h := &FolderHandler{}
+			manifestID, err := h.BackupChunked(context.Background(), BackupItem{
+				Name:     "test-folder",
+				Type:     "folder",
+				Settings: tt.settings,
+			}, repo, func(string, int, string) {})
+			if err != nil {
+				t.Fatalf("BackupChunked: %v", err)
+			}
+			if err := repo.Flush(); err != nil {
+				t.Fatalf("Flush: %v", err)
+			}
+
+			m, err := repo.GetManifest(manifestID)
+			if err != nil {
+				t.Fatalf("GetManifest: %v", err)
+			}
+
+			for _, name := range tt.wantInManifest {
+				if _, ok := m.Files[name]; !ok {
+					t.Errorf("expected %q in manifest", name)
+				}
+			}
+			for _, name := range tt.wantExcluded {
+				if _, ok := m.Files[name]; ok {
+					t.Errorf("expected %q to be excluded from manifest", name)
+				}
+			}
+		})
 	}
 }
 
-// TestFolderBackupChunked_NoChangedSinceBacksUpAll verifies that
-// omitting changed_since produces a full backup (all files in manifest).
-func TestFolderBackupChunked_NoChangedSinceBacksUpAll(t *testing.T) {
-	t.Parallel()
-
-	src := t.TempDir()
-
-	if err := os.WriteFile(filepath.Join(src, "a.txt"), []byte("aaa"), 0o600); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-
-	repo, _, cleanup := dedup.NewTestRepoForEngine(t)
-	defer cleanup()
-
-	h := &FolderHandler{}
-	manifestID, err := h.BackupChunked(context.Background(), BackupItem{
-		Name: "all-files",
-		Type: "folder",
-		Settings: map[string]any{
-			"path": src,
-		},
-	}, repo, func(string, int, string) {})
-	if err != nil {
-		t.Fatalf("BackupChunked: %v", err)
-	}
-	if err := repo.Flush(); err != nil {
-		t.Fatalf("Flush: %v", err)
-	}
-
-	m, err := repo.GetManifest(manifestID)
-	if err != nil {
-		t.Fatalf("GetManifest: %v", err)
-	}
-	if _, ok := m.Files["a.txt"]; !ok {
-		t.Error("expected a.txt in manifest (no changed_since filter)")
-	}
+// testFile describes a file to create on disk for a test case.
+type testFile struct {
+	name    string
+	content string
+	// offset is relative to changedSince; negative = before, positive = after.
+	// Ignored when atExact is non-zero.
+	offset time.Duration
+	// atExact pins the file mtime to this timestamp.
+	atExact time.Time
 }
 
-// TestFolderBackupChunked_InvalidChangedSinceFallsBackToFull verifies
-// that a malformed changed_since value is silently ignored (same behaviour
-// as the classic tar path).
-func TestFolderBackupChunked_InvalidChangedSinceFallsBackToFull(t *testing.T) {
-	t.Parallel()
+func (tf testFile) write(t *testing.T, dir string, changedSince time.Time) {
+	t.Helper()
 
-	src := t.TempDir()
-
-	if err := os.WriteFile(filepath.Join(src, "b.txt"), []byte("bbb"), 0o600); err != nil {
-		t.Fatalf("write: %v", err)
+	full := filepath.Join(dir, tf.name)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", tf.name, err)
+	}
+	if err := os.WriteFile(full, []byte(tf.content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", tf.name, err)
 	}
 
-	repo, _, cleanup := dedup.NewTestRepoForEngine(t)
-	defer cleanup()
-
-	h := &FolderHandler{}
-	manifestID, err := h.BackupChunked(context.Background(), BackupItem{
-		Name: "garbage-changed-since",
-		Type: "folder",
-		Settings: map[string]any{
-			"path":          src,
-			"changed_since": "not-rfc3339",
-		},
-	}, repo, func(string, int, string) {})
-	if err != nil {
-		t.Fatalf("BackupChunked: %v", err)
+	var mtime time.Time
+	if !tf.atExact.IsZero() {
+		mtime = tf.atExact
+	} else {
+		mtime = changedSince.Add(tf.offset)
 	}
-	if err := repo.Flush(); err != nil {
-		t.Fatalf("Flush: %v", err)
-	}
-
-	m, err := repo.GetManifest(manifestID)
-	if err != nil {
-		t.Fatalf("GetManifest: %v", err)
-	}
-	if _, ok := m.Files["b.txt"]; !ok {
-		t.Error("expected b.txt in manifest (invalid changed_since should fall back to full)")
+	if err := os.Chtimes(full, mtime, mtime); err != nil {
+		t.Fatalf("chtimes %s: %v", tf.name, err)
 	}
 }


### PR DESCRIPTION
## Honor `changed_since` in chunked/dedup backup path

### Problem

The chunked/dedup backup path (`BackupChunked`) ignored the `changed_since` setting used for differential backups. While the classic tar path correctly skipped unchanged files via `tarDirectoryFiltered`, the dedup path walked and hashed every source file on every differential run — relying on content-addressed dedup to avoid writing duplicate chunks, but still spending hours reading unchanged data from disk.

### Changes

**`FolderHandler.BackupChunked`** (`folder.go`):
- Parse `changed_since` from `item.Settings` via the existing `parseChangedSince` helper
- Skip regular files whose mtime is before the reference timestamp
- Directory entries are still recorded in the manifest so restore can recreate structure

**`ContainerHandler.BackupChunked`** (`container.go`):
- Skip entire unchanged volumes via `pathChangedSince` fast-check (mirrors classic `Backup` path)
- Propagate `changed_since` into each volume's `volItem.Settings` so `FolderHandler.BackupChunked` can do per-file filtering

### Tests

- `TestFolderBackupChunked_ChangedSinceSkipsOldFiles` — old files excluded, new files included, directory structure preserved
- `TestFolderBackupChunked_NoChangedSinceBacksUpAll` — omitted setting = full backup (no regression)
- `TestFolderBackupChunked_InvalidChangedSinceFallsBackToFull` — malformed value silently ignored (matches classic path)

### Impact

Differential backups on dedup-enabled destinations will now skip unchanged data at the filesystem level instead of reading and hashing everything. For a 2 TB dataset with minor daily changes, this turns hours of I/O into minutes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added differential backup support for chunked container volumes using a configured `changed_since` reference.
  * Unchanged volume sources can now be skipped, while preserving required structure in the backup manifest.
  * Chunked file selection is now limited to items modified after the change reference.

* **Bug Fixes**
  * Malformed or missing `changed_since` now reliably results in a full backup.

* **Tests**
  * Updated and consolidated differential backup tests into a single table-driven suite, including boundary handling for mtime equal to the reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->