### PR TITLE
fix(engine): Stop/restart containers in BackupChunked path  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ internal/release/CHANGELOG.md
 
 # Generated docs reference (built fresh in CI)
 docs/reference/*.md
+.worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -94,4 +94,3 @@ internal/release/CHANGELOG.md
 
 # Generated docs reference (built fresh in CI)
 docs/reference/*.md
-.worktrees

--- a/internal/engine/container.go
+++ b/internal/engine/container.go
@@ -559,7 +559,7 @@ func (h *ContainerHandler) Backup(ctx context.Context, item BackupItem, destDir 
 	if wasRunning && !noStop {
 		progress(item.Name, 20, "stopping container")
 		if _, err := h.cli.ContainerStop(ctx, containerID, client.ContainerStopOptions{}); err != nil {
-			return nil, fmt.Errorf("stopping container: %w", err)
+			return nil, fmt.Errorf("stopping container %s: %w", item.Name, err)
 		}
 	}
 
@@ -1374,71 +1374,90 @@ func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, r
 	// volume-relative paths (mapExclusionsToVolume) for the chunked walk.
 	exclusions := containerExclusions(item.Settings)
 	changedSince, hasChangedSince := parseChangedSince(item.Settings)
+	// Stop container for consistent backup (mirrors classic Backup path).
+	wasRunning := inspect.State.Running
+	noStop, _ := item.Settings["no_stop"].(bool)
+	if wasRunning && !noStop {
+		progress(item.Name, 5, "stopping container")
+		if _, err := h.cli.ContainerStop(ctx, containerID, client.ContainerStopOptions{}); err != nil {
+			return dedup.ID{}, fmt.Errorf("stopping container %s: %w", item.Name, err)
+		}
+	}
 	if progress != nil {
 		progress(item.Name, 50, "backing up volumes")
 	}
-	for _, mnt := range inspect.Mounts {
-		if !backupableMount(string(mnt.Type)) {
-			continue
-		}
-		if mnt.Source == "" || mnt.Destination == "" {
-			continue
-		}
-		key := containerVolPrefix + mnt.Destination
-		if !restorableVolume(string(mnt.Type), mnt.Name) {
-			log.Printf("engine: chunked: skipping anonymous volume %q for %s (not restorable)", mnt.Destination, item.Name)
-			m.Files[key] = dedup.ManifestEntry{Size: volumeSkippedSize}
-			continue
-		}
-		if skip, reason := shouldSkipVolume(mnt.Source); skip {
-			log.Printf("engine: chunked: skipping volume %s for %s: %s", mnt.Source, item.Name, reason)
-			m.Files[key] = dedup.ManifestEntry{Size: volumeSkippedSize}
-			continue
-		}
-		// Honour exclusion patterns at the volume level — for a `/` → `/rootfs`
-		// bind mount (Glances, Telegraf, Netdata) this prevents walking the
-		// entire host filesystem. Recorded as skipped so RestoreChunked keeps
-		// the diagnostic entry without dereferencing a missing sub-manifest.
-		if shouldExcludeMount(exclusions, mnt.Destination) {
-			log.Printf("engine: chunked: skipping volume %s for %s: matches exclusion pattern", mnt.Source, item.Name)
-			m.Files[key] = dedup.ManifestEntry{Size: volumeSkippedSize}
-			continue
-		}
-		// For differential backups, skip volumes whose entire tree is
-		// unchanged since the reference time. Mirrors the classic Backup
-		// path's pathChangedSince check.
-		if hasChangedSince {
-			changed, err := pathChangedSince(mnt.Source, changedSince)
-			if err != nil {
-				return dedup.ID{}, fmt.Errorf("checking volume %s changes: %w", mnt.Source, err)
+
+	err = runWithRestart(wasRunning && !noStop, item.Name, progress, func() error {
+		for _, mnt := range inspect.Mounts {
+			if !backupableMount(string(mnt.Type)) {
+				continue
 			}
-			if !changed {
-				log.Printf("engine: chunked: skipping volume %s for %s: unchanged since reference", mnt.Source, item.Name)
+			if mnt.Source == "" || mnt.Destination == "" {
+				continue
+			}
+			key := containerVolPrefix + mnt.Destination
+			if !restorableVolume(string(mnt.Type), mnt.Name) {
+				log.Printf("engine: chunked: skipping anonymous volume %q for %s (not restorable)", mnt.Destination, item.Name)
 				m.Files[key] = dedup.ManifestEntry{Size: volumeSkippedSize}
 				continue
 			}
+			if skip, reason := shouldSkipVolume(mnt.Source); skip {
+				log.Printf("engine: chunked: skipping volume %s for %s: %s", mnt.Source, item.Name, reason)
+				m.Files[key] = dedup.ManifestEntry{Size: volumeSkippedSize}
+				continue
+			}
+			// Honour exclusion patterns at the volume level — for a `/` → `/rootfs`
+			// bind mount (Glances, Telegraf, Netdata) this prevents walking the
+			// entire host filesystem. Recorded as skipped so RestoreChunked keeps
+			// the diagnostic entry without dereferencing a missing sub-manifest.
+			if shouldExcludeMount(exclusions, mnt.Destination) {
+				log.Printf("engine: chunked: skipping volume %s for %s: matches exclusion pattern", mnt.Source, item.Name)
+				m.Files[key] = dedup.ManifestEntry{Size: volumeSkippedSize}
+				continue
+			}
+			// For differential backups, skip volumes whose entire tree is
+			// unchanged since the reference time. Mirrors the classic Backup
+			// path's pathChangedSince check.
+			if hasChangedSince {
+				changed, err := pathChangedSince(mnt.Source, changedSince)
+				if err != nil {
+					return fmt.Errorf("checking volume %s changes: %w", mnt.Source, err)
+				}
+				if !changed {
+					log.Printf("engine: chunked: skipping volume %s for %s: unchanged since reference", mnt.Source, item.Name)
+					m.Files[key] = dedup.ManifestEntry{Size: volumeSkippedSize}
+					continue
+				}
+			}
+			volItem := BackupItem{
+				Name: mnt.Destination,
+				Type: "folder",
+				Settings: map[string]any{
+					"path":          mnt.Source,
+					"exclude_paths": mapExclusionsToVolume(exclusions, mnt.Destination),
+				},
+			}
+			// Propagate changed_since for per-file filtering inside
+			// FolderHandler.BackupChunked.
+			if hasChangedSince {
+				volItem.Settings["changed_since"] = item.Settings["changed_since"]
+			}
+			volManifestID, vErr := fh.BackupChunked(ctx, volItem, repo, progress)
+			if vErr != nil {
+				return fmt.Errorf("backup volume %s: %w", mnt.Destination, vErr)
+			}
+			m.Files[key] = dedup.ManifestEntry{
+				Size:   0,
+				Chunks: []dedup.ID{volManifestID},
+			}
 		}
-		volItem := BackupItem{
-			Name: mnt.Destination,
-			Type: "folder",
-			Settings: map[string]any{
-				"path":          mnt.Source,
-				"exclude_paths": mapExclusionsToVolume(exclusions, mnt.Destination),
-			},
-		}
-		// Propagate changed_since for per-file filtering inside
-		// FolderHandler.BackupChunked (Task 1).
-		if hasChangedSince {
-			volItem.Settings["changed_since"] = item.Settings["changed_since"]
-		}
-		volManifestID, vErr := fh.BackupChunked(ctx, volItem, repo, progress)
-		if vErr != nil {
-			return dedup.ID{}, fmt.Errorf("backup volume %s: %w", mnt.Destination, vErr)
-		}
-		m.Files[key] = dedup.ManifestEntry{
-			Size:   0,
-			Chunks: []dedup.ID{volManifestID},
-		}
+		return nil
+	}, func() error {
+		_, err := h.cli.ContainerStart(ctx, containerID, client.ContainerStartOptions{})
+		return err
+	})
+	if err != nil {
+		return dedup.ID{}, err
 	}
 
 	manifestID, err := repo.PutManifest(item.Name, m)

--- a/internal/engine/container.go
+++ b/internal/engine/container.go
@@ -811,7 +811,9 @@ func runWithRestart(shouldRestart bool, itemName string, progress ProgressFunc, 
 		return runErr
 	}
 
-	progress(itemName, 92, "restarting container")
+	if progress != nil {
+		progress(itemName, 92, "restarting container")
+	}
 	restartErr := restart()
 	if restartErr == nil {
 		return runErr
@@ -1318,6 +1320,12 @@ func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, r
 		if err != nil {
 			return dedup.ID{}, fmt.Errorf("inspecting container: %w", err)
 		}
+		// Reassign containerID from the fresh inspect so that
+		// ContainerStop/ContainerStart below target the current container,
+		// not a stale ID from a previous run. Mirrors the classic Backup
+		// path (see containerID reassignment after fallback inspect).
+		containerID = inspectResult.Container.ID
+		log.Printf("[backup-chunked] container %q: resolved by name (ID changed from stored value to %s)", item.Name, ShortID(containerID))
 	}
 	inspect := inspectResult.Container
 	warnNetworkDependency(inspect, item.Name)
@@ -1378,13 +1386,15 @@ func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, r
 	wasRunning := inspect.State.Running
 	noStop, _ := item.Settings["no_stop"].(bool)
 	if wasRunning && !noStop {
-		progress(item.Name, 5, "stopping container")
+		if progress != nil {
+			progress(item.Name, 20, "stopping container")
+		}
 		if _, err := h.cli.ContainerStop(ctx, containerID, client.ContainerStopOptions{}); err != nil {
 			return dedup.ID{}, fmt.Errorf("stopping container %s: %w", item.Name, err)
 		}
 	}
 	if progress != nil {
-		progress(item.Name, 50, "backing up volumes")
+		progress(item.Name, 60, "backing up volumes")
 	}
 
 	err = runWithRestart(wasRunning && !noStop, item.Name, progress, func() error {

--- a/internal/engine/container_chunked_test.go
+++ b/internal/engine/container_chunked_test.go
@@ -2,7 +2,7 @@ package engine
 
 import (
 	"context"
-	"io"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,65 +15,16 @@ import (
 	"github.com/ruaan-deysel/vault/internal/dedup"
 )
 
-// chunkedStopMock tracks ContainerStop/ContainerStart calls while
-// delegating ContainerInspect and ImageInspect to canned responses.
-// It satisfies dockerClient at compile time.
-type chunkedStopMock struct {
-	inspectResp client.ContainerInspectResult
-	imageResp   client.ImageInspectResult
-
-	stopCalled  bool
-	startCalled bool
-}
-
-func (m *chunkedStopMock) ContainerList(_ context.Context, _ client.ContainerListOptions) (client.ContainerListResult, error) {
-	panic("unreachable")
-}
-func (m *chunkedStopMock) ContainerInspect(_ context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
-	return m.inspectResp, nil
-}
-func (m *chunkedStopMock) ContainerCreate(_ context.Context, _ client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
-	panic("unreachable")
-}
-func (m *chunkedStopMock) ContainerStart(_ context.Context, _ string, _ client.ContainerStartOptions) (client.ContainerStartResult, error) {
-	m.startCalled = true
-	return client.ContainerStartResult{}, nil
-}
-func (m *chunkedStopMock) ContainerStop(_ context.Context, _ string, _ client.ContainerStopOptions) (client.ContainerStopResult, error) {
-	m.stopCalled = true
-	return client.ContainerStopResult{}, nil
-}
-func (m *chunkedStopMock) ContainerRemove(_ context.Context, _ string, _ client.ContainerRemoveOptions) (client.ContainerRemoveResult, error) {
-	panic("unreachable")
-}
-func (m *chunkedStopMock) ImageInspect(_ context.Context, _ string, _ ...client.ImageInspectOption) (client.ImageInspectResult, error) {
-	return m.imageResp, nil
-}
-func (m *chunkedStopMock) ImageSave(_ context.Context, _ []string, _ ...client.ImageSaveOption) (client.ImageSaveResult, error) {
-	panic("unreachable")
-}
-func (m *chunkedStopMock) ImageLoad(_ context.Context, _ io.Reader, _ ...client.ImageLoadOption) (client.ImageLoadResult, error) {
-	panic("unreachable")
-}
-func (m *chunkedStopMock) ContainerStats(_ context.Context, _ string, _ client.ContainerStatsOptions) (client.ContainerStatsResult, error) {
-	return client.ContainerStatsResult{}, nil
-}
-func (m *chunkedStopMock) ImagePull(_ context.Context, _ string, _ client.ImagePullOptions) (client.ImagePullResponse, error) {
-	panic("unreachable")
-}
-
-var _ dockerClient = (*chunkedStopMock)(nil)
-
-// newChunkedMock builds a chunkedStopMock wired with a single bind mount
+// newRunningMock builds a mockDockerClient wired with a single bind mount
 // pointing at a temp dir with one small file, and a container in the
 // specified running state.
-func newChunkedMock(t *testing.T, running bool) *chunkedStopMock {
+func newRunningMock(t *testing.T, running bool) *mockDockerClient {
 	t.Helper()
 	volSrc := t.TempDir()
 	if err := os.WriteFile(filepath.Join(volSrc, "data.txt"), []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	return &chunkedStopMock{
+	return &mockDockerClient{
 		inspectResp: client.ContainerInspectResult{
 			Container: containertypes.InspectResponse{
 				ID:   "abc123",
@@ -104,108 +55,110 @@ func newChunkedMock(t *testing.T, running bool) *chunkedStopMock {
 // when shouldRestart is true).
 func noopProgress(_ string, _ int, _ string) {}
 
-// TestBackupChunked_StopsAndRestartsRunningContainer verifies that
-// BackupChunked calls ContainerStop before backing up volumes and
-// ContainerStart after, when the container is running and no_stop is
-// not set.
-func TestBackupChunked_StopsAndRestartsRunningContainer(t *testing.T) {
-	mock := newChunkedMock(t, true)
-
-	r, _, cleanup := dedup.NewTestRepoForEngine(t)
-	defer cleanup()
-
-	h := &ContainerHandler{cli: mock}
-	item := BackupItem{
-		Name:     "test",
-		Type:     "container",
-		Settings: map[string]any{"id": "abc123"},
-	}
-
-	// Must use non-nil progress because runWithRestart calls
-	// progress(itemName, 92, "restarting container") when shouldRestart
-	// is true.
-	if _, err := h.BackupChunked(context.Background(), item, r, noopProgress); err != nil {
-		t.Fatalf("BackupChunked() error = %v", err)
-	}
-
-	if !mock.stopCalled {
-		t.Error("expected ContainerStop to be called for running container")
-	}
-	if !mock.startCalled {
-		t.Error("expected ContainerStart to be called after backup")
-	}
-}
-
-// TestBackupChunked_NoStopSkipsStopAndStart verifies that when no_stop
-// is true, BackupChunked does NOT call ContainerStop or ContainerStart.
-func TestBackupChunked_NoStopSkipsStopAndStart(t *testing.T) {
-	mock := newChunkedMock(t, true)
-
-	r, _, cleanup := dedup.NewTestRepoForEngine(t)
-	defer cleanup()
-
-	h := &ContainerHandler{cli: mock}
-	item := BackupItem{
-		Name: "test",
-		Type: "container",
-		Settings: map[string]any{
-			"id":      "abc123",
-			"no_stop": true,
+// TestBackupChunked_StopRestartBehaviour consolidates the stop/restart
+// lifecycle tests for BackupChunked into a single table-driven test.
+// Each case varies the container running state, no_stop setting, and
+// optional mock error, then asserts whether ContainerStop and
+// ContainerStart were called.
+func TestBackupChunked_StopRestartBehaviour(t *testing.T) {
+	cases := []struct {
+		name          string
+		running       bool
+		noStop        bool
+		stopErr       error
+		wantStopCall  bool
+		wantStartCall bool
+		wantErr       bool
+	}{
+		{
+			name:          "running container is stopped and restarted",
+			running:       true,
+			noStop:        false,
+			wantStopCall:  true,
+			wantStartCall: true,
+		},
+		{
+			name:          "no_stop skips stop and start",
+			running:       true,
+			noStop:        true,
+			wantStopCall:  false,
+			wantStartCall: false,
+		},
+		{
+			name:          "already stopped container is left alone",
+			running:       false,
+			noStop:        false,
+			wantStopCall:  false,
+			wantStartCall: false,
+		},
+		{
+			name:          "ContainerStop error propagates and does not restart",
+			running:       true,
+			noStop:        false,
+			stopErr:       errors.New("mock stop failure"),
+			wantStopCall:  true,
+			wantStartCall: false,
+			wantErr:       true,
 		},
 	}
 
-	// no_stop=true means shouldRestart=false, so runWithRestart
-	// never calls progress. nil is safe here.
-	if _, err := h.BackupChunked(context.Background(), item, r, nil); err != nil {
-		t.Fatalf("BackupChunked() error = %v", err)
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := newRunningMock(t, tc.running)
+			mock.stopErr = tc.stopErr
 
-	if mock.stopCalled {
-		t.Error("ContainerStop should NOT be called when no_stop is true")
-	}
-	if mock.startCalled {
-		t.Error("ContainerStart should NOT be called when no_stop is true")
-	}
-}
+			r, _, cleanup := dedup.NewTestRepoForEngine(t)
+			defer cleanup()
 
-// TestBackupChunked_StoppedContainerNotStoppedAgain verifies that
-// BackupChunked does not call ContainerStop when the container is
-// already stopped (Running: false), and does not attempt to restart it.
-func TestBackupChunked_StoppedContainerNotStoppedAgain(t *testing.T) {
-	mock := newChunkedMock(t, false)
+			h := &ContainerHandler{cli: mock}
+			settings := map[string]any{"id": "abc123"}
+			if tc.noStop {
+				settings["no_stop"] = true
+			}
+			item := BackupItem{Name: "test", Type: "container", Settings: settings}
 
-	r, _, cleanup := dedup.NewTestRepoForEngine(t)
-	defer cleanup()
+			// Use non-nil progress when shouldRestart may be true
+			// (runWithRestart calls progress on restart).
+			var progress ProgressFunc = noopProgress
+			if !tc.running || tc.noStop {
+				progress = nil
+			}
 
-	h := &ContainerHandler{cli: mock}
-	item := BackupItem{
-		Name:     "test",
-		Type:     "container",
-		Settings: map[string]any{"id": "abc123"},
-	}
+			_, err := h.BackupChunked(context.Background(), item, r, progress)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+			} else if err != nil {
+				t.Fatalf("BackupChunked() unexpected error = %v", err)
+			}
 
-	// Container already stopped → shouldRestart=false → nil progress safe.
-	if _, err := h.BackupChunked(context.Background(), item, r, nil); err != nil {
-		t.Fatalf("BackupChunked() error = %v", err)
-	}
-
-	if mock.stopCalled {
-		t.Error("ContainerStop should NOT be called when container is already stopped")
-	}
-	if mock.startCalled {
-		t.Error("ContainerStart should NOT be called when container was not stopped")
+			if mock.stopCalled != tc.wantStopCall {
+				t.Errorf("stopCalled = %v, want %v", mock.stopCalled, tc.wantStopCall)
+			}
+			if mock.startCalled != tc.wantStartCall {
+				t.Errorf("startCalled = %v, want %v", mock.startCalled, tc.wantStartCall)
+			}
+		})
 	}
 }
 
 // TestBackupChunked_RestartsOnBackupError verifies that ContainerStart
 // is called even when the volume backup loop returns an error, which is
 // the core safety guarantee provided by runWithRestart.
+//
+// Note: This test relies on FolderHandler.BackupChunked failing when the
+// mount source directory does not exist. That coupling is intentional but
+// fragile — if FolderHandler.BackupChunked ever gains a graceful skip for
+// missing directories, this test would stop exercising the error path and
+// silently pass without validating the restart guarantee. Consider switching
+// to a mock FolderHandler if the coupling breaks.
 func TestBackupChunked_RestartsOnBackupError(t *testing.T) {
 	volSrc := t.TempDir()
 	// Point the mount at a nonexistent directory to force a backup failure.
 	nonexistent := filepath.Join(volSrc, "nosuchdir")
 
-	mock := &chunkedStopMock{
+	mock := &mockDockerClient{
 		inspectResp: client.ContainerInspectResult{
 			Container: containertypes.InspectResponse{
 				ID:   "fail-id",

--- a/internal/engine/container_chunked_test.go
+++ b/internal/engine/container_chunked_test.go
@@ -1,0 +1,256 @@
+package engine
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	containertypes "github.com/moby/moby/api/types/container"
+	imagetypes "github.com/moby/moby/api/types/image"
+	mounttypes "github.com/moby/moby/api/types/mount"
+	"github.com/moby/moby/client"
+
+	"github.com/ruaan-deysel/vault/internal/dedup"
+)
+
+// chunkedStopMock tracks ContainerStop/ContainerStart calls while
+// delegating ContainerInspect and ImageInspect to canned responses.
+// It satisfies dockerClient at compile time.
+type chunkedStopMock struct {
+	inspectResp client.ContainerInspectResult
+	imageResp   client.ImageInspectResult
+
+	stopCalled  bool
+	startCalled bool
+}
+
+func (m *chunkedStopMock) ContainerList(_ context.Context, _ client.ContainerListOptions) (client.ContainerListResult, error) {
+	panic("unreachable")
+}
+func (m *chunkedStopMock) ContainerInspect(_ context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+	return m.inspectResp, nil
+}
+func (m *chunkedStopMock) ContainerCreate(_ context.Context, _ client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
+	panic("unreachable")
+}
+func (m *chunkedStopMock) ContainerStart(_ context.Context, _ string, _ client.ContainerStartOptions) (client.ContainerStartResult, error) {
+	m.startCalled = true
+	return client.ContainerStartResult{}, nil
+}
+func (m *chunkedStopMock) ContainerStop(_ context.Context, _ string, _ client.ContainerStopOptions) (client.ContainerStopResult, error) {
+	m.stopCalled = true
+	return client.ContainerStopResult{}, nil
+}
+func (m *chunkedStopMock) ContainerRemove(_ context.Context, _ string, _ client.ContainerRemoveOptions) (client.ContainerRemoveResult, error) {
+	panic("unreachable")
+}
+func (m *chunkedStopMock) ImageInspect(_ context.Context, _ string, _ ...client.ImageInspectOption) (client.ImageInspectResult, error) {
+	return m.imageResp, nil
+}
+func (m *chunkedStopMock) ImageSave(_ context.Context, _ []string, _ ...client.ImageSaveOption) (client.ImageSaveResult, error) {
+	panic("unreachable")
+}
+func (m *chunkedStopMock) ImageLoad(_ context.Context, _ io.Reader, _ ...client.ImageLoadOption) (client.ImageLoadResult, error) {
+	panic("unreachable")
+}
+func (m *chunkedStopMock) ContainerStats(_ context.Context, _ string, _ client.ContainerStatsOptions) (client.ContainerStatsResult, error) {
+	return client.ContainerStatsResult{}, nil
+}
+func (m *chunkedStopMock) ImagePull(_ context.Context, _ string, _ client.ImagePullOptions) (client.ImagePullResponse, error) {
+	panic("unreachable")
+}
+
+var _ dockerClient = (*chunkedStopMock)(nil)
+
+// newChunkedMock builds a chunkedStopMock wired with a single bind mount
+// pointing at a temp dir with one small file, and a container in the
+// specified running state.
+func newChunkedMock(t *testing.T, running bool) *chunkedStopMock {
+	t.Helper()
+	volSrc := t.TempDir()
+	if err := os.WriteFile(filepath.Join(volSrc, "data.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return &chunkedStopMock{
+		inspectResp: client.ContainerInspectResult{
+			Container: containertypes.InspectResponse{
+				ID:   "abc123",
+				Name: "/test",
+				Config: &containertypes.Config{
+					Image: "nginx:latest",
+				},
+				State: &containertypes.State{Running: running},
+				Mounts: []containertypes.MountPoint{
+					{
+						Type:        mounttypes.TypeBind,
+						Source:      volSrc,
+						Destination: "/data",
+					},
+				},
+			},
+		},
+		imageResp: client.ImageInspectResult{
+			InspectResponse: imagetypes.InspectResponse{
+				RepoDigests: []string{"nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+			},
+		},
+	}
+}
+
+// noopProgress is a no-op ProgressFunc for tests where progress callbacks
+// are not under test but must be non-nil (runWithRestart calls progress
+// when shouldRestart is true).
+func noopProgress(_ string, _ int, _ string) {}
+
+// TestBackupChunked_StopsAndRestartsRunningContainer verifies that
+// BackupChunked calls ContainerStop before backing up volumes and
+// ContainerStart after, when the container is running and no_stop is
+// not set.
+func TestBackupChunked_StopsAndRestartsRunningContainer(t *testing.T) {
+	mock := newChunkedMock(t, true)
+
+	r, _, cleanup := dedup.NewTestRepoForEngine(t)
+	defer cleanup()
+
+	h := &ContainerHandler{cli: mock}
+	item := BackupItem{
+		Name:     "test",
+		Type:     "container",
+		Settings: map[string]any{"id": "abc123"},
+	}
+
+	// Must use non-nil progress because runWithRestart calls
+	// progress(itemName, 92, "restarting container") when shouldRestart
+	// is true.
+	if _, err := h.BackupChunked(context.Background(), item, r, noopProgress); err != nil {
+		t.Fatalf("BackupChunked() error = %v", err)
+	}
+
+	if !mock.stopCalled {
+		t.Error("expected ContainerStop to be called for running container")
+	}
+	if !mock.startCalled {
+		t.Error("expected ContainerStart to be called after backup")
+	}
+}
+
+// TestBackupChunked_NoStopSkipsStopAndStart verifies that when no_stop
+// is true, BackupChunked does NOT call ContainerStop or ContainerStart.
+func TestBackupChunked_NoStopSkipsStopAndStart(t *testing.T) {
+	mock := newChunkedMock(t, true)
+
+	r, _, cleanup := dedup.NewTestRepoForEngine(t)
+	defer cleanup()
+
+	h := &ContainerHandler{cli: mock}
+	item := BackupItem{
+		Name: "test",
+		Type: "container",
+		Settings: map[string]any{
+			"id":      "abc123",
+			"no_stop": true,
+		},
+	}
+
+	// no_stop=true means shouldRestart=false, so runWithRestart
+	// never calls progress. nil is safe here.
+	if _, err := h.BackupChunked(context.Background(), item, r, nil); err != nil {
+		t.Fatalf("BackupChunked() error = %v", err)
+	}
+
+	if mock.stopCalled {
+		t.Error("ContainerStop should NOT be called when no_stop is true")
+	}
+	if mock.startCalled {
+		t.Error("ContainerStart should NOT be called when no_stop is true")
+	}
+}
+
+// TestBackupChunked_StoppedContainerNotStoppedAgain verifies that
+// BackupChunked does not call ContainerStop when the container is
+// already stopped (Running: false), and does not attempt to restart it.
+func TestBackupChunked_StoppedContainerNotStoppedAgain(t *testing.T) {
+	mock := newChunkedMock(t, false)
+
+	r, _, cleanup := dedup.NewTestRepoForEngine(t)
+	defer cleanup()
+
+	h := &ContainerHandler{cli: mock}
+	item := BackupItem{
+		Name:     "test",
+		Type:     "container",
+		Settings: map[string]any{"id": "abc123"},
+	}
+
+	// Container already stopped → shouldRestart=false → nil progress safe.
+	if _, err := h.BackupChunked(context.Background(), item, r, nil); err != nil {
+		t.Fatalf("BackupChunked() error = %v", err)
+	}
+
+	if mock.stopCalled {
+		t.Error("ContainerStop should NOT be called when container is already stopped")
+	}
+	if mock.startCalled {
+		t.Error("ContainerStart should NOT be called when container was not stopped")
+	}
+}
+
+// TestBackupChunked_RestartsOnBackupError verifies that ContainerStart
+// is called even when the volume backup loop returns an error, which is
+// the core safety guarantee provided by runWithRestart.
+func TestBackupChunked_RestartsOnBackupError(t *testing.T) {
+	volSrc := t.TempDir()
+	// Point the mount at a nonexistent directory to force a backup failure.
+	nonexistent := filepath.Join(volSrc, "nosuchdir")
+
+	mock := &chunkedStopMock{
+		inspectResp: client.ContainerInspectResult{
+			Container: containertypes.InspectResponse{
+				ID:   "fail-id",
+				Name: "/fail-test",
+				Config: &containertypes.Config{
+					Image: "nginx:latest",
+				},
+				State: &containertypes.State{Running: true},
+				Mounts: []containertypes.MountPoint{
+					{
+						Type:        mounttypes.TypeBind,
+						Source:      nonexistent,
+						Destination: "/data",
+					},
+				},
+			},
+		},
+		imageResp: client.ImageInspectResult{
+			InspectResponse: imagetypes.InspectResponse{
+				RepoDigests: []string{"nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+			},
+		},
+	}
+
+	r, _, cleanup := dedup.NewTestRepoForEngine(t)
+	defer cleanup()
+
+	h := &ContainerHandler{cli: mock}
+	item := BackupItem{
+		Name:     "fail-test",
+		Type:     "container",
+		Settings: map[string]any{"id": "fail-id"},
+	}
+
+	// BackupChunked should fail because the mount source doesn't exist,
+	// but the container must still be restarted.
+	_, err := h.BackupChunked(context.Background(), item, r, noopProgress)
+	if err == nil {
+		t.Fatal("expected BackupChunked to fail for nonexistent mount source")
+	}
+
+	if !mock.stopCalled {
+		t.Error("expected ContainerStop to be called before backup attempt")
+	}
+	if !mock.startCalled {
+		t.Error("expected ContainerStart to be called even though backup failed (runWithRestart guarantee)")
+	}
+}

--- a/internal/engine/container_test.go
+++ b/internal/engine/container_test.go
@@ -568,6 +568,10 @@ type mockDockerClient struct {
 	inspectResp client.ContainerInspectResult
 	inspectErr  error
 	imageResp   client.ImageInspectResult
+
+	stopCalled  bool
+	startCalled bool
+	stopErr    error
 }
 
 func (m *mockDockerClient) ContainerInspect(ctx context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
@@ -587,10 +591,12 @@ func (m *mockDockerClient) ContainerCreate(ctx context.Context, _ client.Contain
 	return client.ContainerCreateResult{}, errors.New("mockDockerClient: ContainerCreate not implemented")
 }
 func (m *mockDockerClient) ContainerStart(ctx context.Context, _ string, _ client.ContainerStartOptions) (client.ContainerStartResult, error) {
-	return client.ContainerStartResult{}, errors.New("mockDockerClient: ContainerStart not implemented")
+	m.startCalled = true
+	return client.ContainerStartResult{}, nil
 }
 func (m *mockDockerClient) ContainerStop(ctx context.Context, _ string, _ client.ContainerStopOptions) (client.ContainerStopResult, error) {
-	return client.ContainerStopResult{}, errors.New("mockDockerClient: ContainerStop not implemented")
+	m.stopCalled = true
+	return client.ContainerStopResult{}, m.stopErr
 }
 func (m *mockDockerClient) ContainerRemove(ctx context.Context, _ string, _ client.ContainerRemoveOptions) (client.ContainerRemoveResult, error) {
 	return client.ContainerRemoveResult{}, errors.New("mockDockerClient: ContainerRemove not implemented")


### PR DESCRIPTION
### Summary

The dedup backup path (`BackupChunked`) was performing live backups of container volumes without ever stopping the container first — unlike the classic `Backup` path which correctly stops containers (unless `no_stop` is set) for consistent snapshots. This meant in-flight writes could corrupt dedup backups.

This PR mirrors the classic path's stop/restart pattern into `BackupChunked`: read `no_stop` from `item.Settings`, stop the container if running, wrap the volume backup loop in `runWithRestart` for guaranteed restart on error, and restart after completion.

### What changed

**`internal/engine/container.go`**
- **`BackupChunked`**: Added `no_stop` read + `ContainerStop` call before the volume backup loop (mirrors lines 559-564 from `Backup`). Wrapped the entire volume loop in `runWithRestart(wasRunning && !noStop, ...)` so the container is always restarted — even when backup fails.
- **`runWithRestart`**: Nil-guarded the `progress()` call at line 814. This benefits both code paths since `BackupChunked` callers may pass a nil progress function.
- **`Backup` (classic)**: Minor drive-by — added `item.Name` to the `ContainerStop` error message for consistency with `BackupChunked`.
- Progress percentage for "backing up volumes" aligned to 60% in `BackupChunked`, matching the classic path.
- Added `containerID` reassignment after name-based inspect lookup to ensure `ContainerStop`/`ContainerStart` target the correct container.

**`internal/engine/container_chunked_test.go`** (new)
- `TestBackupChunked_StopsAndRestartsRunningContainer` — running container is stopped before backup and restarted after.
- `TestBackupChunked_NoStopSkipsStopAndStart` — `no_stop: true` skips both stop and restart.
- `TestBackupChunked_StoppedContainerNotStoppedAgain` — already-stopped container is left alone.
- `TestBackupChunked_RestartsOnBackupError` — container is restarted even when the volume backup fails (the core `runWithRestart` safety guarantee).

**`internal/engine/container_test.go`**
- `mockDockerClient`: `ContainerStop` and `ContainerStart` now record calls (`stopCalled`, `startCalled`) instead of returning "not implemented" errors.

### Testing

All four new tests use real temp directories and a real dedup repo (via `dedup.NewTestRepoForEngine`), not just mock-call assertions. The error-path test verifies the critical guarantee: `runWithRestart` calls restart even when the volume backup loop returns an error.

```
go test ./internal/engine/... -v -run TestBackupChunked -count=1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved container backup reliability by ensuring running containers are restarted after backup attempts, including when errors occur.
  - Added clearer error messages identifying the affected container.
  - Improved handling of container name resolution and excluded or invalid volume mounts.
  - Preserved differential backup settings during chunked volume backups.

- **Tests**
  - Added coverage for container stop, restart, no-stop, stopped-container, and backup-failure scenarios.

- **Chores**
  - Updated ignore rules for worktree files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->