### PR TITLE
fix(web): make SPA boot resilient to blocked browser APIs (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - **Differential backups to dedup/chunked destinations now skip unchanged data at the filesystem level.** The chunked/dedup backup path did not honour the `changed_since` reference that the classic tar path already used, so an incremental run re-read and re-processed files (and whole container volumes) that had not changed since the last backup. Files and volumes older than the reference are now skipped in the chunked walk — matching the differential behaviour of the tar path — while directories are still recorded. A malformed or absent `changed_since` safely falls back to a full backup. Closes #249.
+- **The web UI no longer hangs forever on the loading spinner in Brave (and other privacy-hardened browsers).** Brave's default Shields can make `localStorage` and `matchMedia` throw a `SecurityError` — most often when the console is embedded in the Unraid page as an iframe — which aborted theme setup during boot before the app ever became interactive, so the tab loaded endlessly ("Tab is not responding"). Every storage/media-query access during startup is now guarded and degrades to sensible in-memory defaults, and a boot watchdog guarantees the interface always becomes usable even if a startup step stalls. Closes #250.
+
+### Changed
+
+- **A connection banner now appears when the live link to the Vault daemon is lost.** Instead of a silently frozen page, a banner explains that data may be out of date and offers a one-click reload, so a persistent connection problem is visible and recoverable rather than invisible.
+- **The live-update WebSocket now reconnects with exponential backoff and jitter** (capped at 30s) instead of a fixed 3-second loop, so an unreachable daemon no longer churns the network and many clients reconnecting after a restart don't stampede in lockstep.
 
 ### Security
+
+- **Direct LAN access to the daemon now answers browser Private Network Access preflights.** Chrome and Brave (130+/Edge 143+) block requests from a more-public origin to a private LAN/loopback address unless the daemon echoes `Access-Control-Allow-Private-Network: true` on the preflight. The daemon now returns this header alongside its existing CORS response, without changing the origin allow-list, so the Unraid-embedded and LAN-IP access paths keep working across browsers.
 
 - **Cleared three high-severity advisories in build-time dependencies.** `brace-expansion` (reachable through ESLint) is updated to a patched release in the web UI's dependency tree. The repository root also carried a second, unused npm project whose only declared dependency was the `shadcn` CLI — it was referenced nowhere, excluded from every build, yet still accumulated advisories (`brace-expansion`, `js-yaml`) that had to be patched. It has been removed rather than patched again. None of these packages ship in the daemon or the web UI, so no runtime behaviour changes.
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -107,6 +107,25 @@ func ReadOnlyGuard(next http.Handler) http.Handler {
 	})
 }
 
+// PrivateNetworkAccess answers Chrome/Brave Private Network Access (PNA)
+// preflights. When a page on a more-public origin (e.g. the Unraid webGUI on
+// *.myunraid.net) fetches the daemon on a private LAN/loopback address, the
+// browser sends an OPTIONS preflight carrying
+// Access-Control-Request-Private-Network: true and blocks the request unless the
+// response echoes Access-Control-Allow-Private-Network: true. go-chi/cors does
+// not emit this header, so add it here without touching the origin allow-list.
+// Registered outside cors.Handler so the header survives the preflight response
+// (issue #250).
+func PrivateNetworkAccess(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions &&
+			r.Header.Get("Access-Control-Request-Private-Network") == "true" {
+			w.Header().Set("Access-Control-Allow-Private-Network", "true")
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // BodySizeLimit returns middleware that limits the request body to maxBytes.
 // Requests exceeding the limit receive a 413 Payload Too Large response.
 func BodySizeLimit(maxBytes int64) func(http.Handler) http.Handler {

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-chi/cors"
+
 	"github.com/ruaan-deysel/vault/internal/crypto"
 	"github.com/ruaan-deysel/vault/internal/db"
 )
@@ -103,6 +105,82 @@ func TestReadOnlyGuard(t *testing.T) {
 				t.Errorf("got status %d, want %d", w.Code, tt.wantStatus)
 			}
 		})
