### PR TITLE
fix(dedup): dedup container differential restore broken (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Differential and incremental container restores on dedup-enabled destinations no longer fail with "no such file or directory".** The dedup shortcut guard in `restoreItemChain` — which bypasses chain replay and restores the selected point directly via the chunked restore path — was gated on `itemType == "folder"` and positioned after the merged-chain dispatch that catches containers. Container dedup backups write a complete manifest every run (like folders), so the single-point restore is correct, but containers never reached the guard. The dedup check now runs before the merged-chain dispatch and applies to all item types. Classic (non-dedup) container restores are unaffected. Closes #266.
+
 ## [v2026.07.10] - 2026-07-24
 
 ### Fixed

--- a/internal/runner/restore_dedup_container_test.go
+++ b/internal/runner/restore_dedup_container_test.go
@@ -12,145 +12,152 @@ import (
 	"github.com/ruaan-deysel/vault/internal/storage"
 )
 
-// TestRestoreDedupContainerDifferentialRestoresDirectly verifies that a
-// differential container restore on a dedup-enabled destination takes the
-// single-point dedup path (restoreSinglePoint -> restoreSinglePointChunked)
-// instead of falling into restoreMergedChain -> stageRestorePointItem, which
-// fails because the container data lives in the dedup chunk store, not in
-// classic backup directories on storage.
-//
-// Regression for: differential container restore on dedup dest fails with
-// "listing restore files: open <path>: no such file or directory".
-func TestRestoreDedupContainerDifferentialRestoresDirectly(t *testing.T) {
-	t.Parallel()
+// TestRestoreDedupContainer contains regression tests for the dedup container
+// restore routing fix (issue #266). Subtests verify that:
+//   - dedup differential container restores take the single-point path
+//   - classic (non-dedup) container restores still use merged-chain staging
+func TestRestoreDedupContainer(t *testing.T) {
+	t.Run("dedup_differential_restores_directly", func(t *testing.T) {
+		t.Parallel()
+		restoreDir := t.TempDir()
 
-	r, database, storageDir := setupTestRunner(t)
-	r.serverKey = testServerKey()
-	dest := makeDedupDest(t, database, storageDir)
+		r, database, storageDir := setupTestRunner(t)
+		r.serverKey = testServerKey()
+		dest := makeDedupDest(t, database, storageDir)
 
-	// Initialise the dedup repo on disk.
-	adapter, err := storage.NewAdapter(dest.Type, dest.Config)
-	if err != nil {
-		t.Fatalf("NewAdapter: %v", err)
-	}
-	_, err = dedup.InitRepo(database, adapter, dest.ID, r.serverKey)
-	if err != nil {
-		t.Fatalf("InitRepo: %v", err)
-	}
-	storage.CloseAdapter(adapter)
+		// Initialise the dedup repo on disk.
+		adapter, err := storage.NewAdapter(dest.Type, dest.Config)
+		if err != nil {
+			t.Fatalf("NewAdapter: %v", err)
+		}
+		_, err = dedup.InitRepo(database, adapter, dest.ID, r.serverKey)
+		if err != nil {
+			t.Fatalf("InitRepo: %v", err)
+		}
+		storage.CloseAdapter(adapter)
 
-	// Create a job so restoreSinglePointChunked can look it up.
-	jobID, err := database.CreateJob(db.Job{
-		Name:          "test-containers",
-		StorageDestID: dest.ID,
-		Schedule:      "0 2 * * *",
+		// Create a job so restoreSinglePointChunked can look it up.
+		jobID, err := database.CreateJob(db.Job{
+			Name:          "test-containers",
+			StorageDestID: dest.ID,
+			Schedule:      "0 2 * * *",
+		})
+		if err != nil {
+			t.Fatalf("CreateJob: %v", err)
+		}
+
+		// Create a FULL restore point for the container "sonarr".
+		var fullManifestBytes [32]byte
+		for i := range fullManifestBytes {
+			fullManifestBytes[i] = byte(0xF0 + i) // distinct from the diff manifest
+		}
+		fullRunID, err := database.CreateJobRun(db.JobRun{
+			JobID: jobID, Status: "completed", BackupType: "full",
+		})
+		if err != nil {
+			t.Fatalf("CreateJobRun (full): %v", err)
+		}
+		fullRP := db.RestorePoint{
+			JobRunID:    fullRunID,
+			JobID:       jobID,
+			StoragePath: filepath.Join("Docker", "1_2026-07-20_020000"),
+			BackupType:  "full",
+			ManifestID:  fullManifestBytes[:],
+		}
+		fullRPID, err := database.CreateRestorePoint(fullRP)
+		if err != nil {
+			t.Fatalf("CreateRestorePoint (full): %v", err)
+		}
+		fullRP.ID = fullRPID
+
+		// Use a real 32-byte hex manifest ID so resolveManifestID succeeds.
+		var manifestBytes [32]byte
+		for i := range manifestBytes {
+			manifestBytes[i] = byte(i + 1)
+		}
+		diffManifestHex := hex.EncodeToString(manifestBytes[:])
+		diffMeta := map[string]any{
+			"item_manifests": map[string]any{
+				"sonarr": diffManifestHex,
+			},
+		}
+		diffMetaJSON, _ := json.Marshal(diffMeta)
+
+		diffRunID, err := database.CreateJobRun(db.JobRun{
+			JobID: jobID, Status: "completed", BackupType: "differential",
+		})
+		if err != nil {
+			t.Fatalf("CreateJobRun (diff): %v", err)
+		}
+		diffRP := db.RestorePoint{
+			JobRunID:             diffRunID,
+			JobID:                jobID,
+			StoragePath:          filepath.Join("Docker", "47_2026-07-20_130500"),
+			BackupType:           "differential",
+			ParentRestorePointID: fullRPID,
+			Metadata:             string(diffMetaJSON),
+		}
+		diffRPID, err := database.CreateRestorePoint(diffRP)
+		if err != nil {
+			t.Fatalf("CreateRestorePoint (diff): %v", err)
+		}
+		diffRP.ID = diffRPID
+
+		// RestoreItem should NOT error with "no such file or directory".
+		// It will fail later (no actual dedup chunks on disk, no real container
+		// handler in test) — but the key assertion is that it does NOT fail at
+		// the stageRestorePointItem listing step. We accept any error that is
+		// NOT the "listing restore files" / "no such file or directory" error
+		// that characterises the bug.
+		err = r.RestoreItem(diffRP, "sonarr", "container", restoreDir, "")
+
+		if err != nil && strings.Contains(err.Error(), "listing restore files") {
+			t.Fatalf("restore hit the classic staging path (bug): %v", err)
+		}
+		// Any other error (dedup chunk not found, container handler unavailable,
+		// etc.) is acceptable — the point is we took the dedup restore path,
+		// not the broken classic staging path.
 	})
-	if err != nil {
-		t.Fatalf("CreateJob: %v", err)
-	}
 
-	// Create a FULL restore point for the container "sonarr".
-	var fullManifestBytes [32]byte
-	for i := range fullManifestBytes {
-		fullManifestBytes[i] = byte(0xF0 + i) // distinct from the diff manifest
-	}
-	fullRunID, err := database.CreateJobRun(db.JobRun{
-		JobID: jobID, Status: "completed", BackupType: "full",
+	t.Run("classic_differential_still_uses_chain", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			rp       db.RestorePoint
+			itemName string
+			wantOK   bool
+		}{
+			{
+				name:     "classic restore point with no metadata",
+				rp:       db.RestorePoint{BackupType: "differential", Metadata: ""},
+				itemName: "sonarr",
+				wantOK:   false,
+			},
+			{
+				name: "classic restore point with empty metadata JSON",
+				rp: db.RestorePoint{
+					BackupType: "differential",
+					Metadata:   `{"item_manifests":{}}`,
+				},
+				itemName: "sonarr",
+				wantOK:   false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, ok := resolveManifestID(tt.rp, tt.itemName)
+				if ok != tt.wantOK {
+					t.Fatalf("resolveManifestID returned ok=%v for %s, want %v", ok, tt.name, tt.wantOK)
+				}
+			})
+		}
+
+		// Also verify the dispatch order: usesMergedRestoreChain("container")
+		// must still return true so classic containers go through merged staging.
+		if !usesMergedRestoreChain("container") {
+			t.Fatal("usesMergedRestoreChain(\"container\") returned false — classic containers would not use merged chain staging")
+		}
 	})
-	if err != nil {
-		t.Fatalf("CreateJobRun (full): %v", err)
-	}
-	fullRP := db.RestorePoint{
-		JobRunID:    fullRunID,
-		JobID:       jobID,
-		StoragePath: filepath.Join("Docker", "1_2026-07-20_020000"),
-		BackupType:  "full",
-		ManifestID:  fullManifestBytes[:],
-	}
-	fullRPID, err := database.CreateRestorePoint(fullRP)
-	if err != nil {
-		t.Fatalf("CreateRestorePoint (full): %v", err)
-	}
-	fullRP.ID = fullRPID
-
-	// Use a real 32-byte hex manifest ID so resolveManifestID succeeds.
-	var manifestBytes [32]byte
-	for i := range manifestBytes {
-		manifestBytes[i] = byte(i + 1)
-	}
-	diffManifestHex := hex.EncodeToString(manifestBytes[:])
-	diffMeta := map[string]any{
-		"item_manifests": map[string]any{
-			"sonarr": diffManifestHex,
-		},
-	}
-	diffMetaJSON, _ := json.Marshal(diffMeta)
-
-	diffRunID, err := database.CreateJobRun(db.JobRun{
-		JobID: jobID, Status: "completed", BackupType: "differential",
-	})
-	if err != nil {
-		t.Fatalf("CreateJobRun (diff): %v", err)
-	}
-	diffRP := db.RestorePoint{
-		JobRunID:             diffRunID,
-		JobID:                jobID,
-		StoragePath:          filepath.Join("Docker", "47_2026-07-20_130500"),
-		BackupType:           "differential",
-		ParentRestorePointID: fullRPID,
-		Metadata:             string(diffMetaJSON),
-	}
-	diffRPID, err := database.CreateRestorePoint(diffRP)
-	if err != nil {
-		t.Fatalf("CreateRestorePoint (diff): %v", err)
-	}
-	diffRP.ID = diffRPID
-
-	// RestoreItem should NOT error with "no such file or directory".
-	// It will fail later (no actual dedup chunks on disk, no real container
-	// handler in test) — but the key assertion is that it does NOT fail at
-	// the stageRestorePointItem listing step. We accept any error that is
-	// NOT the "listing restore files" / "no such file or directory" error
-	// that characterises the bug.
-	err = r.RestoreItem(diffRP, "sonarr", "container", "/tmp/restore-test", "")
-
-	if err != nil && strings.Contains(err.Error(), "listing restore files") {
-		t.Fatalf("restore hit the classic staging path (bug): %v", err)
-	}
-	// Any other error (dedup chunk not found, container handler unavailable,
-	// etc.) is acceptable — the point is we took the dedup restore path,
-	// not the broken classic staging path.
-}
-
-// TestRestoreClassicContainerDifferentialStillUsesChain verifies that a
-// differential container restore on a CLASSIC (non-dedup) destination is
-// unaffected by the fix — it should still go through restoreMergedChain
-// (the only path that correctly overlays full + diff tar layers for
-// classic container backups).
-//
-// We cannot easily exercise the full staging pipeline in a unit test
-// (requires a real Docker socket), so we assert that the restore does NOT
-// take the dedup shortcut: resolveManifestID must return false for a
-// classic restore point with no manifest metadata. This confirms the
-// guard correctly falls through to usesMergedRestoreChain for containers.
-func TestRestoreClassicContainerDifferentialStillUsesChain(t *testing.T) {
-	t.Parallel()
-
-	// A classic restore point has no manifest_id and no item_manifests
-	// metadata. resolveManifestID must return ok=false.
-	rp := db.RestorePoint{
-		BackupType: "differential",
-		Metadata:   ``, // no manifest metadata
-	}
-
-	_, ok := resolveManifestID(rp, "sonarr")
-	if ok {
-		t.Fatal("resolveManifestID returned ok=true for a classic (non-dedup) restore point — this would incorrectly bypass chain replay for classic containers")
-	}
-
-	// Also verify the dispatch order: usesMergedRestoreChain("container")
-	// must still return true so classic containers go through merged staging.
-	if !usesMergedRestoreChain("container") {
-		t.Fatal("usesMergedRestoreChain(\"container\") returned false — classic containers would not use merged chain staging")
-	}
 }

--- a/internal/runner/restore_dedup_container_test.go
+++ b/internal/runner/restore_dedup_container_test.go
@@ -121,3 +121,36 @@ func TestRestoreDedupContainerDifferentialRestoresDirectly(t *testing.T) {
 	// etc.) is acceptable — the point is we took the dedup restore path,
 	// not the broken classic staging path.
 }
+
+// TestRestoreClassicContainerDifferentialStillUsesChain verifies that a
+// differential container restore on a CLASSIC (non-dedup) destination is
+// unaffected by the fix — it should still go through restoreMergedChain
+// (the only path that correctly overlays full + diff tar layers for
+// classic container backups).
+//
+// We cannot easily exercise the full staging pipeline in a unit test
+// (requires a real Docker socket), so we assert that the restore does NOT
+// take the dedup shortcut: resolveManifestID must return false for a
+// classic restore point with no manifest metadata. This confirms the
+// guard correctly falls through to usesMergedRestoreChain for containers.
+func TestRestoreClassicContainerDifferentialStillUsesChain(t *testing.T) {
+	t.Parallel()
+
+	// A classic restore point has no manifest_id and no item_manifests
+	// metadata. resolveManifestID must return ok=false.
+	rp := db.RestorePoint{
+		BackupType: "differential",
+		Metadata:   ``, // no manifest metadata
+	}
+
+	_, ok := resolveManifestID(rp, "sonarr")
+	if ok {
+		t.Fatal("resolveManifestID returned ok=true for a classic (non-dedup) restore point — this would incorrectly bypass chain replay for classic containers")
+	}
+
+	// Also verify the dispatch order: usesMergedRestoreChain("container")
+	// must still return true so classic containers go through merged staging.
+	if !usesMergedRestoreChain("container") {
+		t.Fatal("usesMergedRestoreChain(\"container\") returned false — classic containers would not use merged chain staging")
+	}
+}

--- a/internal/runner/restore_dedup_container_test.go
+++ b/internal/runner/restore_dedup_container_test.go
@@ -1,0 +1,123 @@
+package runner
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+	"github.com/ruaan-deysel/vault/internal/dedup"
+	"github.com/ruaan-deysel/vault/internal/storage"
+)
+
+// TestRestoreDedupContainerDifferentialRestoresDirectly verifies that a
+// differential container restore on a dedup-enabled destination takes the
+// single-point dedup path (restoreSinglePoint -> restoreSinglePointChunked)
+// instead of falling into restoreMergedChain -> stageRestorePointItem, which
+// fails because the container data lives in the dedup chunk store, not in
+// classic backup directories on storage.
+//
+// Regression for: differential container restore on dedup dest fails with
+// "listing restore files: open <path>: no such file or directory".
+func TestRestoreDedupContainerDifferentialRestoresDirectly(t *testing.T) {
+	t.Parallel()
+
+	r, database, storageDir := setupTestRunner(t)
+	r.serverKey = testServerKey()
+	dest := makeDedupDest(t, database, storageDir)
+
+	// Initialise the dedup repo on disk.
+	adapter, err := storage.NewAdapter(dest.Type, dest.Config)
+	if err != nil {
+		t.Fatalf("NewAdapter: %v", err)
+	}
+	_, err = dedup.InitRepo(database, adapter, dest.ID, r.serverKey)
+	if err != nil {
+		t.Fatalf("InitRepo: %v", err)
+	}
+	storage.CloseAdapter(adapter)
+
+	// Create a job so restoreSinglePointChunked can look it up.
+	jobID, err := database.CreateJob(db.Job{
+		Name:          "test-containers",
+		StorageDestID: dest.ID,
+		Schedule:      "0 2 * * *",
+	})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+
+	// Create a FULL restore point for the container "sonarr".
+	var fullManifestBytes [32]byte
+	for i := range fullManifestBytes {
+		fullManifestBytes[i] = byte(0xF0 + i) // distinct from the diff manifest
+	}
+	fullRunID, err := database.CreateJobRun(db.JobRun{
+		JobID: jobID, Status: "completed", BackupType: "full",
+	})
+	if err != nil {
+		t.Fatalf("CreateJobRun (full): %v", err)
+	}
+	fullRP := db.RestorePoint{
+		JobRunID:    fullRunID,
+		JobID:       jobID,
+		StoragePath: filepath.Join("Docker", "1_2026-07-20_020000"),
+		BackupType:  "full",
+		ManifestID:  fullManifestBytes[:],
+	}
+	fullRPID, err := database.CreateRestorePoint(fullRP)
+	if err != nil {
+		t.Fatalf("CreateRestorePoint (full): %v", err)
+	}
+	fullRP.ID = fullRPID
+
+	// Use a real 32-byte hex manifest ID so resolveManifestID succeeds.
+	var manifestBytes [32]byte
+	for i := range manifestBytes {
+		manifestBytes[i] = byte(i + 1)
+	}
+	diffManifestHex := hex.EncodeToString(manifestBytes[:])
+	diffMeta := map[string]any{
+		"item_manifests": map[string]any{
+			"sonarr": diffManifestHex,
+		},
+	}
+	diffMetaJSON, _ := json.Marshal(diffMeta)
+
+	diffRunID, err := database.CreateJobRun(db.JobRun{
+		JobID: jobID, Status: "completed", BackupType: "differential",
+	})
+	if err != nil {
+		t.Fatalf("CreateJobRun (diff): %v", err)
+	}
+	diffRP := db.RestorePoint{
+		JobRunID:             diffRunID,
+		JobID:                jobID,
+		StoragePath:          filepath.Join("Docker", "47_2026-07-20_130500"),
+		BackupType:           "differential",
+		ParentRestorePointID: fullRPID,
+		Metadata:             string(diffMetaJSON),
+	}
+	diffRPID, err := database.CreateRestorePoint(diffRP)
+	if err != nil {
+		t.Fatalf("CreateRestorePoint (diff): %v", err)
+	}
+	diffRP.ID = diffRPID
+
+	// RestoreItem should NOT error with "no such file or directory".
+	// It will fail later (no actual dedup chunks on disk, no real container
+	// handler in test) — but the key assertion is that it does NOT fail at
+	// the stageRestorePointItem listing step. We accept any error that is
+	// NOT the "listing restore files" / "no such file or directory" error
+	// that characterises the bug.
+	err = r.RestoreItem(diffRP, "sonarr", "container", "/tmp/restore-test", "")
+
+	if err != nil && strings.Contains(err.Error(), "listing restore files") {
+		t.Fatalf("restore hit the classic staging path (bug): %v", err)
+	}
+	// Any other error (dedup chunk not found, container handler unavailable,
+	// etc.) is acceptable — the point is we took the dedup restore path,
+	// not the broken classic staging path.
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -2930,19 +2930,20 @@ func (r *Runner) restoreItemChain(ctx context.Context, restorePoint db.RestorePo
 		if err != nil {
 			return fmt.Errorf("building restore chain: %w", err)
 		}
+		// Dedup restore points (folder, container, plugin) carry a COMPLETE
+		// manifest — BackupChunked walks the whole item every run, so
+		// increments reuse chunks, not manifest entries. Restoring the
+		// selected point alone reproduces the exact point-in-time state and
+		// cannot resurrect files deleted or excluded after the base full
+		// backup (issue #231). This must run BEFORE the merged-chain dispatch
+		// because containers use merged chains but dedup containers must
+		// take the single-point chunked restore path.
+		if _, ok := resolveManifestID(restorePoint, itemName); ok {
+			log.Printf("runner: dedup restore point %d has a complete manifest — restoring it directly (no chain replay)", restorePoint.ID)
+			return r.restoreSinglePoint(ctx, restorePoint, itemName, itemType, destination, passphrase, filePaths, reporter)
+		}
 		if usesMergedRestoreChain(itemType) {
 			return r.restoreMergedChain(ctx, chain, itemName, itemType, destination, passphrase, filePaths, reporter)
-		}
-		// Dedup folder points carry a COMPLETE manifest (BackupChunked walks
-		// the whole tree every run — increments reuse chunks, not manifest
-		// entries). Restoring the selected point alone reproduces the exact
-		// point-in-time state and cannot resurrect files deleted or excluded
-		// after the base full backup (issue #231).
-		if itemType == "folder" {
-			if _, ok := resolveManifestID(restorePoint, itemName); ok {
-				log.Printf("runner: dedup folder restore point %d has a complete manifest — restoring it directly (no chain replay)", restorePoint.ID)
-				return r.restoreSinglePoint(ctx, restorePoint, itemName, itemType, destination, passphrase, filePaths, reporter)
-			}
 		}
 		replayStart := time.Now()
 		for i, rp := range chain {


### PR DESCRIPTION
### Summary

Differential and incremental **container** restores on dedup-enabled storage destinations fail with:

```
staging chain step 1 (id=41): listing restore files: open <storage_path>/<container>: no such file or directory
```

The full backup restores fine. Only differential/incremental points fail.

### Root Cause

In `restoreItemChain`, the dedup shortcut guard — which bypasses chain replay and restores the selected point directly via `restoreSinglePointChunked` — was positioned **after** the `usesMergedRestoreChain` early-return that catches containers:

```go
if usesMergedRestoreChain(itemType) {    // containers return true → returns here
    return r.restoreMergedChain(...)      // tries classic staging → directory doesn't exist
}
if itemType == "folder" {                 // never reached for containers
    if _, ok := resolveManifestID(...); ok {
        return r.restoreSinglePoint(...)  // dedup path (correct)
    }
}
```

Dedup containers store data in the chunk store, not in classic per-item directories on storage. `restoreMergedChain` → `stageRestorePointItem` calls `adapter.List(storagePath/containerName)` on a path that doesn't exist → error.

The guard was also gated on `itemType == "folder"` only, even though `ContainerHandler` and `PluginHandler` both implement `ChunkedHandler` and write complete per-run manifests.

### Fix

Move the `resolveManifestID` check **above** the `usesMergedRestoreChain` dispatch and remove the `itemType == "folder"` gate:

```go
if _, ok := resolveManifestID(restorePoint, itemName); ok {
    return r.restoreSinglePoint(...)      // dedup path for all chunked types
}
if usesMergedRestoreChain(itemType) {
    return r.restoreMergedChain(...)      // classic containers/VMs only
}
```

This is safe because `resolveManifestID` returns `ok=false` for classic (non-dedup) restore points, so chain replay behaviour is unchanged for non-dedup destinations.

### Changes

- `internal/runner/runner.go` — reorder dedup guard before merged-chain dispatch; remove folder-only type gate
- `internal/runner/restore_dedup_container_test.go` — new: reproducing test + regression test for classic containers
- `CHANGELOG.md` — entry under `[Unreleased] > Fixed`

### Testing

- New test verifies a differential container restore point with a resolvable manifest does NOT hit the classic staging path
- Regression test confirms `resolveManifestID` returns `ok=false` for classic RPs (no metadata), preserving chain replay
- Full runner test suite passes

Closes #266.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed restores for deduplication-enabled container backups.
  * Deduplicated incremental and differential restores now use the correct direct restore path, avoiding “no such file or directory” errors.
  * Preserved existing restore behaviour for classic, non-deduplicated container backups.

* **Tests**
  * Added regression coverage for deduplicated and classic container restore scenarios.

* **Documentation**
  * Updated the unreleased changelog with details of the restore fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->