### PR TITLE
feat(scheduler): defer scheduled deep verify while a backup runs on the same destination (#290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - Updated Go and web dependencies to their latest compatible releases and resolved a high-severity advisory in the web `nanoid` dependency. gosec, govulncheck, and the Go linter pass clean, and the MCP integration remains on the go-sdk v1.7.0 API.
 
+### Changed
+
+- **A scheduled deep verify no longer piles onto a destination that a backup is still writing to.** Deep verification streams and re-hashes every stored item, so running it against the same storage destination as an in-progress backup saturated the shared disk and network — the backup slowed to a crawl and looked frozen, with nothing in the logs to explain it. Vault now defers a scheduled deep verify while a backup is running on the same destination and records why in the activity log, letting the deep verify run at its next scheduled tick instead. Quick verification (existence and size checks only) is light enough to keep running alongside a backup, and an on-demand verify you trigger yourself is never deferred. Closes #290.
+
 ### Fixed
 
 - **A container's database dump is no longer lost when the restore does not reload it.** When a restore left the SQL dump in place — because the restored volume was the newer, consistent copy, the container was not running, or the database never became ready — the dump only ever existed in a temporary staging directory that Vault cleaned up when the restore finished, so there was nothing left for an operator to find. Vault now copies the un-reloaded dump to a durable, discoverable location and reports the exact path in the restore progress and logs: the custom restore destination when one is set (`<destination>/<container>-database.sql`), otherwise beside the container's first restored volume (for example `/mnt/user/appdata/<container>-database.sql`). The file name is prefixed with the container name so restores that share a parent directory do not collide, and the container backup guide now documents where the dump lands for in-place and custom restores. Closes #289.

--- a/docs/guides/backup-jobs.md
+++ b/docs/guides/backup-jobs.md
@@ -263,6 +263,12 @@ Every backup item is hashed with SHA-256 during the upload, and Vault stores the
 
 Both paths use the same code, so per-run and on-demand results are directly comparable.
 
+### Scheduled verification and backup contention
+
+A job can also run verification on its own cron schedule (_Verify schedule_) in either **quick** mode (checks each item exists and is the right size) or **deep** mode (streams every item back and re-hashes it). Deep verification reads the entire backup, so it saturates the destination's disk and network.
+
+To keep that from turning a running backup into an apparent freeze, Vault **defers a scheduled deep verify while a backup is active on the same storage destination**. The deferral is recorded in the activity log (`Deep verify for "<job>" deferred: a backup is running on the same storage destination`) and the deep verify simply runs at its next scheduled tick. Quick verification is cheap enough that it still runs alongside a backup, and on-demand verification you trigger yourself is never deferred.
+
 ---
 
 ## Encryption

--- a/internal/db/coverage_gapfill_test.go
+++ b/internal/db/coverage_gapfill_test.go
@@ -306,9 +306,13 @@ func TestCountRunningBackupsOnDestination(t *testing.T) {
 	if _, err := d.CreateJobRun(JobRun{JobID: jobB, Status: "running", BackupType: "full"}); err != nil {
 		t.Fatal(err)
 	}
+	// A running *restore* on destA must not count as backup write load.
+	if _, err := d.CreateJobRun(JobRun{JobID: jobA, Status: "running", BackupType: "full", RunType: "restore"}); err != nil {
+		t.Fatal(err)
+	}
 
-	// Only the running run on destA counts; the finished one and destB's run
-	// do not.
+	// Only the running backup run on destA counts; the finished one, the
+	// running restore, and destB's run do not.
 	if n, err := d.CountRunningBackupsOnDestination(destA); err != nil || n != 1 {
 		t.Fatalf("CountRunningBackupsOnDestination(destA) = %d, %v; want 1, nil", n, err)
 	}

--- a/internal/db/coverage_gapfill_test.go
+++ b/internal/db/coverage_gapfill_test.go
@@ -291,11 +291,6 @@ func TestCountRunningBackupsOnDestination(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Nothing running yet.
-	if n, err := d.CountRunningBackupsOnDestination(destA); err != nil || n != 0 {
-		t.Fatalf("CountRunningBackupsOnDestination(destA) = %d, %v; want 0, nil", n, err)
-	}
-
 	// One running and one finished run on destA; one running on destB.
 	if _, err := d.CreateJobRun(JobRun{JobID: jobA, Status: "running", BackupType: "full"}); err != nil {
 		t.Fatal(err)
@@ -311,18 +306,26 @@ func TestCountRunningBackupsOnDestination(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Only the running backup run on destA counts; the finished one, the
-	// running restore, and destB's run do not.
-	if n, err := d.CountRunningBackupsOnDestination(destA); err != nil || n != 1 {
-		t.Fatalf("CountRunningBackupsOnDestination(destA) = %d, %v; want 1, nil", n, err)
+	cases := []struct {
+		name string
+		dest int64
+		want int
+	}{
+		{"only the running backup counts, not the finished run or the restore", destA, 1},
+		{"a different destination counts its own running backup", destB, 1},
+		{"a destination with no jobs counts zero", 99999, 0},
 	}
-	if n, err := d.CountRunningBackupsOnDestination(destB); err != nil || n != 1 {
-		t.Fatalf("CountRunningBackupsOnDestination(destB) = %d, %v; want 1, nil", n, err)
-	}
-
-	// A destination with no jobs counts zero.
-	if n, err := d.CountRunningBackupsOnDestination(99999); err != nil || n != 0 {
-		t.Fatalf("CountRunningBackupsOnDestination(missing) = %d, %v; want 0, nil", n, err)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			n, err := d.CountRunningBackupsOnDestination(tc.dest)
+			if err != nil {
+				t.Fatalf("CountRunningBackupsOnDestination(%d): %v", tc.dest, err)
+			}
+			if n != tc.want {
+				t.Fatalf("CountRunningBackupsOnDestination(%d) = %d, want %d", tc.dest, n, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/db/coverage_gapfill_test.go
+++ b/internal/db/coverage_gapfill_test.go
@@ -271,6 +271,57 @@ func TestListJobsByStorageDestID(t *testing.T) {
 	}
 }
 
+func TestCountRunningBackupsOnDestination(t *testing.T) {
+	t.Parallel()
+	d := setupTestDB(t)
+	destA, err := d.CreateStorageDestination(StorageDestination{Name: "A", Type: "local", Config: "{}"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	destB, err := d.CreateStorageDestination(StorageDestination{Name: "B", Type: "local", Config: "{}"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobA, err := d.CreateJob(Job{Name: "ja", StorageDestID: destA, BackupTypeChain: "full"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobB, err := d.CreateJob(Job{Name: "jb", StorageDestID: destB, BackupTypeChain: "full"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Nothing running yet.
+	if n, err := d.CountRunningBackupsOnDestination(destA); err != nil || n != 0 {
+		t.Fatalf("CountRunningBackupsOnDestination(destA) = %d, %v; want 0, nil", n, err)
+	}
+
+	// One running and one finished run on destA; one running on destB.
+	if _, err := d.CreateJobRun(JobRun{JobID: jobA, Status: "running", BackupType: "full"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.CreateJobRun(JobRun{JobID: jobA, Status: "success", BackupType: "full"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.CreateJobRun(JobRun{JobID: jobB, Status: "running", BackupType: "full"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only the running run on destA counts; the finished one and destB's run
+	// do not.
+	if n, err := d.CountRunningBackupsOnDestination(destA); err != nil || n != 1 {
+		t.Fatalf("CountRunningBackupsOnDestination(destA) = %d, %v; want 1, nil", n, err)
+	}
+	if n, err := d.CountRunningBackupsOnDestination(destB); err != nil || n != 1 {
+		t.Fatalf("CountRunningBackupsOnDestination(destB) = %d, %v; want 1, nil", n, err)
+	}
+
+	// A destination with no jobs counts zero.
+	if n, err := d.CountRunningBackupsOnDestination(99999); err != nil || n != 0 {
+		t.Fatalf("CountRunningBackupsOnDestination(missing) = %d, %v; want 0, nil", n, err)
+	}
+}
+
 // --- storage_repo: ReplaceDedupPack / ReplaceDedupChunk ---------------------
 
 func TestReplaceDedupPackUpsertsExisting(t *testing.T) {

--- a/internal/db/job_repo.go
+++ b/internal/db/job_repo.go
@@ -414,17 +414,20 @@ func (d *DB) CleanupStaleRuns() (int64, error) {
 }
 
 // CountRunningBackupsOnDestination returns how many backup runs are currently
-// active (status 'running') for jobs that target the given storage
-// destination. Used to avoid starting a heavy deep verify against a
-// destination a backup is already saturating (#290): the two share the same
-// disk/network and running them together turns a slow backup into an apparent
-// freeze.
+// active (status 'running', run_type 'backup') for jobs that target the given
+// storage destination. Restores and other non-backup run types are excluded so
+// the count reflects genuine backup write load. Used to avoid starting a heavy
+// deep verify against a destination a backup is already saturating (#290): the
+// two share the same disk/network and running them together turns a slow backup
+// into an apparent freeze.
 func (d *DB) CountRunningBackupsOnDestination(storageDestID int64) (int, error) {
 	var count int
 	err := d.QueryRow(
 		`SELECT COUNT(*) FROM job_runs r
 		 JOIN jobs j ON j.id = r.job_id
-		 WHERE r.status = 'running' AND j.storage_dest_id = ?`,
+		 WHERE r.status = 'running'
+		   AND COALESCE(r.run_type, 'backup') = 'backup'
+		   AND j.storage_dest_id = ?`,
 		storageDestID,
 	).Scan(&count)
 	if err != nil {

--- a/internal/db/job_repo.go
+++ b/internal/db/job_repo.go
@@ -413,6 +413,26 @@ func (d *DB) CleanupStaleRuns() (int64, error) {
 	return res.RowsAffected()
 }
 
+// CountRunningBackupsOnDestination returns how many backup runs are currently
+// active (status 'running') for jobs that target the given storage
+// destination. Used to avoid starting a heavy deep verify against a
+// destination a backup is already saturating (#290): the two share the same
+// disk/network and running them together turns a slow backup into an apparent
+// freeze.
+func (d *DB) CountRunningBackupsOnDestination(storageDestID int64) (int, error) {
+	var count int
+	err := d.QueryRow(
+		`SELECT COUNT(*) FROM job_runs r
+		 JOIN jobs j ON j.id = r.job_id
+		 WHERE r.status = 'running' AND j.storage_dest_id = ?`,
+		storageDestID,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("counting running backups on destination %d: %w", storageDestID, err)
+	}
+	return count, nil
+}
+
 // DeleteOldFailedRuns removes failed/error job runs older than keepDays.
 func (d *DB) DeleteOldFailedRuns(keepDays int) (int64, error) {
 	res, err := d.Exec(

--- a/internal/runner/verify.go
+++ b/internal/runner/verify.go
@@ -77,8 +77,11 @@ func (r *Runner) RunScheduledVerify(jobID int64, mode string) {
 		} else if active > 0 {
 			msg := fmt.Sprintf("Deep verify for %q deferred: a backup is running on the same storage destination", job.Name)
 			log.Printf("runner: scheduled verify: %s (active backups=%d); will retry at the next scheduled verify", msg, active)
-			r.logActivity("info", "verify", msg,
-				fmt.Sprintf(`{"job_id":%d,"storage_dest_id":%d,"active_backups":%d}`, jobID, job.StorageDestID, active))
+			r.logActivity("info", "verify", msg, structuredDetails(map[string]any{
+				"job_id":          jobID,
+				"storage_dest_id": job.StorageDestID,
+				"active_backups":  active,
+			}))
 			return
 		}
 	}

--- a/internal/runner/verify.go
+++ b/internal/runner/verify.go
@@ -65,6 +65,23 @@ func (r *Runner) RunScheduledVerify(jobID int64, mode string) {
 		log.Printf("runner: scheduled verify: job %d (%s) has no restore points yet, skipping", jobID, job.Name)
 		return
 	}
+	// #290: a deep verify streams and re-hashes every chunk, saturating the
+	// destination's disk/network. If a backup is already running against the
+	// same destination, starting one now turns that backup into an apparent
+	// freeze from heavy contention. Defer the deep verify to its next
+	// scheduled tick and surface why, rather than piling onto the destination.
+	// Quick verify only issues HEADs, so it is cheap enough to let through.
+	if VerifyMode(mode) == VerifyModeDeep {
+		if active, cerr := r.db.CountRunningBackupsOnDestination(job.StorageDestID); cerr != nil {
+			log.Printf("runner: scheduled verify: job %d (%s): could not check for active backups, proceeding: %v", jobID, job.Name, cerr)
+		} else if active > 0 {
+			msg := fmt.Sprintf("Deep verify for %q deferred: a backup is running on the same storage destination", job.Name)
+			log.Printf("runner: scheduled verify: %s (active backups=%d); will retry at the next scheduled verify", msg, active)
+			r.logActivity("info", "verify", msg,
+				fmt.Sprintf(`{"job_id":%d,"storage_dest_id":%d,"active_backups":%d}`, jobID, job.StorageDestID, active))
+			return
+		}
+	}
 	id, err := r.RunVerify(rp, VerifyMode(mode))
 	if err != nil {
 		log.Printf("runner: scheduled verify: dispatch failed for job %d: %v", jobID, err)

--- a/internal/runner/verify_gap_test.go
+++ b/internal/runner/verify_gap_test.go
@@ -61,6 +61,109 @@ func TestRunScheduledVerifyInvalidMode(t *testing.T) {
 	r.RunScheduledVerify(jobID, "totally-bogus-mode")
 }
 
+// seedVerifiableJob creates a job on its own destination with a single restore
+// point so RunScheduledVerify reaches the dispatch decision. It returns the
+// job ID and its storage destination.
+func seedVerifiableJob(t *testing.T, database *db.DB, storageDir, name string) (int64, db.StorageDestination) {
+	t.Helper()
+	dest := createLocalDest(t, database, storageDir)
+	jobID, err := database.CreateJob(db.Job{
+		Name: name, Enabled: true, BackupTypeChain: "full", StorageDestID: dest.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runID, err := database.CreateJobRun(db.JobRun{JobID: jobID, Status: "success", BackupType: "full"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.CreateRestorePoint(db.RestorePoint{
+		JobRunID: runID, JobID: jobID, BackupType: "full",
+		StoragePath: name + "/1_run", Metadata: "{}", SizeBytes: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return jobID, dest
+}
+
+// TestRunScheduledDeepVerifyDeferredWhenBackupActive covers #290: a scheduled
+// deep verify must not start while a backup is running on the same storage
+// destination, or the two saturate the destination and the backup appears to
+// freeze.
+func TestRunScheduledDeepVerifyDeferredWhenBackupActive(t *testing.T) {
+	t.Parallel()
+	r, database, storageDir := setupTestRunner(t)
+	jobID, dest := seedVerifiableJob(t, database, storageDir, "verify-defer")
+
+	// A second job on the SAME destination is mid-backup.
+	busyJob, err := database.CreateJob(db.Job{
+		Name: "busy", Enabled: true, BackupTypeChain: "full", StorageDestID: dest.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.CreateJobRun(db.JobRun{JobID: busyJob, Status: "running", BackupType: "full"}); err != nil {
+		t.Fatal(err)
+	}
+
+	r.RunScheduledVerify(jobID, "deep")
+
+	runs, err := database.ListRecentVerifyRuns(10)
+	if err != nil {
+		t.Fatalf("ListRecentVerifyRuns: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("deep verify was dispatched despite an active backup on the destination (%d verify runs)", len(runs))
+	}
+}
+
+// TestRunScheduledDeepVerifyProceedsWhenIdle is the control: with no backup
+// running on the destination, the deep verify is dispatched (a verify_run row
+// is created).
+func TestRunScheduledDeepVerifyProceedsWhenIdle(t *testing.T) {
+	t.Parallel()
+	r, database, storageDir := setupTestRunner(t)
+	jobID, _ := seedVerifiableJob(t, database, storageDir, "verify-idle")
+
+	r.RunScheduledVerify(jobID, "deep")
+
+	runs, err := database.ListRecentVerifyRuns(10)
+	if err != nil {
+		t.Fatalf("ListRecentVerifyRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected the deep verify to be dispatched (1 verify run), got %d", len(runs))
+	}
+}
+
+// TestRunScheduledQuickVerifyProceedsDespiteActiveBackup confirms only deep
+// verify is gated — a quick verify (HEAD-only) still runs during a backup.
+func TestRunScheduledQuickVerifyProceedsDespiteActiveBackup(t *testing.T) {
+	t.Parallel()
+	r, database, storageDir := setupTestRunner(t)
+	jobID, dest := seedVerifiableJob(t, database, storageDir, "verify-quick")
+
+	busyJob, err := database.CreateJob(db.Job{
+		Name: "busy-quick", Enabled: true, BackupTypeChain: "full", StorageDestID: dest.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.CreateJobRun(db.JobRun{JobID: busyJob, Status: "running", BackupType: "full"}); err != nil {
+		t.Fatal(err)
+	}
+
+	r.RunScheduledVerify(jobID, "quick")
+
+	runs, err := database.ListRecentVerifyRuns(10)
+	if err != nil {
+		t.Fatalf("ListRecentVerifyRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected quick verify to run during a backup (1 verify run), got %d", len(runs))
+	}
+}
+
 // TestVerifyOneFileMissingFile exercises the Stat-failure error path.
 func TestVerifyOneFileMissingFile(t *testing.T) {
 	t.Parallel()

--- a/internal/runner/verify_gap_test.go
+++ b/internal/runner/verify_gap_test.go
@@ -130,6 +130,29 @@ func TestRunScheduledVerifyBackupContention(t *testing.T) {
 			if len(runs) != tc.wantRuns {
 				t.Fatalf("verify runs = %d, want %d (mode=%s, busyBackup=%v)", len(runs), tc.wantRuns, tc.mode, tc.busyBackup)
 			}
+
+			if tc.wantRuns == 0 {
+				// Deferral must be surfaced in the activity log so the user can
+				// see why the deep verify did not run.
+				entries, err := database.ListActivityLogs(10, "verify")
+				if err != nil {
+					t.Fatalf("ListActivityLogs: %v", err)
+				}
+				if len(entries) != 1 {
+					t.Fatalf("verify activity entries = %d, want 1", len(entries))
+				}
+				if !strings.Contains(entries[0].Message, "deferred") {
+					t.Errorf("activity message = %q, want it to mention the deferral", entries[0].Message)
+				}
+				if !strings.Contains(entries[0].Details, `"active_backups"`) {
+					t.Errorf("activity details = %q, want the active_backups count", entries[0].Details)
+				}
+			} else {
+				// A dispatched run must carry the requested mode.
+				if runs[0].Mode != tc.mode {
+					t.Errorf("dispatched verify mode = %q, want %q", runs[0].Mode, tc.mode)
+				}
+			}
 		})
 	}
 }

--- a/internal/runner/verify_gap_test.go
+++ b/internal/runner/verify_gap_test.go
@@ -86,81 +86,51 @@ func seedVerifiableJob(t *testing.T, database *db.DB, storageDir, name string) (
 	return jobID, dest
 }
 
-// TestRunScheduledDeepVerifyDeferredWhenBackupActive covers #290: a scheduled
-// deep verify must not start while a backup is running on the same storage
-// destination, or the two saturate the destination and the backup appears to
-// freeze.
-func TestRunScheduledDeepVerifyDeferredWhenBackupActive(t *testing.T) {
+// TestRunScheduledVerifyBackupContention covers #290: a scheduled deep verify
+// must not start while a backup is running on the same storage destination (it
+// would saturate the destination and make the backup appear frozen), while a
+// quick verify and an idle deep verify still dispatch.
+func TestRunScheduledVerifyBackupContention(t *testing.T) {
 	t.Parallel()
-	r, database, storageDir := setupTestRunner(t)
-	jobID, dest := seedVerifiableJob(t, database, storageDir, "verify-defer")
-
-	// A second job on the SAME destination is mid-backup.
-	busyJob, err := database.CreateJob(db.Job{
-		Name: "busy", Enabled: true, BackupTypeChain: "full", StorageDestID: dest.ID,
-	})
-	if err != nil {
-		t.Fatal(err)
+	cases := []struct {
+		name       string
+		mode       string
+		busyBackup bool
+		wantRuns   int
+	}{
+		{"deep deferred while backup active", "deep", true, 0},
+		{"deep dispatched when destination idle", "deep", false, 1},
+		{"quick runs alongside an active backup", "quick", true, 1},
 	}
-	if _, err := database.CreateJobRun(db.JobRun{JobID: busyJob, Status: "running", BackupType: "full"}); err != nil {
-		t.Fatal(err)
-	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r, database, storageDir := setupTestRunner(t)
+			jobID, dest := seedVerifiableJob(t, database, storageDir, "verify-job")
 
-	r.RunScheduledVerify(jobID, "deep")
+			if tc.busyBackup {
+				busyJob, err := database.CreateJob(db.Job{
+					Name: "busy-job", Enabled: true, BackupTypeChain: "full", StorageDestID: dest.ID,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := database.CreateJobRun(db.JobRun{JobID: busyJob, Status: "running", BackupType: "full"}); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	runs, err := database.ListRecentVerifyRuns(10)
-	if err != nil {
-		t.Fatalf("ListRecentVerifyRuns: %v", err)
-	}
-	if len(runs) != 0 {
-		t.Fatalf("deep verify was dispatched despite an active backup on the destination (%d verify runs)", len(runs))
-	}
-}
+			r.RunScheduledVerify(jobID, tc.mode)
 
-// TestRunScheduledDeepVerifyProceedsWhenIdle is the control: with no backup
-// running on the destination, the deep verify is dispatched (a verify_run row
-// is created).
-func TestRunScheduledDeepVerifyProceedsWhenIdle(t *testing.T) {
-	t.Parallel()
-	r, database, storageDir := setupTestRunner(t)
-	jobID, _ := seedVerifiableJob(t, database, storageDir, "verify-idle")
-
-	r.RunScheduledVerify(jobID, "deep")
-
-	runs, err := database.ListRecentVerifyRuns(10)
-	if err != nil {
-		t.Fatalf("ListRecentVerifyRuns: %v", err)
-	}
-	if len(runs) != 1 {
-		t.Fatalf("expected the deep verify to be dispatched (1 verify run), got %d", len(runs))
-	}
-}
-
-// TestRunScheduledQuickVerifyProceedsDespiteActiveBackup confirms only deep
-// verify is gated — a quick verify (HEAD-only) still runs during a backup.
-func TestRunScheduledQuickVerifyProceedsDespiteActiveBackup(t *testing.T) {
-	t.Parallel()
-	r, database, storageDir := setupTestRunner(t)
-	jobID, dest := seedVerifiableJob(t, database, storageDir, "verify-quick")
-
-	busyJob, err := database.CreateJob(db.Job{
-		Name: "busy-quick", Enabled: true, BackupTypeChain: "full", StorageDestID: dest.ID,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := database.CreateJobRun(db.JobRun{JobID: busyJob, Status: "running", BackupType: "full"}); err != nil {
-		t.Fatal(err)
-	}
-
-	r.RunScheduledVerify(jobID, "quick")
-
-	runs, err := database.ListRecentVerifyRuns(10)
-	if err != nil {
-		t.Fatalf("ListRecentVerifyRuns: %v", err)
-	}
-	if len(runs) != 1 {
-		t.Fatalf("expected quick verify to run during a backup (1 verify run), got %d", len(runs))
+			runs, err := database.ListRecentVerifyRuns(10)
+			if err != nil {
+				t.Fatalf("ListRecentVerifyRuns: %v", err)
+			}
+			if len(runs) != tc.wantRuns {
+				t.Fatalf("verify runs = %d, want %d (mode=%s, busyBackup=%v)", len(runs), tc.wantRuns, tc.mode, tc.busyBackup)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #290.

Forum diagnostics showed a long-running backup and a scheduled **deep verify** overlapping on the same storage destination: the deep verify streams and re-hashes every stored item, so the two saturated the shared disk/network and the backup appeared frozen — with nothing in the logs to explain it (backup `job 4 / run 13` active ~31h50m alongside deep verify `id=2`).

## Changes

- **`internal/db/job_repo.go`**: new `CountRunningBackupsOnDestination(storageDestID)` — counts `running` job runs for jobs targeting a destination (a `job_runs`⋈`jobs` join).
- **`internal/runner/verify.go`**: `RunScheduledVerify` now checks, for **deep** mode only, whether a backup is running on the same destination. If so it defers to the next scheduled tick and records the reason in the activity log (`Deep verify for "<job>" deferred: a backup is running on the same storage destination`). Quick verify (HEAD-only) still runs alongside a backup; on-demand verification (`RunVerify` directly) is never deferred.
- **Tests**: `TestCountRunningBackupsOnDestination`, plus runner tests covering deferral under an active backup, dispatch when idle, and quick-verify proceeding during a backup.
- **`docs/guides/backup-jobs.md`**: documents the scheduled-verification modes and the deep-verify deferral behaviour.

## Verification

- `go test ./internal/db/ ./internal/runner/` passes; `golangci-lint`, `gosec`, `govulncheck` clean.
- Built, deployed, and verified on the live Unraid host.

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Scheduled deep verification is now deferred while a backup is writing to the same storage destination.
  - The deferral is recorded in the activity log and automatically retried at the next scheduled interval.
  - Quick verification and manually triggered verification continue without delay.
  - Verification proceeds normally when the destination is idle.

- **Documentation**
  - Added guidance covering scheduled verification modes and deferral behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->