### PR TITLE
fix(engine): honour file picker on dedup plugin restore (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Restoring selected files from a plugin backup on a deduplicated destination no longer restores the whole plugin.** When a plugin backup lived on a dedup destination and you picked specific files to restore, the file-picker selection was dropped on the way through the deduplicated restore path and the entire plugin config directory was written back instead. The selection now carries through to the folder restore that reconstructs the files, so only the chosen files are restored — matching how the same picker already worked for non-dedup plugin restores. Closes #271.
 - **Backup sizes now read the same everywhere they are shown.** Four operator-facing places still formatted sizes with their own math instead of the shared byte contract, so the same backup could read differently depending on where you looked: the Storage page's saved-backups list stopped at TB with no clamp (a petabyte showed as `1024.0 TB`), the Recover Vault wizard always printed raw kilobytes (`1048576 KB` for a gigabyte), the packaged plugin History page always printed megabytes (`1073741824.0 MB` for a petabyte), and the transfer-speed label capped at GB/s and disagreed with the app near unit boundaries. All four now go through the same `formatBytes` contract the app and notifications already use, so a size or speed reads identically across the console, the wizard, the plugin pages, and Discord/webhook messages. Closes #270.
 
 ## [v2026.08.00] - 2026-08-02

--- a/internal/engine/plugin.go
+++ b/internal/engine/plugin.go
@@ -237,7 +237,15 @@ func (h *PluginHandler) RestoreChunked(ctx context.Context, item BackupItem, rep
 	if destPath == "" {
 		return fmt.Errorf("plugin: cannot resolve restore directory for %q", item.Name)
 	}
-	proxy := BackupItem{Name: item.Name, Type: "folder", Settings: map[string]any{"path": destPath}}
+	// Propagate the partial-restore file picker through the proxy item so a
+	// selection made on a dedup plugin restore reaches FolderHandler.
+	// RestoreChunked, which honours restore_file_paths. Without this the
+	// setting is dropped and the whole config directory is restored.
+	proxySettings := map[string]any{"path": destPath}
+	if rfp := extractRestoreFilePaths(item.Settings); rfp != nil {
+		proxySettings["restore_file_paths"] = rfp
+	}
+	proxy := BackupItem{Name: item.Name, Type: "folder", Settings: proxySettings}
 	fh := &FolderHandler{}
 	return fh.RestoreChunked(ctx, proxy, repo, manifestID, destPath, progress)
 }

--- a/internal/engine/plugin_test.go
+++ b/internal/engine/plugin_test.go
@@ -117,8 +117,10 @@ func TestPluginChunkedRestoreHonoursFilePicker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := os.Stat(filepath.Join(dst, "config.toml")); err != nil {
+	if got, err := os.ReadFile(filepath.Join(dst, "config.toml")); err != nil { // #nosec G304 — test-controlled tempdir
 		t.Errorf("selected file config.toml should have been restored: %v", err)
+	} else if string(got) != "setting=true" {
+		t.Errorf("selected file config.toml has unexpected content: %q", got)
 	}
 	if _, err := os.Stat(filepath.Join(dst, "data/state.bin")); !os.IsNotExist(err) {
 		t.Errorf("unselected file data/state.bin should not have been restored (err=%v)", err)

--- a/internal/engine/plugin_test.go
+++ b/internal/engine/plugin_test.go
@@ -75,3 +75,52 @@ func TestPluginChunkedRoundTrip(t *testing.T) {
 		t.Fatalf("%d mismatches", errs)
 	}
 }
+
+// TestPluginChunkedRestoreHonoursFilePicker is a regression test for #271:
+// PluginHandler.RestoreChunked dropped restore_file_paths when building the
+// proxy folder item, so a partial-restore selection on a dedup plugin backup
+// restored the entire config directory instead of only the chosen files.
+func TestPluginChunkedRestoreHonoursFilePicker(t *testing.T) {
+	src := t.TempDir()
+	must := func(p string, data []byte) {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(filepath.Join(src, "config.toml"), []byte("setting=true"))
+	must(filepath.Join(src, "data/state.bin"), bytes.Repeat([]byte{0xee}, 8192))
+
+	r, _, cleanup := dedup.NewTestRepoForEngine(t)
+	defer cleanup()
+
+	h := &PluginHandler{}
+	item := BackupItem{Name: "test-plugin", Type: "plugin", Settings: map[string]any{"path": src}}
+	ctx := context.Background()
+	manifestID, err := h.BackupChunked(ctx, item, r, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := t.TempDir()
+	restoreItem := BackupItem{
+		Name:     "test-plugin",
+		Type:     "plugin",
+		Settings: map[string]any{"restore_file_paths": []string{"config.toml"}},
+	}
+	if err := h.RestoreChunked(ctx, restoreItem, r, manifestID, dst, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dst, "config.toml")); err != nil {
+		t.Errorf("selected file config.toml should have been restored: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "data/state.bin")); !os.IsNotExist(err) {
+		t.Errorf("unselected file data/state.bin should not have been restored (err=%v)", err)
+	}
+}


### PR DESCRIPTION
Closes #271.

`PluginHandler.RestoreChunked` built its proxy `folder` item with only `path`, dropping the `restore_file_paths` file-picker selection. `FolderHandler.RestoreChunked` honours `restore_file_paths`, but the plugin handler never passed it through — so a partial restore of a plugin backup on a dedup destination restored the **entire** config directory. Same class of bug as the earlier `destPath` drop in `ContainerHandler.RestoreChunked`.

## Change
- `internal/engine/plugin.go` — propagate `restore_file_paths` (via `extractRestoreFilePaths`) into the proxy item settings so `FolderHandler.RestoreChunked` filters to the selected entries.
- `internal/engine/plugin_test.go` — Linux-tagged regression test: back up a two-file plugin dir, restore with `restore_file_paths: ["config.toml"]`, assert only `config.toml` is restored (and its content matches) while `data/state.bin` is not.

## Verification
- `GOOS=linux go build/vet` + test-compile — clean
- `make build` — unit tests, lint, cross-compile, web build green
- CodeRabbit CLI review — 1 minor finding (verify restored content) addressed, re-review clean
- `make deploy` + `make verify` on Unraid (192.168.20.21) — core endpoints 3/3, WebSocket 101, MCP OK (30 tools)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plugin restores using the file picker so that only selected files are restored.
  * Prevented unselected files in the plugin configuration folder from being restored during partial restores.

* **Documentation**
  * Added an unreleased changelog entry describing the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->