### PR TITLE
feat(engine): skip stop/restart for unchanged containers on differential runs

### DIFF
--- a/internal/engine/container.go
+++ b/internal/engine/container.go
@@ -556,14 +556,45 @@ func (h *ContainerHandler) Backup(ctx context.Context, item BackupItem, destDir 
 	// the checkbox-driven excluded_mounts from the job wizard.
 	exclusions := containerExclusions(item.Settings)
 
-	if wasRunning && !noStop {
+	// Differential runs: when no backupable volume changed since the parent
+	// restore point, skip the stop/restart cycle entirely. The in-loop
+	// per-volume pathChangedSince checks skip every volume anyway, so
+	// stopping would be pure downtime with no consistency benefit. The image
+	// save and template copy inside runWithRestart do NOT gate this decision
+	// — docker save is daemon-side and the template is a file copy; both are
+	// safe on a running container.
+	needsStop := wasRunning && !noStop
+	var volChanges map[string]bool
+	if needsStop && hasChangedSince {
+		// Accepted race: if a file changes between this pre-check and the
+		// archiving loop, that volume is backed up live instead of
+		// stopped. This matches pre-#253 behaviour but it's ultimately
+		// an accepted risk due to how negligible it is.
+		//
+		// When the pre-check runs, per-volume results are cached so the
+		// archiving loop reuses them instead of re-walking the same trees
+		// via pathChangedSince.
+		var anyChanged bool
+		var err error
+		volChanges, anyChanged, err = anyVolumeChangedSince(ctx, inspect.Mounts, exclusions, changedSince)
+		if err != nil {
+			return nil, err
+		}
+		if !anyChanged {
+			log.Printf("engine: container %s volumes unchanged since %s — skipping stop/restart",
+				item.Name, changedSince.Format(time.RFC3339))
+			needsStop = false
+		}
+	}
+
+	if needsStop {
 		progress(item.Name, 20, "stopping container")
 		if _, err := h.cli.ContainerStop(ctx, containerID, client.ContainerStopOptions{}); err != nil {
 			return nil, fmt.Errorf("stopping container %s: %w", item.Name, err)
 		}
 	}
 
-	if err := runWithRestart(wasRunning && !noStop, item.Name, progress, func() error {
+	if err := runWithRestart(needsStop, item.Name, progress, func() error {
 		// Step 3: Save image.
 		includeImage := true
 		if hasChangedSince {
@@ -626,6 +657,9 @@ func (h *ContainerHandler) Backup(ctx context.Context, item BackupItem, destDir 
 			if !backupableMount(string(mount.Type)) {
 				continue
 			}
+			if mount.Source == "" || mount.Destination == "" {
+				continue
+			}
 
 			entry := volumeManifestEntry{
 				Index:       i,
@@ -675,9 +709,13 @@ func (h *ContainerHandler) Backup(ctx context.Context, item BackupItem, destDir 
 			}
 
 			if hasChangedSince {
-				changed, err := pathChangedSince(ctx, mount.Source, changedSince)
-				if err != nil {
-					return fmt.Errorf("checking volume %s changes: %w", mount.Source, err)
+				changed, cached := volChanges[mount.Source]
+				if !cached {
+					var err error
+					changed, err = pathChangedSince(ctx, mount.Source, changedSince)
+					if err != nil {
+						return fmt.Errorf("checking volume %s changes: %w", mount.Source, err)
+					}
 				}
 				if !changed {
 					entry.BackedUp = false
@@ -839,6 +877,48 @@ func runWithRestart(shouldRestart bool, itemName string, progress ProgressFunc, 
 	}
 
 	return wrappedRestartErr
+}
+
+// anyVolumeChangedSince reports whether at least one backupable, restorable,
+// non-skipped, non-excluded volume in mounts has been modified after
+// changedSince. It applies the same skip filters — in the same order — as
+// the Backup and BackupChunked volume loops: exclusions are checked BEFORE
+// pathChangedSince so an excluded host-root bind mount (/ → /rootfs —
+// Telegraf, Netdata, Glances) is never walked (issues #70, #251).
+//
+// Callers use this to decide whether a differential run needs to stop the
+// container at all: when no volume changed, the in-loop per-volume
+// pathChangedSince checks skip every volume anyway, so the stop/restart
+// cycle would be pure downtime with no consistency benefit.
+func anyVolumeChangedSince(ctx context.Context, mounts []container.MountPoint, exclusions []string, changedSince time.Time) (map[string]bool, bool, error) {
+	changes := make(map[string]bool)
+	anyChanged := false
+	for _, mnt := range mounts {
+		if !backupableMount(string(mnt.Type)) {
+			continue
+		}
+		if mnt.Source == "" || mnt.Destination == "" {
+			continue
+		}
+		if !restorableVolume(string(mnt.Type), mnt.Name) {
+			continue
+		}
+		if skip, _ := shouldSkipVolume(mnt.Source); skip {
+			continue
+		}
+		if shouldExcludeMount(exclusions, mnt.Destination) {
+			continue
+		}
+		changed, err := pathChangedSince(ctx, mnt.Source, changedSince)
+		if err != nil {
+			return nil, false, fmt.Errorf("checking volume %s changes: %w", mnt.Source, err)
+		}
+		changes[mnt.Source] = changed
+		if changed {
+			anyChanged = true
+		}
+	}
+	return changes, anyChanged, nil
 }
 
 // Restore restores a Docker container from a backup directory:
@@ -1397,9 +1477,33 @@ func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, r
 	exclusions := containerExclusions(item.Settings)
 	changedSince, hasChangedSince := parseChangedSince(item.Settings)
 	// Stop container for consistent backup (mirrors classic Backup path).
+	// Differential runs: when no backupable volume changed since the parent
+	// restore point, skip the stop/restart cycle entirely — the in-loop
+	// per-volume pathChangedSince checks skip every volume anyway. The
+	// chunked path saves no image.tar (restore pulls the image), so only
+	// volume changes gate the stop.
 	wasRunning := inspect.State.Running
 	noStop, _ := item.Settings["no_stop"].(bool)
-	if wasRunning && !noStop {
+	needsStop := wasRunning && !noStop
+	var volChanges map[string]bool
+	if needsStop && hasChangedSince {
+		// Accepted race: if a file changes between this pre-check and the
+		// archiving loop, that volume is backed up live instead of stopped.
+		//
+		// Per-volume results are cached so the archiving loop reuses them.
+		var anyChanged bool
+		var err error
+		volChanges, anyChanged, err = anyVolumeChangedSince(ctx, inspect.Mounts, exclusions, changedSince)
+		if err != nil {
+			return dedup.ID{}, err
+		}
+		if !anyChanged {
+			log.Printf("engine: chunked: container %s volumes unchanged since %s — skipping stop/restart",
+				item.Name, changedSince.Format(time.RFC3339))
+			needsStop = false
+		}
+	}
+	if needsStop {
 		if progress != nil {
 			progress(item.Name, 20, "stopping container")
 		}
@@ -1411,7 +1515,7 @@ func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, r
 		progress(item.Name, 60, "backing up volumes")
 	}
 
-	err = runWithRestart(wasRunning && !noStop, item.Name, progress, func() error {
+	err = runWithRestart(needsStop, item.Name, progress, func() error {
 		for _, mnt := range inspect.Mounts {
 			if !backupableMount(string(mnt.Type)) {
 				continue
@@ -1441,11 +1545,15 @@ func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, r
 			}
 			// For differential backups, skip volumes whose entire tree is
 			// unchanged since the reference time. Mirrors the classic Backup
-			// path's pathChangedSince check.
+			// path. Reuses cached pre-check results when available.
 			if hasChangedSince {
-				changed, err := pathChangedSince(ctx, mnt.Source, changedSince)
-				if err != nil {
-					return fmt.Errorf("checking volume %s changes: %w", mnt.Source, err)
+				changed, cached := volChanges[mnt.Source]
+				if !cached {
+					var err error
+					changed, err = pathChangedSince(ctx, mnt.Source, changedSince)
+					if err != nil {
+						return fmt.Errorf("checking volume %s changes: %w", mnt.Source, err)
+					}
 				}
 				if !changed {
 					log.Printf("engine: chunked: skipping volume %s for %s: unchanged since reference", mnt.Source, item.Name)

--- a/internal/engine/container_chunked_test.go
+++ b/internal/engine/container_chunked_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	containertypes "github.com/moby/moby/api/types/container"
 	imagetypes "github.com/moby/moby/api/types/image"
@@ -205,5 +206,120 @@ func TestBackupChunked_RestartsOnBackupError(t *testing.T) {
 	}
 	if !mock.startCalled {
 		t.Error("expected ContainerStart to be called even though backup failed (runWithRestart guarantee)")
+	}
+}
+
+// newChunkedMockForChangedSince builds a mockDockerClient with a single
+// bind mount whose file tree (file and containing dir) is pinned to
+// volMtime via os.Chtimes, letting changed_since tests control whether
+// pathChangedSince sees the volume as changed.
+func newChunkedMockForChangedSince(t *testing.T, volMtime time.Time) *mockDockerClient {
+	t.Helper()
+	volSrc := t.TempDir()
+	file := filepath.Join(volSrc, "data.txt")
+	if err := os.WriteFile(file, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{file, volSrc} {
+		if err := os.Chtimes(p, volMtime, volMtime); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &mockDockerClient{
+		inspectResp: client.ContainerInspectResult{
+			Container: containertypes.InspectResponse{
+				ID:     "abc123",
+				Name:   "/test",
+				Config: &containertypes.Config{Image: "nginx:latest"},
+				State:  &containertypes.State{Running: true},
+				Mounts: []containertypes.MountPoint{
+					{Type: mounttypes.TypeBind, Source: volSrc, Destination: "/data"},
+				},
+			},
+		},
+		imageResp: client.ImageInspectResult{
+			InspectResponse: imagetypes.InspectResponse{
+				RepoDigests: []string{"nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+			},
+		},
+	}
+}
+
+// TestBackupChunked_DifferentialStopBehaviour consolidates the differential
+// pre-check tests for BackupChunked into a single table-driven test.
+// Each case varies whether the volume's files are older or newer than the
+// changed_since reference, then asserts whether ContainerStop and
+// ContainerStart were called. The unchanged case additionally verifies
+// the manifest records the volume as skipped.
+func TestBackupChunked_DifferentialStopBehaviour(t *testing.T) {
+	reference := time.Now().Add(-1 * time.Hour)
+
+	cases := []struct {
+		name           string
+		volMtime       time.Time // mtime applied to the volume's file and dir
+		wantStopCall   bool
+		wantStartCall  bool
+		checkSkipEntry bool // when true, verify manifest has volumeSkippedSize entry
+	}{
+		{
+			name:           "no_changes_skips_stop",
+			volMtime:       time.Now().Add(-2 * time.Hour),
+			wantStopCall:   false,
+			wantStartCall:  false,
+			checkSkipEntry: true,
+		},
+		{
+			name:          "volume_changed_stops_and_restarts",
+			volMtime:      time.Now(), // fresh — after the reference
+			wantStopCall:  true,
+			wantStartCall: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := newChunkedMockForChangedSince(t, tc.volMtime)
+
+			r, _, cleanup := dedup.NewTestRepoForEngine(t)
+			defer cleanup()
+
+			h := &ContainerHandler{cli: mock}
+			item := BackupItem{
+				Name: "test",
+				Type: "container",
+				Settings: map[string]any{
+					"id":            "abc123",
+					"changed_since": reference.UTC().Format(time.RFC3339),
+				},
+			}
+
+			manifestID, err := h.BackupChunked(context.Background(), item, r, noopProgress)
+			if err != nil {
+				t.Fatalf("BackupChunked() error = %v", err)
+			}
+			if mock.stopCalled != tc.wantStopCall {
+				t.Errorf("stopCalled = %v, want %v", mock.stopCalled, tc.wantStopCall)
+			}
+			if mock.startCalled != tc.wantStartCall {
+				t.Errorf("startCalled = %v, want %v", mock.startCalled, tc.wantStartCall)
+			}
+
+			if tc.checkSkipEntry {
+				if err := r.Flush(); err != nil {
+					t.Fatalf("Flush() error = %v", err)
+				}
+				m, err := r.GetManifest(manifestID)
+				if err != nil {
+					t.Fatalf("GetManifest() error = %v", err)
+				}
+				entry, ok := m.Files[containerVolPrefix+"/data"]
+				if !ok {
+					t.Fatalf("manifest missing %s/data entry", containerVolPrefix)
+				}
+				if entry.Size != volumeSkippedSize {
+					t.Errorf("volume entry Size = %d, want volumeSkippedSize (%d)", entry.Size, volumeSkippedSize)
+				}
+			}
+		})
 	}
 }

--- a/internal/engine/container_test.go
+++ b/internal/engine/container_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	containertypes "github.com/moby/moby/api/types/container"
 	imagetypes "github.com/moby/moby/api/types/image"
@@ -992,5 +993,226 @@ func TestContainerChunkedGCKeepsNestedVolumeData(t *testing.T) {
 		if _, err := r.Get(c); err != nil {
 			t.Fatalf("DATA LOSS: volume data chunk %x was swept by GC: %v", c[:8], err)
 		}
+	}
+}
+
+func TestAnyVolumeChangedSince(t *testing.T) {
+	reference := time.Now().Add(-1 * time.Hour)
+	old := time.Now().Add(-2 * time.Hour)
+	recent := time.Now()
+
+	// mkVolume creates a temp dir with one file whose mtime (and the dir's
+	// own mtime) is pinned to modTime, so pathChangedSince sees a stable
+	// changed/unchanged answer regardless of when the test runs.
+	mkVolume := func(t *testing.T, modTime time.Time) string {
+		t.Helper()
+		dir := t.TempDir()
+		file := filepath.Join(dir, "data.txt")
+		if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		for _, p := range []string{file, dir} {
+			if err := os.Chtimes(p, modTime, modTime); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return dir
+	}
+	bind := func(src, dest string) containertypes.MountPoint {
+		return containertypes.MountPoint{Type: mounttypes.TypeBind, Source: src, Destination: dest}
+	}
+
+	cases := []struct {
+		name        string
+		mounts      []containertypes.MountPoint
+		exclusions  []string
+		ctx         context.Context // defaults to context.Background() when nil
+		wantChanged bool
+		wantErr     bool
+	}{
+		{
+			name:        "no mounts returns false",
+			mounts:      nil,
+			wantChanged: false,
+		},
+		{
+			name: "all volumes unchanged returns false",
+			mounts: []containertypes.MountPoint{
+				bind(mkVolume(t, old), "/data"),
+				bind(mkVolume(t, old), "/config"),
+			},
+			wantChanged: false,
+		},
+		{
+			name: "one changed volume returns true",
+			mounts: []containertypes.MountPoint{
+				bind(mkVolume(t, old), "/data"),
+				bind(mkVolume(t, recent), "/config"),
+			},
+			wantChanged: true,
+		},
+		{
+			name: "changed but excluded mount is ignored",
+			mounts: []containertypes.MountPoint{
+				bind(mkVolume(t, recent), "/rootfs"),
+			},
+			exclusions:  []string{"/rootfs"},
+			wantChanged: false,
+		},
+		{
+			name: "non-backupable mount type is ignored",
+			mounts: []containertypes.MountPoint{
+				{Type: mounttypes.TypeTmpfs, Source: "", Destination: "/tmp"},
+			},
+			wantChanged: false,
+		},
+		{
+			name: "missing source returns error",
+			mounts: []containertypes.MountPoint{
+				bind(filepath.Join(t.TempDir(), "nosuchdir"), "/data"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "cancelled context returns error",
+			mounts: []containertypes.MountPoint{
+				bind(mkVolume(t, recent), "/data"),
+			},
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := tc.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			volChanges, anyChanged, err := anyVolumeChangedSince(ctx, tc.mounts, tc.exclusions, reference)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if anyChanged != tc.wantChanged {
+				t.Errorf("anyChanged = %v, want %v", anyChanged, tc.wantChanged)
+			}
+			// Verify per-volume map is consistent with the aggregate.
+			for _, mnt := range tc.mounts {
+				if cached, ok := volChanges[mnt.Source]; ok {
+					if cached && !tc.wantChanged {
+						t.Errorf("volChanges[%s] = true but wantChanged = false", mnt.Source)
+					}
+				}
+			}
+		})
+	}
+}
+
+// newClassicMock builds a mockDockerClient for classic Backup tests: one
+// bind mount at volSrc and a container whose Created timestamp is supplied
+// by the caller. createdAt must be RFC3339Nano-parseable and older than the
+// test's changed_since reference so the image save is skipped — the mock's
+// ImageSave intentionally returns an error, and the image-save block is the
+// only classic-path caller of it.
+func newClassicMock(t *testing.T, running bool, volSrc, createdAt string) *mockDockerClient {
+	t.Helper()
+	return &mockDockerClient{
+		inspectResp: client.ContainerInspectResult{
+			Container: containertypes.InspectResponse{
+				ID:      "abc123",
+				Name:    "/test",
+				Created: createdAt,
+				Config:  &containertypes.Config{Image: "nginx:latest"},
+				State:   &containertypes.State{Running: running},
+				Mounts: []containertypes.MountPoint{
+					{Type: mounttypes.TypeBind, Source: volSrc, Destination: "/data"},
+				},
+			},
+		},
+		imageResp: client.ImageInspectResult{
+			InspectResponse: imagetypes.InspectResponse{
+				RepoDigests: []string{"nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+			},
+		},
+	}
+}
+
+// TestBackupDifferentialStopBehaviour consolidates the differential
+// pre-check tests for the classic Backup path into a single table-driven
+// test. Each case varies whether the volume's files are older or newer
+// than the changed_since reference, then asserts whether ContainerStop
+// and ContainerStart were called.
+func TestBackupDifferentialStopBehaviour(t *testing.T) {
+	reference := time.Now().Add(-1 * time.Hour)
+	old := time.Now().Add(-2 * time.Hour)
+
+	cases := []struct {
+		name          string
+		volMtime      time.Time // mtime applied to the volume's file and dir
+		wantStopCall  bool
+		wantStartCall bool
+	}{
+		{
+			name:          "no_changes_skips_stop",
+			volMtime:      old,
+			wantStopCall:  false,
+			wantStartCall: false,
+		},
+		{
+			name:          "volume_changed_stops_and_restarts",
+			volMtime:      time.Now(), // fresh — after the reference
+			wantStopCall:  true,
+			wantStartCall: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			volSrc := t.TempDir()
+			file := filepath.Join(volSrc, "data.txt")
+			if err := os.WriteFile(file, []byte("hello"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			for _, p := range []string{file, volSrc} {
+				if err := os.Chtimes(p, tc.volMtime, tc.volMtime); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			mock := newClassicMock(t, true, volSrc, time.Now().Add(-48*time.Hour).UTC().Format(time.RFC3339Nano))
+			h := &ContainerHandler{cli: mock}
+			item := BackupItem{
+				Name: "test",
+				Type: "container",
+				Settings: map[string]any{
+					"id":            "abc123",
+					"changed_since": reference.UTC().Format(time.RFC3339),
+				},
+			}
+
+			result, err := h.Backup(context.Background(), item, t.TempDir(), noopProgress)
+			if err != nil {
+				t.Fatalf("Backup() error = %v", err)
+			}
+			if !result.Success {
+				t.Error("expected result.Success")
+			}
+			if mock.stopCalled != tc.wantStopCall {
+				t.Errorf("stopCalled = %v, want %v", mock.stopCalled, tc.wantStopCall)
+			}
+			if mock.startCalled != tc.wantStartCall {
+				t.Errorf("startCalled = %v, want %v", mock.startCalled, tc.wantStartCall)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Skip stop/restart for unchanged containers on differential runs

### Problem

On differential container backups, Vault stops and restarts every running container, even when none of their volumes have changed since the parent restore point. This produces pure-downtime stop/restart cycles with zero backup data to show for it. For users with dozens of containers on a differential schedule, this means unnecessary disruptions every run.

### Solution

Add a pre-check (`anyVolumeChangedSince`) that walks backupable volumes' mtimes **before** deciding whether to stop the container. When `changed_since` is set and no volume has changed, the container stays running. Per-volume results are cached and reused in the archiving loops, so each volume tree is walked exactly once.

The in-loop skip entries are still recorded in the manifest — manifest/volumes.json semantics are unchanged.

### Changes

- **`internal/engine/container.go`** (+128/-11)
  - `anyVolumeChangedSince` helper — applies the same skip filters as both backup loops (`backupableMount` → `Source/Destination non-empty` → `restorableVolume` → `shouldSkipVolume` → `shouldExcludeMount` → `pathChangedSince`), in the same order
  - Returns per-volume `map[string]bool` so callers cache results and the archiving loops skip the redundant `pathChangedSince` re-walk
  - Classic `Backup` and `BackupChunked` paths: gate `needsStop` behind the pre-check; archiving loops use cached results when available, fall back to `pathChangedSince` when the pre-check didn't run (`no_stop`, already-stopped)
  - Added `Source == ""` guard to the classic volume loop for consistency
  - Race-window documentation at both call sites

- **`internal/engine/container_test.go`** (+222)
  - `TestAnyVolumeChangedSince` — table-driven coverage: changed, excluded, non-backupable, missing source, cancelled context, per-volume map consistency
  - `TestBackupDifferentialStopBehaviour` — classic path stop/restart gating for changed vs unchanged volumes

- **`internal/engine/container_chunked_test.go`** (+116)
  - `TestBackupChunked_DifferentialStopBehaviour` — chunked path stop/restart gating + manifest skip-entry verification

### What's unaffected

- **Full backups** (`changed_since` absent) — pre-check gated behind `hasChangedSince`, zero extra filesystem walks
- **`no_stop` containers** — pre-check only narrows `needsStop`
- **Already-stopped containers** — `needsStop` starts as `false`
- **Image save / template copy** — happen inside `runWithRestart`, don't gate the stop decision

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Differential container backups now avoid unnecessary stop-and-start cycles when no eligible volumes have changed.
  * Backup processing now safely ignores mounts without valid source or destination paths.
  * Improved handling of excluded and unsupported volumes during change detection.

* **Tests**
  * Added coverage for changed and unchanged volumes, mount filtering, cancellation, and both standard and chunked backup workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->