### PR TITLE
fix(ui): put remaining size formatters on shared byte contract (#270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Backup sizes now read the same everywhere they are shown.** Four operator-facing places still formatted sizes with their own math instead of the shared byte contract, so the same backup could read differently depending on where you looked: the Storage page's saved-backups list stopped at TB with no clamp (a petabyte showed as `1024.0 TB`), the Recover Vault wizard always printed raw kilobytes (`1048576 KB` for a gigabyte), the packaged plugin History page always printed megabytes (`1073741824.0 MB` for a petabyte), and the transfer-speed label capped at GB/s and disagreed with the app near unit boundaries. All four now go through the same `formatBytes` contract the app and notifications already use, so a size or speed reads identically across the console, the wizard, the plugin pages, and Discord/webhook messages. Closes #270.
+
 ## [v2026.08.00] - 2026-08-02
 
 ### Added

--- a/plugin/assets/js/vault.js
+++ b/plugin/assets/js/vault.js
@@ -39,6 +39,16 @@ function formatBytes(bytes) {
     return parseFloat((Math.round(v * 10) / 10).toFixed(1)) + ' ' + sizes[i];
 }
 
+// Renders server-emitted raw byte counts through the shared formatBytes
+// contract, so packaged plugin pages read the same size as the app and
+// notifications instead of carrying their own divergent /1024 math.
+function hydrateByteCells(root) {
+    (root || document).querySelectorAll('[data-vault-bytes]').forEach(function (el) {
+        el.textContent = formatBytes(Number(el.getAttribute('data-vault-bytes')));
+    });
+}
+document.addEventListener('DOMContentLoaded', function () { hydrateByteCells(document); });
+
 // WebSocket for real-time progress
 let ws = null;
 

--- a/plugin/pages/VaultHistory.page
+++ b/plugin/pages/VaultHistory.page
@@ -44,7 +44,7 @@ $jobs = vault_get('/jobs') ?: [];
                 <td><span class="vault-badge badge-<?= $run['status'] ?>"><?= $run['status'] ?></span></td>
                 <td><?= $run['backup_type'] ?></td>
                 <td><?= $run['items_done'] ?>/<?= $run['items_total'] ?> (<?= $run['items_failed'] ?> failed)</td>
-                <td><?= number_format($run['size_bytes'] / 1024 / 1024, 1) ?> MB</td>
+                <td data-vault-bytes="<?= (int)$run['size_bytes'] ?>"><?= number_format((int)$run['size_bytes']) ?> B</td>
                 <td><?= $run['started_at'] ?></td>
                 <td><?= $run['completed_at'] ?></td>
             </tr>

--- a/web/src/lib/utils.js
+++ b/web/src/lib/utils.js
@@ -281,11 +281,9 @@ export function formatDurationFromDates(startedAt, completedAt) {
 /** Format bytes/seconds into human-readable speed (e.g. "31.2 MB/s") */
 export function formatSpeed(bytes, seconds) {
   if (!bytes || !seconds || seconds === 0) return null;
-  const bps = bytes / seconds;
-  const k = 1024;
-  const units = ['B/s', 'KB/s', 'MB/s', 'GB/s'];
-  const i = Math.min(Math.floor(Math.log(bps) / Math.log(k)), units.length - 1);
-  return parseFloat((bps / Math.pow(k, i)).toFixed(1)) + ' ' + units[i];
+  // Derived from the shared byte contract so speed units and rounding match
+  // formatBytes (and the daemon) instead of diverging near unit boundaries.
+  return formatBytes(bytes / seconds) + '/s';
 }
 
 // Describes the outcome of a database location change for the Settings toast,

--- a/web/src/lib/utils.test.js
+++ b/web/src/lib/utils.test.js
@@ -70,6 +70,13 @@ describe('formatSpeed', () => {
   it('formats bytes/sec', () => {
     expect(formatSpeed(1048576, 1)).toBe('1 MB/s')
   })
+  it('inherits the shared contract above GB and at boundaries', () => {
+    // Old implementation capped units at GB/s (1 TB/s printed "1024 GB/s")
+    // and used Math.log indexing that diverged near unit boundaries.
+    expect(formatSpeed(1024 ** 4, 1)).toBe('1 TB/s')
+    expect(formatSpeed(1024 ** 5, 1)).toBe('1 PB/s')
+    expect(formatSpeed(1024 ** 3, 2)).toBe(formatBytes(1024 ** 3 / 2) + '/s')
+  })
 })
 
 // These two back the cross-cutting "partial status" cluster — lock current

--- a/web/src/pages/RecoverWizard.svelte
+++ b/web/src/pages/RecoverWizard.svelte
@@ -1,6 +1,7 @@
 <script>
   import { api } from '../lib/api.js'
   import { navigate } from '../lib/router.svelte.js'
+  import { formatBytes } from '../lib/utils.js'
   import StorageForm from '../components/StorageForm.svelte'
   import Toast from '../components/Toast.svelte'
   import InlineSpinner from '../components/InlineSpinner.svelte'
@@ -254,7 +255,7 @@
             <input type="radio" name="recover-snapshot" class="accent-vault mt-1" value={b} bind:group={selected} />
             <span class="min-w-0">
               <span class="block text-sm font-medium text-text">{b.is_latest ? 'Most recent backup' : fmtWhen(b.timestamp)}</span>
-              <span class="block text-xs text-text-muted mt-0.5 truncate">{b.name} · {(b.size / 1024).toFixed(0)} KB{b.encrypted ? ' · encrypted' : ''}</span>
+              <span class="block text-xs text-text-muted mt-0.5 truncate">{b.name} · {formatBytes(b.size)}{b.encrypted ? ' · encrypted' : ''}</span>
             </span>
           </label>
         {/each}

--- a/web/src/pages/Storage.svelte
+++ b/web/src/pages/Storage.svelte
@@ -345,15 +345,6 @@
     }
   }
 