+	}
+}
+
+func TestPrivateNetworkAccess(t *testing.T) {
+	t.Parallel()
+
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := PrivateNetworkAccess(okHandler)
+
+	tests := []struct {
+		name      string
+		method    string
+		pnaHeader string
+		wantAllow bool
+	}{
+		{"preflight with PNA request gets allow header", http.MethodOptions, "true", true},
+		{"preflight without PNA request header is untouched", http.MethodOptions, "", false},
+		{"non-preflight request is untouched", http.MethodGet, "true", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(tt.method, "/api/v1/health", nil)
+			if tt.pnaHeader != "" {
+				req.Header.Set("Access-Control-Request-Private-Network", tt.pnaHeader)
+			}
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			got := w.Header().Get("Access-Control-Allow-Private-Network")
+			if tt.wantAllow && got != "true" {
+				t.Fatalf("expected Access-Control-Allow-Private-Network=true, got %q", got)
+			}
+			if !tt.wantAllow && got != "" {
+				t.Fatalf("expected no Access-Control-Allow-Private-Network header, got %q", got)
+			}
+		})
+	}
+}
+
+// TestPrivateNetworkAccessWithCORS composes PrivateNetworkAccess with the real
+// cors.Handler in the same order the router wires them (PNA outer, CORS inner),
+// and asserts a realistic PNA preflight receives BOTH the standard CORS headers
+// AND Access-Control-Allow-Private-Network — the browser rejects the preflight
+// unless all are present (issue #250).
+func TestPrivateNetworkAccessWithCORS(t *testing.T) {
+	t.Parallel()
+
+	corsMW := cors.Handler(cors.Options{
+		AllowedOrigins:   []string{"https://*.myunraid.net", "http://localhost:*", "http://127.0.0.1:*"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowedHeaders:   []string{"Content-Type", "X-API-Key"},
+		AllowCredentials: true,
+		MaxAge:           300,
+	})
+	final := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := PrivateNetworkAccess(corsMW(final))
+
+	// Realistic PNA preflight: allowed origin + request-method + PNA request header.
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/health", nil)
+	req.Header.Set("Origin", "https://tower.myunraid.net")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	req.Header.Set("Access-Control-Request-Private-Network", "true")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://tower.myunraid.net" {
+		t.Fatalf("expected CORS origin echoed, got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Private-Network"); got != "true" {
+		t.Fatalf("expected Access-Control-Allow-Private-Network=true, got %q", got)
 	}
 }
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -44,6 +44,10 @@ func (s *Server) setupRoutes() *chi.Mux {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Heartbeat("/ping"))
 	r.Use(BodySizeLimit(maxRequestBodySize))
+	// Answer Private Network Access preflights before cors.Handler writes the
+	// preflight response, so Chrome/Brave don't block LAN/loopback fetches from
+	// a more-public origin (issue #250).
+	r.Use(PrivateNetworkAccess)
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   []string{"https://*.myunraid.net", "http://localhost:*", "http://127.0.0.1:*"},
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -136,6 +136,10 @@
         ready = true
       }
     })()
+
+    // Clear the watchdog on unmount so a pending timeout can't fire against a
+    // destroyed component (e.g. during dev HMR).
+    return () => clearTimeout(watchdog)
   })
 
   // Surface persistent connection trouble in a small, non-blocking banner so a

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,6 +1,6 @@
 <script>
   import { getRoute, navigate } from './lib/router.svelte.js'
-  import { connectWs } from './lib/ws.svelte.js'
+  import { connectWs, getWsStatus } from './lib/ws.svelte.js'
   import { initTheme, getMode, setMode, getIsThemed } from './lib/theme.svelte.js'
   import { api, setReplicaMode } from './lib/api.js'
   import { shouldRedirectRoute } from './lib/route-guard.js'
@@ -99,22 +99,54 @@
   let ready = $state(false)
   let replicaMode = $state(false)
 
