### PR TITLE
feat(replication): surface per-sync summary and up-to-date state (#287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Replication targets now show what the last sync actually did.** A target that connected but had nothing new to copy previously just read "Synced", which looked the same as a sync that transferred data — so replication could appear to "connect but not do much". Each target now shows an explicit **Up to date** state when a sync found nothing new, a per-sync summary (jobs synced, new restore points, bytes transferred, and any failures), and the time replication last fully succeeded. These counters are stored with each run, so they are visible on page load and after a refresh, not only in the moment a sync finishes. Closes #287.
+
 ### Security
 
 - Updated Go and web dependencies to their latest compatible releases and resolved a high-severity advisory in the web `nanoid` dependency. gosec, govulncheck, and the Go linter pass clean, and the MCP integration remains on the go-sdk v1.7.0 API.

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -328,4 +328,10 @@ var dataMigrations = []string{
 	// would instead make identical data behave differently depending on which
 	// jobs an operator happened to edit.
 	"UPDATE jobs SET container_mode = 'stop_all' WHERE container_mode = 'all_at_once'",
+	// Replication last-successful-sync backfill (#287). last_sync_success_at is
+	// a new column, so existing sources that already completed a successful
+	// sync before the upgrade would report no successful sync until the next
+	// run. Seed it from last_sync_at for rows whose last recorded status was a
+	// success, so the UI shows the historical timestamp immediately.
+	"UPDATE replication_sources SET last_sync_success_at = last_sync_at WHERE last_sync_success_at IS NULL AND last_sync_status = 'success' AND last_sync_at IS NOT NULL",
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -303,6 +303,17 @@ var alterMigrations = []string{
 	// retry_next_at, so the driver hands back a time.Time.
 	"ALTER TABLE job_runs ADD COLUMN stalled_at TIMESTAMP DEFAULT NULL",
 	"ALTER TABLE job_runs ADD COLUMN stall_reason TEXT DEFAULT ''",
+	// Replication sync summary (#287). The per-sync counters were only ever
+	// broadcast on the completion WebSocket event, so a page load (or the 10s
+	// poll) could not tell "connected but nothing new to replicate" apart from
+	// a sync that actually transferred data. Persist the last run's counters
+	// plus the last time a sync fully succeeded so the UI can show an explicit
+	// up-to-date / synced / failed state with per-item numbers.
+	"ALTER TABLE replication_sources ADD COLUMN last_sync_jobs_synced INTEGER DEFAULT 0",
+	"ALTER TABLE replication_sources ADD COLUMN last_sync_jobs_failed INTEGER DEFAULT 0",
+	"ALTER TABLE replication_sources ADD COLUMN last_sync_restore_points INTEGER DEFAULT 0",
+	"ALTER TABLE replication_sources ADD COLUMN last_sync_bytes INTEGER DEFAULT 0",
+	"ALTER TABLE replication_sources ADD COLUMN last_sync_success_at DATETIME",
 }
 
 // dataMigrations are idempotent row rewrites, applied after alterMigrations.

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -282,6 +282,15 @@ type ReplicationSource struct {
 	LastSyncAt     *time.Time `json:"last_sync_at"`
 	LastSyncStatus string     `json:"last_sync_status"`
 	LastSyncError  string     `json:"last_sync_error"`
-	CreatedAt      time.Time  `json:"created_at"`
-	UpdatedAt      time.Time  `json:"updated_at"`
+	// Per-sync summary of the most recent run (#287), persisted so the UI can
+	// show an explicit up-to-date / synced / failed state on load, not only
+	// via the transient completion event. LastSyncSuccessAt is the last time a
+	// sync fully succeeded (nil until the first clean sync).
+	LastSyncJobsSynced    int        `json:"last_sync_jobs_synced"`
+	LastSyncJobsFailed    int        `json:"last_sync_jobs_failed"`
+	LastSyncRestorePoints int        `json:"last_sync_restore_points"`
+	LastSyncBytes         int64      `json:"last_sync_bytes"`
+	LastSyncSuccessAt     *time.Time `json:"last_sync_success_at"`
+	CreatedAt             time.Time  `json:"created_at"`
+	UpdatedAt             time.Time  `json:"updated_at"`
 }

--- a/internal/db/replication_repo.go
+++ b/internal/db/replication_repo.go
@@ -1,6 +1,9 @@
 package db
 
-import "database/sql"
+import (
+	"database/sql"
+	"fmt"
+)
 
 // CreateReplicationSource inserts a new replication source and returns its ID.
 func (d *DB) CreateReplicationSource(src ReplicationSource) (int64, error) {
@@ -107,7 +110,10 @@ func (d *DB) UpdateReplicationSyncStatus(id int64, status, syncError string) err
 		updated_at=CURRENT_TIMESTAMP WHERE id=?`,
 		status, syncError, id,
 	)
-	return err
+	if err != nil {
+		return fmt.Errorf("update replication sync status for source %d: %w", id, err)
+	}
+	return nil
 }
 
 // UpdateReplicationSyncResult stores the outcome of a completed sync along
@@ -124,7 +130,10 @@ func (d *DB) UpdateReplicationSyncResult(id int64, status, syncError string, job
 		updated_at=CURRENT_TIMESTAMP WHERE id=?`,
 		status, syncError, jobsSynced, jobsFailed, restorePoints, bytes, status, id,
 	)
-	return err
+	if err != nil {
+		return fmt.Errorf("update replication sync result for source %d: %w", id, err)
+	}
+	return nil
 }
 
 // DeleteReplicationSource removes a replication source by ID.

--- a/internal/db/replication_repo.go
+++ b/internal/db/replication_repo.go
@@ -34,11 +34,16 @@ func (d *DB) GetReplicationSource(id int64) (ReplicationSource, error) {
 	err := d.QueryRow(
 		`SELECT id, name, COALESCE(type, 'remote_vault'), url, COALESCE(config, '{}'),
 			COALESCE(storage_dest_id, 0), schedule, enabled,
-			last_sync_at, last_sync_status, last_sync_error, created_at, updated_at
+			last_sync_at, last_sync_status, last_sync_error,
+			COALESCE(last_sync_jobs_synced, 0), COALESCE(last_sync_jobs_failed, 0),
+			COALESCE(last_sync_restore_points, 0), COALESCE(last_sync_bytes, 0),
+			last_sync_success_at, created_at, updated_at
 		FROM replication_sources WHERE id = ?`, id,
 	).Scan(&src.ID, &src.Name, &src.Type, &src.URL, &src.Config, &src.StorageDestID,
 		&src.Schedule, &src.Enabled, &src.LastSyncAt, &src.LastSyncStatus,
-		&src.LastSyncError, &src.CreatedAt, &src.UpdatedAt)
+		&src.LastSyncError, &src.LastSyncJobsSynced, &src.LastSyncJobsFailed,
+		&src.LastSyncRestorePoints, &src.LastSyncBytes, &src.LastSyncSuccessAt,
+		&src.CreatedAt, &src.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return src, ErrNotFound
 	}
@@ -50,7 +55,10 @@ func (d *DB) ListReplicationSources() ([]ReplicationSource, error) {
 	rows, err := d.Query(
 		`SELECT id, name, COALESCE(type, 'remote_vault'), url, COALESCE(config, '{}'),
 			COALESCE(storage_dest_id, 0), schedule, enabled,
-			last_sync_at, last_sync_status, last_sync_error, created_at, updated_at
+			last_sync_at, last_sync_status, last_sync_error,
+			COALESCE(last_sync_jobs_synced, 0), COALESCE(last_sync_jobs_failed, 0),
+			COALESCE(last_sync_restore_points, 0), COALESCE(last_sync_bytes, 0),
+			last_sync_success_at, created_at, updated_at
 		FROM replication_sources ORDER BY name`)
 	if err != nil {
 		return nil, err
@@ -61,7 +69,9 @@ func (d *DB) ListReplicationSources() ([]ReplicationSource, error) {
 		var src ReplicationSource
 		if err := rows.Scan(&src.ID, &src.Name, &src.Type, &src.URL, &src.Config, &src.StorageDestID,
 			&src.Schedule, &src.Enabled, &src.LastSyncAt, &src.LastSyncStatus,
-			&src.LastSyncError, &src.CreatedAt, &src.UpdatedAt); err != nil {
+			&src.LastSyncError, &src.LastSyncJobsSynced, &src.LastSyncJobsFailed,
+			&src.LastSyncRestorePoints, &src.LastSyncBytes, &src.LastSyncSuccessAt,
+			&src.CreatedAt, &src.UpdatedAt); err != nil {
 			return nil, err
 		}
 		sources = append(sources, src)
@@ -84,12 +94,35 @@ func (d *DB) UpdateReplicationSource(src ReplicationSource) error {
 	return err
 }
 
-// UpdateReplicationSyncStatus stores the result of a sync attempt.
+// UpdateReplicationSyncStatus stores the status of a sync attempt without
+// per-item counters. Used when a sync starts ("running") or fails before it
+// produces a summary; the counters are reset so a stale summary from an
+// earlier successful sync is never shown against a running or failed state.
 func (d *DB) UpdateReplicationSyncStatus(id int64, status, syncError string) error {
 	_, err := d.Exec(
 		`UPDATE replication_sources SET last_sync_at=CURRENT_TIMESTAMP,
-		last_sync_status=?, last_sync_error=?, updated_at=CURRENT_TIMESTAMP WHERE id=?`,
+		last_sync_status=?, last_sync_error=?,
+		last_sync_jobs_synced=0, last_sync_jobs_failed=0,
+		last_sync_restore_points=0, last_sync_bytes=0,
+		updated_at=CURRENT_TIMESTAMP WHERE id=?`,
 		status, syncError, id,
+	)
+	return err
+}
+
+// UpdateReplicationSyncResult stores the outcome of a completed sync along
+// with its per-item counters. last_sync_success_at only advances on a fully
+// successful sync, so the UI can show when replication was last known good
+// even after a later partial or failed run.
+func (d *DB) UpdateReplicationSyncResult(id int64, status, syncError string, jobsSynced, jobsFailed, restorePoints int, bytes int64) error {
+	_, err := d.Exec(
+		`UPDATE replication_sources SET last_sync_at=CURRENT_TIMESTAMP,
+		last_sync_status=?, last_sync_error=?,
+		last_sync_jobs_synced=?, last_sync_jobs_failed=?,
+		last_sync_restore_points=?, last_sync_bytes=?,
+		last_sync_success_at=CASE WHEN ?='success' THEN CURRENT_TIMESTAMP ELSE last_sync_success_at END,
+		updated_at=CURRENT_TIMESTAMP WHERE id=?`,
+		status, syncError, jobsSynced, jobsFailed, restorePoints, bytes, status, id,
 	)
 	return err
 }

--- a/internal/db/replication_repo_test.go
+++ b/internal/db/replication_repo_test.go
@@ -87,6 +87,44 @@ func TestReplicationSourceCRUD(t *testing.T) {
 		t.Error("LastSyncAt should not be nil after sync")
 	}
 
+	// #287: a completed sync persists its per-item counters and, on success,
+	// advances last_sync_success_at.
+	if err := database.UpdateReplicationSyncResult(id, "success", "", 3, 0, 12, 1024); err != nil {
+		t.Fatalf("UpdateReplicationSyncResult() error = %v", err)
+	}
+	withCounts, _ := database.GetReplicationSource(id)
+	if withCounts.LastSyncJobsSynced != 3 || withCounts.LastSyncRestorePoints != 12 || withCounts.LastSyncBytes != 1024 {
+		t.Errorf("counters = %d/%d/%d, want 3/12/1024",
+			withCounts.LastSyncJobsSynced, withCounts.LastSyncRestorePoints, withCounts.LastSyncBytes)
+	}
+	if withCounts.LastSyncSuccessAt == nil {
+		t.Error("LastSyncSuccessAt should be set after a successful sync")
+	}
+
+	// A subsequent running/failed status resets the counters but preserves the
+	// last successful timestamp.
+	if err := database.UpdateReplicationSyncStatus(id, "running", ""); err != nil {
+		t.Fatalf("UpdateReplicationSyncStatus(running) error = %v", err)
+	}
+	running, _ := database.GetReplicationSource(id)
+	if running.LastSyncJobsSynced != 0 || running.LastSyncRestorePoints != 0 || running.LastSyncBytes != 0 {
+		t.Errorf("counters after running = %d/%d/%d, want all 0",
+			running.LastSyncJobsSynced, running.LastSyncRestorePoints, running.LastSyncBytes)
+	}
+	if running.LastSyncSuccessAt == nil {
+		t.Error("LastSyncSuccessAt should survive a later running state")
+	}
+
+	// A failed completion does not advance last_sync_success_at.
+	prevSuccess := *running.LastSyncSuccessAt
+	if err := database.UpdateReplicationSyncResult(id, "failed", "boom", 0, 2, 0, 0); err != nil {
+		t.Fatalf("UpdateReplicationSyncResult(failed) error = %v", err)
+	}
+	failed, _ := database.GetReplicationSource(id)
+	if failed.LastSyncSuccessAt == nil || !failed.LastSyncSuccessAt.Equal(prevSuccess) {
+		t.Errorf("LastSyncSuccessAt should not change on a failed sync")
+	}
+
 	// Delete
 	if err := database.DeleteReplicationSource(id); err != nil {
 		t.Fatalf("DeleteReplicationSource() error = %v", err)

--- a/internal/db/replication_repo_test.go
+++ b/internal/db/replication_repo_test.go
@@ -103,6 +103,7 @@ func TestReplicationSourceCRUD(t *testing.T) {
 
 	// A subsequent running/failed status resets the counters but preserves the
 	// last successful timestamp.
+	successBeforeRunning := *withCounts.LastSyncSuccessAt
 	if err := database.UpdateReplicationSyncStatus(id, "running", ""); err != nil {
 		t.Fatalf("UpdateReplicationSyncStatus(running) error = %v", err)
 	}
@@ -111,8 +112,8 @@ func TestReplicationSourceCRUD(t *testing.T) {
 		t.Errorf("counters after running = %d/%d/%d, want all 0",
 			running.LastSyncJobsSynced, running.LastSyncRestorePoints, running.LastSyncBytes)
 	}
-	if running.LastSyncSuccessAt == nil {
-		t.Error("LastSyncSuccessAt should survive a later running state")
+	if running.LastSyncSuccessAt == nil || !running.LastSyncSuccessAt.Equal(successBeforeRunning) {
+		t.Error("LastSyncSuccessAt should survive a later running state unchanged")
 	}
 
 	// A failed completion does not advance last_sync_success_at.

--- a/internal/db/replication_repo_test.go
+++ b/internal/db/replication_repo_test.go
@@ -93,9 +93,9 @@ func TestReplicationSourceCRUD(t *testing.T) {
 		t.Fatalf("UpdateReplicationSyncResult() error = %v", err)
 	}
 	withCounts, _ := database.GetReplicationSource(id)
-	if withCounts.LastSyncJobsSynced != 3 || withCounts.LastSyncRestorePoints != 12 || withCounts.LastSyncBytes != 1024 {
-		t.Errorf("counters = %d/%d/%d, want 3/12/1024",
-			withCounts.LastSyncJobsSynced, withCounts.LastSyncRestorePoints, withCounts.LastSyncBytes)
+	if withCounts.LastSyncJobsSynced != 3 || withCounts.LastSyncJobsFailed != 0 || withCounts.LastSyncRestorePoints != 12 || withCounts.LastSyncBytes != 1024 {
+		t.Errorf("counters = %d/%d/%d/%d, want 3/0/12/1024",
+			withCounts.LastSyncJobsSynced, withCounts.LastSyncJobsFailed, withCounts.LastSyncRestorePoints, withCounts.LastSyncBytes)
 	}
 	if withCounts.LastSyncSuccessAt == nil {
 		t.Error("LastSyncSuccessAt should be set after a successful sync")
@@ -121,6 +121,9 @@ func TestReplicationSourceCRUD(t *testing.T) {
 		t.Fatalf("UpdateReplicationSyncResult(failed) error = %v", err)
 	}
 	failed, _ := database.GetReplicationSource(id)
+	if failed.LastSyncJobsFailed != 2 {
+		t.Errorf("LastSyncJobsFailed = %d, want 2", failed.LastSyncJobsFailed)
+	}
 	if failed.LastSyncSuccessAt == nil || !failed.LastSyncSuccessAt.Equal(prevSuccess) {
 		t.Errorf("LastSyncSuccessAt should not change on a failed sync")
 	}

--- a/internal/db/replication_repo_test.go
+++ b/internal/db/replication_repo_test.go
@@ -64,13 +64,24 @@ func TestReplicationSourceCRUD(t *testing.T) {
 		t.Fatalf("len(sources) = %d, want 1", len(sources))
 	}
 
+	// getSource re-reads the row and fails the test on error, so a query
+	// failure can't be masked by assertions passing against a zero-value struct.
+	getSource := func(t *testing.T) ReplicationSource {
+		t.Helper()
+		src, err := database.GetReplicationSource(id)
+		if err != nil {
+			t.Fatalf("GetReplicationSource() error = %v", err)
+		}
+		return src
+	}
+
 	// Update
 	got.Name = "prod-server-v2"
 	got.Schedule = "0 */12 * * *"
 	if err := database.UpdateReplicationSource(got); err != nil {
 		t.Fatalf("UpdateReplicationSource() error = %v", err)
 	}
-	updated, _ := database.GetReplicationSource(id)
+	updated := getSource(t)
 	if updated.Name != "prod-server-v2" {
 		t.Errorf("Name after update = %q, want %q", updated.Name, "prod-server-v2")
 	}
@@ -79,7 +90,7 @@ func TestReplicationSourceCRUD(t *testing.T) {
 	if err := database.UpdateReplicationSyncStatus(id, "success", ""); err != nil {
 		t.Fatalf("UpdateReplicationSyncStatus() error = %v", err)
 	}
-	synced, _ := database.GetReplicationSource(id)
+	synced := getSource(t)
 	if synced.LastSyncStatus != "success" {
 		t.Errorf("LastSyncStatus = %q, want %q", synced.LastSyncStatus, "success")
 	}
@@ -95,7 +106,7 @@ func TestReplicationSourceCRUD(t *testing.T) {
 		if err := database.UpdateReplicationSyncResult(id, "success", "", 3, 0, 12, 1024); err != nil {
 			t.Fatalf("UpdateReplicationSyncResult() error = %v", err)
 		}
-		withCounts, _ := database.GetReplicationSource(id)
+		withCounts := getSource(t)
 		if withCounts.LastSyncJobsSynced != 3 || withCounts.LastSyncJobsFailed != 0 || withCounts.LastSyncRestorePoints != 12 || withCounts.LastSyncBytes != 1024 {
 			t.Errorf("counters = %d/%d/%d/%d, want 3/0/12/1024",
 				withCounts.LastSyncJobsSynced, withCounts.LastSyncJobsFailed, withCounts.LastSyncRestorePoints, withCounts.LastSyncBytes)
@@ -110,7 +121,7 @@ func TestReplicationSourceCRUD(t *testing.T) {
 		if err := database.UpdateReplicationSyncStatus(id, "running", ""); err != nil {
 			t.Fatalf("UpdateReplicationSyncStatus(running) error = %v", err)
 		}
-		running, _ := database.GetReplicationSource(id)
+		running := getSource(t)
 		if running.LastSyncJobsSynced != 0 || running.LastSyncRestorePoints != 0 || running.LastSyncBytes != 0 {
 			t.Errorf("counters after running = %d/%d/%d, want all 0",
 				running.LastSyncJobsSynced, running.LastSyncRestorePoints, running.LastSyncBytes)
@@ -125,7 +136,7 @@ func TestReplicationSourceCRUD(t *testing.T) {
 		if err := database.UpdateReplicationSyncResult(id, "failed", "boom", 0, 2, 0, 0); err != nil {
 			t.Fatalf("UpdateReplicationSyncResult(failed) error = %v", err)
 		}
-		failed, _ := database.GetReplicationSource(id)
+		failed := getSource(t)
 		if failed.LastSyncJobsFailed != 2 {
 			t.Errorf("LastSyncJobsFailed = %d, want 2", failed.LastSyncJobsFailed)
 		}

--- a/internal/db/replication_repo_test.go
+++ b/internal/db/replication_repo_test.go
@@ -87,47 +87,52 @@ func TestReplicationSourceCRUD(t *testing.T) {
 		t.Error("LastSyncAt should not be nil after sync")
 	}
 
-	// #287: a completed sync persists its per-item counters and, on success,
-	// advances last_sync_success_at.
-	if err := database.UpdateReplicationSyncResult(id, "success", "", 3, 0, 12, 1024); err != nil {
-		t.Fatalf("UpdateReplicationSyncResult() error = %v", err)
-	}
-	withCounts, _ := database.GetReplicationSource(id)
-	if withCounts.LastSyncJobsSynced != 3 || withCounts.LastSyncJobsFailed != 0 || withCounts.LastSyncRestorePoints != 12 || withCounts.LastSyncBytes != 1024 {
-		t.Errorf("counters = %d/%d/%d/%d, want 3/0/12/1024",
-			withCounts.LastSyncJobsSynced, withCounts.LastSyncJobsFailed, withCounts.LastSyncRestorePoints, withCounts.LastSyncBytes)
-	}
-	if withCounts.LastSyncSuccessAt == nil {
-		t.Error("LastSyncSuccessAt should be set after a successful sync")
-	}
+	// #287: a completed sync persists per-item counters, resets them on the
+	// next running/failed state, and only advances last_sync_success_at on a
+	// full success. Grouped in a subtest since it exercises the sync-summary
+	// state transitions rather than plain CRUD.
+	t.Run("last-sync summary persistence", func(t *testing.T) {
+		if err := database.UpdateReplicationSyncResult(id, "success", "", 3, 0, 12, 1024); err != nil {
+			t.Fatalf("UpdateReplicationSyncResult() error = %v", err)
+		}
+		withCounts, _ := database.GetReplicationSource(id)
+		if withCounts.LastSyncJobsSynced != 3 || withCounts.LastSyncJobsFailed != 0 || withCounts.LastSyncRestorePoints != 12 || withCounts.LastSyncBytes != 1024 {
+			t.Errorf("counters = %d/%d/%d/%d, want 3/0/12/1024",
+				withCounts.LastSyncJobsSynced, withCounts.LastSyncJobsFailed, withCounts.LastSyncRestorePoints, withCounts.LastSyncBytes)
+		}
+		if withCounts.LastSyncSuccessAt == nil {
+			t.Fatal("LastSyncSuccessAt should be set after a successful sync")
+		}
 
-	// A subsequent running/failed status resets the counters but preserves the
-	// last successful timestamp.
-	successBeforeRunning := *withCounts.LastSyncSuccessAt
-	if err := database.UpdateReplicationSyncStatus(id, "running", ""); err != nil {
-		t.Fatalf("UpdateReplicationSyncStatus(running) error = %v", err)
-	}
-	running, _ := database.GetReplicationSource(id)
-	if running.LastSyncJobsSynced != 0 || running.LastSyncRestorePoints != 0 || running.LastSyncBytes != 0 {
-		t.Errorf("counters after running = %d/%d/%d, want all 0",
-			running.LastSyncJobsSynced, running.LastSyncRestorePoints, running.LastSyncBytes)
-	}
-	if running.LastSyncSuccessAt == nil || !running.LastSyncSuccessAt.Equal(successBeforeRunning) {
-		t.Error("LastSyncSuccessAt should survive a later running state unchanged")
-	}
+		// A subsequent running status resets the counters but preserves the
+		// last successful timestamp.
+		successBeforeRunning := *withCounts.LastSyncSuccessAt
+		if err := database.UpdateReplicationSyncStatus(id, "running", ""); err != nil {
+			t.Fatalf("UpdateReplicationSyncStatus(running) error = %v", err)
+		}
+		running, _ := database.GetReplicationSource(id)
+		if running.LastSyncJobsSynced != 0 || running.LastSyncRestorePoints != 0 || running.LastSyncBytes != 0 {
+			t.Errorf("counters after running = %d/%d/%d, want all 0",
+				running.LastSyncJobsSynced, running.LastSyncRestorePoints, running.LastSyncBytes)
+		}
+		if running.LastSyncSuccessAt == nil || !running.LastSyncSuccessAt.Equal(successBeforeRunning) {
+			t.Error("LastSyncSuccessAt should survive a later running state unchanged")
+		}
 
-	// A failed completion does not advance last_sync_success_at.
-	prevSuccess := *running.LastSyncSuccessAt
-	if err := database.UpdateReplicationSyncResult(id, "failed", "boom", 0, 2, 0, 0); err != nil {
-		t.Fatalf("UpdateReplicationSyncResult(failed) error = %v", err)
-	}
-	failed, _ := database.GetReplicationSource(id)
-	if failed.LastSyncJobsFailed != 2 {
-		t.Errorf("LastSyncJobsFailed = %d, want 2", failed.LastSyncJobsFailed)
-	}
-	if failed.LastSyncSuccessAt == nil || !failed.LastSyncSuccessAt.Equal(prevSuccess) {
-		t.Errorf("LastSyncSuccessAt should not change on a failed sync")
-	}
+		// A failed completion records its failure count but does not advance
+		// last_sync_success_at.
+		prevSuccess := *running.LastSyncSuccessAt
+		if err := database.UpdateReplicationSyncResult(id, "failed", "boom", 0, 2, 0, 0); err != nil {
+			t.Fatalf("UpdateReplicationSyncResult(failed) error = %v", err)
+		}
+		failed, _ := database.GetReplicationSource(id)
+		if failed.LastSyncJobsFailed != 2 {
+			t.Errorf("LastSyncJobsFailed = %d, want 2", failed.LastSyncJobsFailed)
+		}
+		if failed.LastSyncSuccessAt == nil || !failed.LastSyncSuccessAt.Equal(prevSuccess) {
+			t.Errorf("LastSyncSuccessAt should not change on a failed sync")
+		}
+	})
 
 	// Delete
 	if err := database.DeleteReplicationSource(id); err != nil {

--- a/internal/replication/sync.go
+++ b/internal/replication/sync.go
@@ -232,7 +232,13 @@ func (s *Syncer) completeSyncStatus(sourceID int64, sourceName string, result *S
 		"bytes_transferred": result.BytesTransferred,
 	})
 
-	s.updateSyncStatus(sourceID, status, errMsg)
+	// Persist the status together with the per-item counters so the UI can
+	// show an explicit synced / up-to-date / failed state on load, not only
+	// from the transient completion event above.
+	if err := s.db.UpdateReplicationSyncResult(sourceID, status, errMsg,
+		result.JobsSynced, result.JobsFailed, result.RestorePointsNew, result.BytesTransferred); err != nil {
+		log.Printf("replication: update sync result for source %d: %v", sourceID, err)
+	}
 	s.db.LogActivity(level, "replication",
 		fmt.Sprintf("Replication sync %s: %s — %d jobs, %d failed, %d restore points, %d bytes",
 			status, sourceName, result.JobsSynced, result.JobsFailed, result.RestorePointsNew, result.BytesTransferred),

--- a/internal/replication/sync.go
+++ b/internal/replication/sync.go
@@ -224,10 +224,14 @@ func (s *Syncer) completeSyncStatus(sourceID int64, sourceName string, result *S
 	// Persist the status together with the per-item counters BEFORE
 	// broadcasting completion: the UI reloads on the completion event, so a
 	// broadcast that raced ahead of the write could read the previous row and
-	// show stale counters / last_sync_success_at.
+	// show stale counters / last_sync_success_at. If the write itself fails,
+	// stop here rather than announce a completion the database does not
+	// reflect — the source stays in its "running" state and self-corrects on
+	// the next sync instead of showing stale completed numbers.
 	if err := s.db.UpdateReplicationSyncResult(sourceID, status, errMsg,
 		result.JobsSynced, result.JobsFailed, result.RestorePointsNew, result.BytesTransferred); err != nil {
 		log.Printf("replication: update sync result for source %d: %v", sourceID, err)
+		return
 	}
 
 	s.broadcast(map[string]any{

--- a/internal/replication/sync.go
+++ b/internal/replication/sync.go
@@ -221,6 +221,15 @@ func (s *Syncer) completeSyncStatus(sourceID int64, sourceName string, result *S
 		level = "warning"
 	}
 
+	// Persist the status together with the per-item counters BEFORE
+	// broadcasting completion: the UI reloads on the completion event, so a
+	// broadcast that raced ahead of the write could read the previous row and
+	// show stale counters / last_sync_success_at.
+	if err := s.db.UpdateReplicationSyncResult(sourceID, status, errMsg,
+		result.JobsSynced, result.JobsFailed, result.RestorePointsNew, result.BytesTransferred); err != nil {
+		log.Printf("replication: update sync result for source %d: %v", sourceID, err)
+	}
+
 	s.broadcast(map[string]any{
 		"type":              "replication_sync_completed",
 		"source_id":         sourceID,
@@ -232,13 +241,6 @@ func (s *Syncer) completeSyncStatus(sourceID int64, sourceName string, result *S
 		"bytes_transferred": result.BytesTransferred,
 	})
 
-	// Persist the status together with the per-item counters so the UI can
-	// show an explicit synced / up-to-date / failed state on load, not only
-	// from the transient completion event above.
-	if err := s.db.UpdateReplicationSyncResult(sourceID, status, errMsg,
-		result.JobsSynced, result.JobsFailed, result.RestorePointsNew, result.BytesTransferred); err != nil {
-		log.Printf("replication: update sync result for source %d: %v", sourceID, err)
-	}
 	s.db.LogActivity(level, "replication",
 		fmt.Sprintf("Replication sync %s: %s — %d jobs, %d failed, %d restore points, %d bytes",
 			status, sourceName, result.JobsSynced, result.JobsFailed, result.RestorePointsNew, result.BytesTransferred),

--- a/internal/replication/sync_test.go
+++ b/internal/replication/sync_test.go
@@ -742,6 +742,38 @@ func TestCompleteSyncStatusDirect(t *testing.T) {
 	}
 }
 
+// TestCompleteSyncStatusPersistFailureStopsEarly verifies that when the result
+// write fails, completeSyncStatus bails out before announcing completion — it
+// must not present a completed sync (progress 1.0) that the database does not
+// reflect, or a client reload would read stale counters.
+func TestCompleteSyncStatusPersistFailureStopsEarly(t *testing.T) {
+	d := openTestDB(t)
+	destID, _ := d.CreateStorageDestination(db.StorageDestination{
+		Name: "d", Type: "local", Config: `{"path":"/tmp"}`,
+	})
+	srcID, _ := d.CreateReplicationSource(db.ReplicationSource{
+		Name: "src", URL: "http://x", StorageDestID: destID,
+	})
+	hub := ws.NewHub()
+	go hub.Run()
+	s := NewSyncer(d, hub)
+
+	// Force the result persistence to fail.
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	progress, seen := captureProgress()
+	res := &SyncResult{JobsSynced: 1, RestorePointsNew: 2, BytesTransferred: 100}
+	s.completeSyncStatus(srcID, "src", res, progress)
+
+	for _, p := range *seen {
+		if p == 1.0 {
+			t.Fatalf("completeSyncStatus reported completion despite a persistence failure: %v", *seen)
+		}
+	}
+}
+
 // --- completeSyncStatus honesty (#177) ---
 
 func TestCompleteSyncStatusHonest(t *testing.T) {

--- a/web/src/pages/Replication.svelte
+++ b/web/src/pages/Replication.svelte
@@ -280,7 +280,7 @@
       `${jobs} job${jobs === 1 ? '' : 's'} synced`,
       `${rps} new restore point${rps === 1 ? '' : 's'}`,
     ]
-    if (src.last_sync_bytes) parts.push(formatBytes(src.last_sync_bytes))
+    if (src.last_sync_bytes != null) parts.push(formatBytes(src.last_sync_bytes))
     if ((src.last_sync_jobs_failed || 0) > 0) parts.push(`${src.last_sync_jobs_failed} job(s) failed`)
     return parts.join(' · ')
   }

--- a/web/src/pages/Replication.svelte
+++ b/web/src/pages/Replication.svelte
@@ -3,7 +3,7 @@
   import { api, isReplicaMode } from '../lib/api.js'
   import { onWsMessage } from '../lib/ws.svelte.js'
   import { getLiveMode } from '../lib/runtime-config.js'
-  import { formatDate, describeSchedule } from '../lib/utils.js'
+  import { formatDate, describeSchedule, formatBytes } from '../lib/utils.js'
   import Modal from '../components/Modal.svelte'
   import Toast from '../components/Toast.svelte'
   import Spinner from '../components/Spinner.svelte'
@@ -253,11 +253,36 @@
 
   function statusBadge(src) {
     if (!src.enabled) return { label: 'Disabled', cls: 'bg-surface-3 text-text-muted' }
-    if (src.last_sync_status === 'success') return { label: 'Synced', cls: 'bg-success/10 text-success' }
+    if (src.last_sync_status === 'success') {
+      // A successful sync that transferred nothing new means the replica is
+      // already current — say so explicitly rather than an ambiguous "Synced".
+      return (src.last_sync_restore_points || 0) > 0
+        ? { label: 'Synced', cls: 'bg-success/10 text-success' }
+        : { label: 'Up to date', cls: 'bg-success/10 text-success' }
+    }
     if (src.last_sync_status === 'error' || src.last_sync_status === 'failed') return { label: 'Failed', cls: 'bg-danger/10 text-danger' }
     if (src.last_sync_status === 'partial') return { label: 'Partial', cls: 'bg-warning/10 text-warning' }
     if (src.last_sync_status === 'running') return { label: 'Syncing', cls: 'bg-warning/10 text-warning' }
     return { label: 'Pending', cls: 'bg-surface-3 text-text-muted' }
+  }
+
+  // Human summary of the most recent sync, so a connected-but-idle target reads
+  // clearly instead of looking like it "doesn't do much" (#287).
+  function syncSummary(src) {
+    if (src.last_sync_status === 'running') return 'Sync in progress…'
+    if (!src.last_sync_at || !src.last_sync_status) return 'No sync has run yet.'
+    if (src.last_sync_status === 'success' && (src.last_sync_restore_points || 0) === 0) {
+      return 'Up to date — nothing new to replicate.'
+    }
+    const jobs = src.last_sync_jobs_synced || 0
+    const rps = src.last_sync_restore_points || 0
+    const parts = [
+      `${jobs} job${jobs === 1 ? '' : 's'} synced`,
+      `${rps} new restore point${rps === 1 ? '' : 's'}`,
+    ]
+    if (src.last_sync_bytes) parts.push(formatBytes(src.last_sync_bytes))
+    if ((src.last_sync_jobs_failed || 0) > 0) parts.push(`${src.last_sync_jobs_failed} job(s) failed`)
+    return parts.join(' · ')
   }
 </script>
 
@@ -331,6 +356,11 @@
                 <p class="text-text font-medium">{formatDate(src.created_at)}</p>
               </div>
             </div>
+
+            <p class="mt-3 text-xs text-text-muted">{syncSummary(src)}</p>
+            {#if src.last_sync_success_at}
+              <p class="text-xs text-text-dim mt-0.5">Last successful sync: {formatDate(src.last_sync_success_at)}</p>
+            {/if}
 
             {#if (src.last_sync_status === 'error' || src.last_sync_status === 'failed' || src.last_sync_status === 'partial') && src.last_sync_error}
               <div class="mt-3 p-2 bg-danger/5 border border-danger/20 rounded-lg text-xs text-danger">


### PR DESCRIPTION
Closes #287.

Replication showed a single "Synced" state and never surfaced what a sync actually did, so a target that connected but had nothing new looked identical to one that transferred data — the reported "connects but doesn't seem to do much" confusion. The per-sync counters existed in `SyncResult` but were only broadcast on the completion event, so a page load or the 10s poll couldn't show them.

## Change
- **DB** (`migrations.go`, `models.go`, `replication_repo.go`) — persist the last run's counters (`last_sync_jobs_synced/failed`, `last_sync_restore_points`, `last_sync_bytes`) and `last_sync_success_at`. New `UpdateReplicationSyncResult`; `UpdateReplicationSyncStatus` now resets counters on `running`/early-failure so a stale summary is never shown; `last_sync_success_at` only advances on a full success.
- **Syncer** (`sync.go`) — `completeSyncStatus` persists the result **before** broadcasting the completion event (the UI reloads on that event, so persisting first avoids a stale read).
- **UI** (`Replication.svelte`) — explicit **Up to date** badge + "nothing new to replicate" when a sync found nothing; a per-sync summary line (jobs synced · new restore points · bytes · failures); and the last-successful-sync time.
- Tests: repo test covers counter persistence, reset-on-running, timestamp preservation, and no-advance-on-failure.

Scope note: does not assert a "WIP vs GA" maturity label — that's a product decision. This makes the actual state observable, which is the core of the report.

## Verification
- `go test ./internal/db ./internal/replication ./internal/api/...` pass; `npm --prefix web run lint`/`build` clean
- CodeRabbit CLI: 2 findings (round 1) + 2 (round 2: persist-before-broadcast race, timestamp assertion) all addressed; re-review rate-limited — requesting the bot below
- Will run `make build/deploy/verify` on Unraid before merge

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replication now shows an **Up to date** status when no new restore points are available.
  * Added per-sync summaries for transferred data, synced items, failures, and restore points.
  * Sync summaries and counters remain visible after refreshing the page.
  * Added the timestamp of the last successful replication.

* **Bug Fixes**
  * Replication results are now saved before completion is displayed, ensuring the interface shows current information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->