-  function formatSize(bytes) {
-    if (!bytes || bytes === 0) return '–'
-    const units = ['B', 'KB', 'MB', 'GB', 'TB']
-    let i = 0
-    let size = bytes
-    while (size >= 1024 && i < units.length - 1) { size /= 1024; i++ }
-    return `${size.toFixed(i > 0 ? 1 : 0)} ${units[i]}`
-  }
-
   async function testConnection(id) {
     testing = id
     try {
@@ -834,7 +825,7 @@
             <div class="flex-1 min-w-0">
               <div class="flex items-center justify-between">
                 <p class="text-sm font-medium text-text truncate">{backup.job_name || 'Unknown Job'}</p>
-                <span class="text-xs text-text-dim shrink-0 ml-2">{formatSize(backup.size_bytes)}</span>
+                <span class="text-xs text-text-dim shrink-0 ml-2">{formatBytes(backup.size_bytes)}</span>
               </div>
               <div class="flex flex-wrap gap-x-3 mt-1 text-xs text-text-dim">
                 <span>{backup.backup_type || 'full'}</span>


### PR DESCRIPTION
Closes #270.

Follow-up to #269. Four operator-facing size formatters still carried their own math and diverged from the shared `formatBytes` contract used by the app and notifications. This points all four at the single contract so a size or speed reads identically everywhere.

## Changes
- **`web/src/pages/Storage.svelte`** — removed the local `formatSize` (stopped at TB, no clamp: `1 PB → 1024.0 TB`); the saved-backups list now uses shared `formatBytes`.
- **`web/src/pages/RecoverWizard.svelte`** — replaced the inline `(size / 1024).toFixed(0)` KB rendering (`1 GB → 1048576 KB`) with `formatBytes`.
- **`web/src/lib/utils.js`** — `formatSpeed` is now `formatBytes(bytes / seconds) + '/s'`, inheriting the contract (previously capped at GB/s and diverged near unit boundaries via `Math.log` indexing). Null guard preserved.
- **`plugin/pages/VaultHistory.page`** — dropped the MB-only server-side formatting (`1 PB → 1073741824.0 MB`); emits raw bytes in `data-vault-bytes` and hydrates through the packaged `vault.js` shared `formatBytes`.
- **`plugin/assets/js/vault.js`** — added a small `data-vault-bytes` hydrator run on `DOMContentLoaded`.
- **`web/src/lib/utils.test.js`** — added `formatSpeed` regression coverage above GB and at boundaries.

The IEC-vs-SI labelling question raised in the issue is left as a separate decision (unchanged here).

## Verification
- `npm --prefix web test` — 57 passed
- `npm --prefix web run lint` / `run build` — clean
- CodeRabbit CLI review (`--base main`) — **No findings**
- `make build` — tests, lint, cross-compile, web build all green
- `make deploy` + `make verify` on Unraid (192.168.20.21) — core endpoints 3/3, WebSocket 101, MCP OK (30 tools)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardised byte-size formatting across storage, recovery, vault history, transfer speeds, plugins, Discord, webhooks and notifications.
  * Vault history now displays consistently rounded run sizes.
  * Backup sizes and transfer speeds now use consistent units, including larger terabyte and petabyte values.
* **Tests**
  * Added coverage for transfer-speed formatting and unit boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->