-  onMount(async () => {
-    initTheme()
-    // Detect replica mode from health endpoint.
-    try {
-      const health = await api.health()
-      if (health.mode === 'replica') {
-        setReplicaMode(true)
-        replicaMode = true
+  // Watchdog threshold: how long any boot step may stall before we force the
+  // shell to render anyway. Brave's blocked storage APIs and an unreachable
+  // daemon (the LAN-IP workaround) could otherwise hang the SPA forever.
+  const BOOT_WATCHDOG_MS = 8000
+
+  onMount(() => {
+    let watchdog = setTimeout(() => {
+      ready = true
+    }, BOOT_WATCHDOG_MS)
+
+    ;(async () => {
+      try {
+        // initTheme is guarded internally, but keep a belt-and-braces catch so a
+        // future unguarded line here can never abort the boot sequence.
+        try { initTheme() } catch { /* theme failures must never block boot */ }
+
+        // Detect replica mode from health endpoint.
+        try {
+          const health = await api.health()
+          if (health.mode === 'replica') {
+            setReplicaMode(true)
+            replicaMode = true
+          }
+        } catch { /* ignore – default to daemon mode */ }
+
+        // connectWs is synchronous; guard it so a throwing WebSocket constructor
+        // can't reject this IIFE. The ws layer owns its own retry/backoff.
+        try { connectWs() } catch { /* ignore – ws layer reconnects on its own */ }
+
+        try {
+          await loadFeatureFlags()
+        } catch { /* ignore – store fails open; never block the app from becoming ready */ }
+      } finally {
+        clearTimeout(watchdog)
+        ready = true
       }
-    } catch { /* ignore – default to daemon mode */ }
-    connectWs()
-    try {
-      await loadFeatureFlags()
-    } catch { /* ignore – store fails open; never block the app from becoming ready */ }
-    ready = true
+    })()
   })
+
+  // Surface persistent connection trouble in a small, non-blocking banner so a
+  // failing daemon/WebSocket is diagnosable instead of appearing as a frozen
+  // page. Driven purely by the live-connection status: 'polling', 'connecting',
+  // and 'connected' are healthy/transient and stay silent. Deliberately NOT tied
+  // to boot-degraded state — a browser that merely blocks storage must not be
+  // reported as a daemon outage.
+  let connectionLost = $derived(
+    ready && (getWsStatus() === 'disconnected' || getWsStatus() === 'reconnecting')
+  )
 
   function isActive(path) {
     const route = getRoute()
@@ -159,6 +191,15 @@
 <CommandPalette bind:show={showCommandPalette} onclose={() => showCommandPalette = false} />
 
 <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[200] focus:px-4 focus:py-2 focus:bg-vault focus:text-white focus:rounded-lg focus:text-sm focus:font-medium">Skip to main content</a>
+
+{#if connectionLost}
+  <div role="status" aria-live="polite"
+    class="fixed top-0 left-0 right-0 z-[150] flex items-center justify-center gap-3 px-4 py-2 text-sm bg-amber-500/95 text-amber-950">
+    <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
+    <span>Live connection to the Vault daemon is unavailable. Data may be out of date.</span>
+    <button onclick={() => location.reload()} class="underline font-medium hover:no-underline">Reload</button>
+  </div>
+{/if}
 
 <div class="flex h-screen bg-surface">
   {#if !ready}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -148,9 +148,10 @@
   // and 'connected' are healthy/transient and stay silent. Deliberately NOT tied
   // to boot-degraded state — a browser that merely blocks storage must not be
   // reported as a daemon outage.
-  let connectionLost = $derived(
-    ready && (getWsStatus() === 'disconnected' || getWsStatus() === 'reconnecting')
-  )
+  let connectionLost = $derived.by(() => {
+    const wsStatus = getWsStatus()
+    return ready && (wsStatus === 'disconnected' || wsStatus === 'reconnecting')
+  })
 
   function isActive(path) {
     const route = getRoute()

--- a/web/src/lib/theme.svelte.js
+++ b/web/src/lib/theme.svelte.js
@@ -20,6 +20,36 @@ let isThemed = $state(false)
 /** @type {MediaQueryList | null} */
 let mediaQuery = null
 
+// Brave's aggressive Shields (and Safari private mode / sandboxed iframes) can
+// throw SecurityError on any localStorage access. These helpers degrade to
+// in-memory defaults instead of throwing, so a blocked storage API can never
+// abort theme init and, in turn, the whole boot sequence (issue #250).
+/** @param {string} key @returns {string | null} */
+function safeGet(key) {
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+/** @param {string} key @param {string} value @returns {boolean} true when persisted */
+function safeSet(key, value) {
+  try {
+    localStorage.setItem(key, value)
+    return true
+  } catch {
+    return false // storage blocked or quota exceeded – keep in-memory value only
+  }
+}
+
+/** @param {string} key */
+function safeRemove(key) {
+  try {
+    localStorage.removeItem(key)
+  } catch { /* storage blocked – nothing to remove */ }
+}
+
 const STYLE_CLASSES = ['theme-1bit', 'theme-8bit', 'theme-16bit']
 const VALID_STYLES = /** @type {const} */ (['default', '1bit', '8bit', '16bit'])
 const VALID_MODES = /** @type {const} */ (['light', 'system', 'dark'])
@@ -58,7 +88,7 @@ function applyTheme() {
 
 /** Migrate from old single-key 'vault-theme' to two-key system */
 function migrateOldTheme() {
-  const old = localStorage.getItem('vault-theme')
+  const old = safeGet('vault-theme')
   if (!old) return
   /** @type {Record<string, {style: string, mode: string}>} */
   const map = {
@@ -70,16 +100,30 @@ function migrateOldTheme() {
   }
   const mapped = map[old]
   if (mapped) {
-    localStorage.setItem(STYLE_KEY, mapped.style)
-    localStorage.setItem(MODE_KEY, mapped.mode)
+    // Apply the migrated preference in memory immediately so it takes effect
+    // this session even if persistence fails. initTheme reads the new keys
+    // after this returns, but on a failed write those keys are null and won't
+    // override what we set here.
+    style = /** @type {'default' | '1bit' | '8bit' | '16bit'} */ (mapped.style)
+    mode = /** @type {'light' | 'system' | 'dark'} */ (mapped.mode)
+    // Only retire the legacy key once BOTH new keys are durably written, so a
+    // partial write (e.g. quota exceeded mid-migration) can't drop the setting;
+    // vault-theme is retained for a retry on the next boot.
+    const wroteStyle = safeSet(STYLE_KEY, mapped.style)
+    const wroteMode = safeSet(MODE_KEY, mapped.mode)
+    if (wroteStyle && wroteMode) {
+      safeRemove('vault-theme')
+    }
+    return
   }
-  localStorage.removeItem('vault-theme')
+  // Unrecognised legacy value – nothing to preserve, drop it.
+  safeRemove('vault-theme')
 }
 
 export function initTheme() {
   migrateOldTheme()
-  const storedStyle = localStorage.getItem(STYLE_KEY)
-  const storedMode = localStorage.getItem(MODE_KEY)
+  const storedStyle = safeGet(STYLE_KEY)
+  const storedMode = safeGet(MODE_KEY)
   if (storedStyle && VALID_STYLES.includes(/** @type {any} */ (storedStyle))) {
     style = /** @type {'default' | '1bit' | '8bit' | '16bit'} */ (storedStyle)
   }
@@ -91,10 +135,18 @@ export function initTheme() {
   // to actually unregister the old listener – a fresh matchMedia() returns a
   // brand-new object that has no listeners attached.
   if (mediaQuery) {
-    mediaQuery.removeEventListener('change', applyTheme)
+    try {
+      mediaQuery.removeEventListener('change', applyTheme)
+    } catch { /* ignore – listener may not be attachable in this browser */ }
   }
-  mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-  mediaQuery.addEventListener('change', applyTheme)
+  // matchMedia is blocked by Brave's fingerprinting protection in some
+  // configs; degrade to the dark default rather than throwing (issue #250).
+  try {
+    mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    mediaQuery.addEventListener('change', applyTheme)
+  } catch {
+    mediaQuery = null
+  }
   applyTheme()
 }
 
@@ -124,13 +176,13 @@ export const getIsRetro = getIsThemed
 /** @param {'default' | '1bit' | '8bit' | '16bit'} newStyle */
 export function setStyle(newStyle) {
   style = newStyle
-  localStorage.setItem(STYLE_KEY, newStyle)
+  safeSet(STYLE_KEY, newStyle)
   applyTheme()
 }
 
 /** @param {'light' | 'system' | 'dark'} newMode */
 export function setMode(newMode) {
   mode = newMode
-  localStorage.setItem(MODE_KEY, newMode)
+  safeSet(MODE_KEY, newMode)
   applyTheme()
 }

--- a/web/src/lib/ws-backoff.js
+++ b/web/src/lib/ws-backoff.js
@@ -1,0 +1,21 @@
+// Bounded exponential backoff for WebSocket reconnection. Extracted as a pure,
+// runes-free module so the delay math can be unit-tested under the plain-node
+// vitest environment (ws.svelte.js itself uses $state and can't be imported
+// there). This is the core of the #250 fix that replaced the old fixed 3s
+// uncapped retry loop.
+
+export const RECONNECT_BASE_MS = 1000
+export const RECONNECT_MAX_MS = 30000
+
+/**
+ * Full-jitter exponential backoff: returns a delay in [0, cap], where the cap
+ * grows as base * 2**attempts and is clamped to RECONNECT_MAX_MS. Full jitter
+ * spreads reconnecting clients so they don't stampede after a daemon restart.
+ * @param {number} attempts  reconnect attempts so far (0-based)
+ * @param {() => number} rand random source in [0,1) — injectable for tests
+ * @returns {number} delay in milliseconds
+ */
+export function backoffDelay(attempts, rand = Math.random) {
+  const cap = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * 2 ** attempts)
+  return Math.round(rand() * cap)
+}

--- a/web/src/lib/ws-backoff.test.js
+++ b/web/src/lib/ws-backoff.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { backoffDelay, RECONNECT_BASE_MS, RECONNECT_MAX_MS } from './ws-backoff.js'
+
+describe('backoffDelay', () => {
+  it('never exceeds the cap, even at absurdly high attempt counts', () => {
+    // rand() => 1 yields the maximum possible delay for a given attempt count.
+    for (const attempts of [0, 1, 5, 10, 50, 1000]) {
+      expect(backoffDelay(attempts, () => 1)).toBeLessThanOrEqual(RECONNECT_MAX_MS)
+    }
+  })
+
+  it('grows exponentially before the cap and clamps after', () => {
+    expect(backoffDelay(0, () => 1)).toBe(RECONNECT_BASE_MS)      // 1000
+    expect(backoffDelay(1, () => 1)).toBe(RECONNECT_BASE_MS * 2)  // 2000
+    expect(backoffDelay(2, () => 1)).toBe(RECONNECT_BASE_MS * 4)  // 4000
+    // 1000 * 2**5 = 32000 → clamped to the 30000 ceiling.
+    expect(backoffDelay(5, () => 1)).toBe(RECONNECT_MAX_MS)
+    expect(backoffDelay(100, () => 1)).toBe(RECONNECT_MAX_MS)
+  })
+
+  it('applies full jitter within [0, cap]', () => {
+    expect(backoffDelay(10, () => 0)).toBe(0)
+    expect(backoffDelay(10, () => 0.5)).toBe(RECONNECT_MAX_MS / 2)
+  })
+})

--- a/web/src/lib/ws.svelte.js
+++ b/web/src/lib/ws.svelte.js
@@ -1,6 +1,7 @@
 /** WebSocket client with auto-reconnect */
 
 import { buildApiRequest, getLiveMode } from './runtime-config.js'
+import { backoffDelay } from './ws-backoff.js'
 import {
   handleAnomalyRaised,
   handleAnomalyUpdated,
@@ -18,19 +19,14 @@ let pollEnabled = false
 let status = $state('disconnected')
 
 // Bounded exponential backoff for reconnection. A fixed 3s uncapped loop churned
-// silently forever when the daemon was unreachable; backoff with jitter and a
-// ceiling makes persistent failures gentle on the daemon and diagnosable via the
-// connection indicator (issue #250).
-const RECONNECT_BASE_MS = 1000
-const RECONNECT_MAX_MS = 30000
+// silently forever when the daemon was unreachable; jittered, capped backoff
+// (see ws-backoff.js) makes persistent failures gentle on the daemon and
+// diagnosable via the connection indicator (issue #250).
 let reconnectAttempts = 0
 
 function scheduleReconnect() {
   clearTimeout(reconnectTimer)
-  const backoff = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * 2 ** reconnectAttempts)
-  // Full jitter: pick a random delay in [0, backoff] so many clients reconnecting
-  // after a daemon restart don't stampede in lockstep.
-  const delay = Math.round(Math.random() * backoff)
+  const delay = backoffDelay(reconnectAttempts)
   reconnectAttempts++
   reconnectTimer = setTimeout(connectWs, delay)
 }
@@ -148,7 +144,18 @@ export function connectWs() {
   status = 'connecting'
   // Capture this socket locally so a stale handler (from a socket that was
   // replaced) can never mutate shared state for the current connection.
-  const socket = new WebSocket(url)
+  let socket
+  try {
+    socket = new WebSocket(url)
+  } catch {
+    // The WebSocket constructor can throw (blocked API / SecurityError). This
+    // runs from the reconnect timer too, so swallow it and keep the bounded
+    // retry loop alive instead of letting the exception kill reconnection.
+    ws = null
+    status = 'reconnecting'
+    scheduleReconnect()
+    return
+  }
   ws = socket
 
   socket.onopen = () => {

--- a/web/src/lib/ws.svelte.js
+++ b/web/src/lib/ws.svelte.js
@@ -166,6 +166,9 @@ export function connectWs() {
   }
 
   socket.onmessage = (e) => {
+    // Drop late messages from a superseded socket so a reconnect race can't
+    // emit stale events — same guard as onopen/onclose.
+    if (ws !== socket) return
     try {
       const msg = JSON.parse(e.data)
       emitMessage(msg)

--- a/web/src/lib/ws.svelte.js
+++ b/web/src/lib/ws.svelte.js
@@ -17,6 +17,24 @@ let previousStatus = null
 let pollEnabled = false
 let status = $state('disconnected')
 
+// Bounded exponential backoff for reconnection. A fixed 3s uncapped loop churned
+// silently forever when the daemon was unreachable; backoff with jitter and a
+// ceiling makes persistent failures gentle on the daemon and diagnosable via the
+// connection indicator (issue #250).
+const RECONNECT_BASE_MS = 1000
+const RECONNECT_MAX_MS = 30000
+let reconnectAttempts = 0
+
+function scheduleReconnect() {
+  clearTimeout(reconnectTimer)
+  const backoff = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * 2 ** reconnectAttempts)
+  // Full jitter: pick a random delay in [0, backoff] so many clients reconnecting
+  // after a daemon restart don't stampede in lockstep.
+  const delay = Math.round(Math.random() * backoff)
+  reconnectAttempts++
+  reconnectTimer = setTimeout(connectWs, delay)
+}
+
 export function getWsStatus() {
   return status
 }
@@ -128,14 +146,19 @@ export function connectWs() {
   let url = `${proto}//${location.host}/api/v1/ws`
 
   status = 'connecting'
-  ws = new WebSocket(url)
+  // Capture this socket locally so a stale handler (from a socket that was
+  // replaced) can never mutate shared state for the current connection.
+  const socket = new WebSocket(url)
+  ws = socket
 
-  ws.onopen = () => {
+  socket.onopen = () => {
+    if (ws !== socket) return
     status = 'connected'
+    reconnectAttempts = 0
     clearTimeout(reconnectTimer)
   }
 
-  ws.onmessage = (e) => {
+  socket.onmessage = (e) => {
     try {
       const msg = JSON.parse(e.data)
       emitMessage(msg)
@@ -144,14 +167,18 @@ export function connectWs() {
     }
   }
 
-  ws.onclose = () => {
-    status = 'disconnected'
+  socket.onclose = () => {
+    if (ws !== socket) return
+    // Every onclose schedules an automatic retry (disconnectWs detaches this
+    // handler for manual/terminal closes), so 'reconnecting' is the honest
+    // status — 'disconnected' is reserved for the idle/torn-down state.
+    status = 'reconnecting'
     ws = null
-    reconnectTimer = setTimeout(connectWs, 3000)
+    scheduleReconnect()
   }
 
-  ws.onerror = () => {
-    ws?.close()
+  socket.onerror = () => {
+    socket.close()
   }
 }
 
@@ -161,6 +188,7 @@ export function disconnectWs() {
   pollTimer = null
   pollEnabled = false
   previousStatus = null
+  reconnectAttempts = 0
   if (ws) {
     ws.onclose = null
     ws.close()


### PR DESCRIPTION
Closes #250.

## Root cause
The UI hangs forever on the "Connecting…" spinner in **Brave** (and other privacy-hardened browsers) — often only when embedded in the Unraid page as an iframe — while every other client on the network works fine.

`initTheme()` ran **first and unguarded** in `App.svelte`'s `onMount`. Brave's default Shields make `localStorage` and `matchMedia` throw a `SecurityError`; that throw rejected the async boot sequence *before* `ready` flipped, so the app never became interactive ("Tab is not responding"). The reporter's iPad (Safari) worked because it doesn't block those APIs in that context.

## Changes (following the CodeRabbit plan)

**Phase 1 — resilient boot (the actual fix)**
- `web/src/lib/theme.svelte.js`: every `localStorage` read/write and the `matchMedia` call/listener is guarded and degrades to in-memory defaults. Legacy-theme migration now applies in memory immediately and only retires the old key once **both** new keys are durably written (no data loss on a partial/quota-limited write).
- `web/src/App.svelte`: the whole `onMount` body is wrapped in `try/finally` so `ready` always flips, plus an 8s **boot watchdog** that force-renders the shell if any step stalls.

**Phase 2 — live-connection hardening + visibility**
- `web/src/lib/ws.svelte.js`: bounded **exponential backoff with full jitter** (cap 30s) replacing the fixed 3s uncapped loop; the socket is captured locally so a stale handler can't mutate the current connection.
- A non-blocking **connection banner** (with a one-click reload) appears when the live link is lost. It's driven purely by live-connection status — deliberately **not** by boot-degraded state, so a storage-blocking browser is never misreported as a daemon outage.

**Phase 3 — cross-browser LAN access**
- `internal/api`: a small `PrivateNetworkAccess` middleware answers Chrome/Brave **Private Network Access** preflights with `Access-Control-Allow-Private-Network: true` (registered before `cors.Handler` so the header rides the preflight response), without changing the origin allow-list. This keeps the LAN-IP and Unraid-embedded paths working on Chrome 130+/Edge 143+.

### Deliberately **not** changed
`apply.sh` / `api.php` / `Backups.page` (Phase 3 plugin tasks): the stale-PID restart and loopback-target paths are already handled by the earlier #124/#130/#136 fixes and reproduce cleanly, so touching them would be churn without a repro. Happy to add if a concrete failure surfaces.

## Verification
- Cross-checked the approach against Chrome PNA docs / WICG spec (PNA preflights are CORS preflights and must carry `Access-Control-Allow-Private-Network`) and Brave's storage-blocking behavior.
- **Playwright (Chromium):** forced `localStorage.getItem` and `matchMedia` to throw `SecurityError`, reloaded → the Dashboard boots fully (nav, KPIs, live activity) past the spinner with **0 console errors**. Normal mode still persists theme correctly.
- Live `OPTIONS` preflight on the daemon returns `Access-Control-Allow-Private-Network: true` alongside the standard CORS headers only when the request header is present.
- New Go tests for the PNA middleware (unit + integration composing the real `cors.Handler`).
- `make build` / `make deploy` / `make verify` on Unraid — all green.
- CodeRabbit CLI reviewed iteratively; all valid findings addressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visible connection-lost banner with a one-click reload option.
  - Improved direct LAN access in browsers supporting Private Network Access.

- **Bug Fixes**
  - Prevented startup hangs in privacy-hardened browsers.
  - Added safeguards so blocked browser storage and media-query access do not prevent the app loading.

- **Improvements**
  - WebSocket reconnection now uses adaptive backoff and jitter, reducing repeated connection attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->