### PR TITLE
feat(engine): run logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **Replication targets now show what the last sync actually did.** A target that connected but had nothing new to copy previously just read "Synced", which looked the same as a sync that transferred data — so replication could appear to "connect but not do much". Each target now shows an explicit **Up to date** state when a sync found nothing new, a per-sync summary (jobs synced, new restore points, bytes transferred, and any failures), and the time replication last fully succeeded. These counters are stored with each run, so they are visible on page load and after a refresh, not only in the moment a sync finishes. Closes #287.
 
+- **Run logs (#328):** backups and restores now write a real streaming log — run start, per-item start/success/failure with sizes and durations, phase changes (staging, deferred upload, stop-all), stalls, and an end-of-run summary (items, duration, percent successful). In the Logs tab, any backup or restore entry now expands to show its run's log in a scrollable box that appends in real time while the run is live. Entries persist with the run and are cleaned up with run history, backed by a defensive 10,000-line-per-run cap alongside the existing activity-log cap. Storage health checks now record per-destination outcomes in the activity log. New API: `GET /api/v1/runs/{runId}/logs?after=<id>`; new MCP tool: `get_run_logs`; new WebSocket event: `run_log`. Closes #328.
+
 ### Security
 
 - Updated Go and web dependencies to their latest compatible releases and resolved a high-severity advisory in the web `nanoid` dependency. gosec, govulncheck, and the Go linter pass clean, and the MCP integration remains on the go-sdk v1.7.0 API.

--- a/ansible/roles/build/tasks/main.yml
+++ b/ansible/roles/build/tasks/main.yml
@@ -40,7 +40,7 @@
 
     - name: Install web dependencies
       ansible.builtin.command:
-        cmd: npm ci
+        cmd: npm ci --include=dev
         chdir: "{{ playbook_dir }}/../web"
       changed_when: false
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -118,6 +118,7 @@ The job payload's `backup_type_chain` field accepts `full`, `incremental`, or `d
 | ------ | ------------------- | ------------------------------------------------------------------ |
 | GET    | `/activity?limit=N` | Activity log entries (`limit` is clamped to ≤ 1000 to prevent OOM) |
 | DELETE | `/activity`         | Purge all activity log entries (irreversible)                      |
+| GET    | `/runs/{runId}/logs?after=<id>&limit=N` | Streaming log entries for one backup/restore run, oldest-first. `?after=<id>` tails only newer lines; `?limit=N` clamped to [1, 1000]. Unknown run → 404; invalid run id or negative `after` / non-positive `limit` → 400 |
 
 ## History
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -141,6 +141,7 @@ The MCP surface is intentionally curated rather than a 1:1 mirror of every REST 
 | `get_health_summary` | Dashboard health metrics     |
 | `get_runner_status`  | Current backup/restore state |
 | `get_activity_log`   | Recent activity log          |
+| `get_run_logs`       | Per-run streaming log entries |
 
 ### Restore
 

--- a/internal/anomaly/lifecycle.go
+++ b/internal/anomaly/lifecycle.go
@@ -153,22 +153,20 @@ func (e *Evaluator) BulkAck(ids []int64, action AckAction, by, reason string) (a
 			"skipped":      skipped,
 			"ids":          ids,
 		})
-		e.db.LogActivity("info", "anomaly",
+		e.db.LogActivity("warn", "health",
 			fmt.Sprintf("%d anomaly(s) acknowledged via bulk action by %s", acknowledged, by), "")
 	}
 	return acknowledged, skipped, nil
 }
 
 // logActivity writes a single activity_log row for an anomaly lifecycle
-// transition. The category is always "anomaly". Level is "warn" for critical
-// severity, "info" otherwise.
+// transition. Anomaly detection is the run/storage health-monitoring
+// subsystem, so rows are filed under the canonical "health" category (there
+// is no "anomaly" category — #328 r3) and always at WARN (an anomaly report
+// is never routine INFO noise — #328 r3).
 func (e *Evaluator) logActivity(a Anomaly, transition string) {
-	level := "info"
-	if a.Severity == SeverityCritical {
-		level = "warn"
-	}
 	msg := fmt.Sprintf("Anomaly %s: [%s/%s] %s (id=%d)", transition, a.Severity, a.ScopeKind, a.Summary, a.ID)
-	e.db.LogActivity(level, "anomaly", msg, a.Details)
+	e.db.LogActivity("warn", "health", msg, a.Details)
 }
 
 // maybeNotify is implemented in notify.go (Task 16).

--- a/internal/anomaly/lifecycle_test.go
+++ b/internal/anomaly/lifecycle_test.go
@@ -291,7 +291,7 @@ func TestLifecycleAck(t *testing.T) {
 		t.Fatalf("GetOpenAnomalyByFingerprint (mark_expected): %v", err)
 	}
 
-	logsBefore, _ := d.ListActivityLogs(100, "anomaly")
+	logsBefore, _ := d.ListActivityLogs(100, "health", 0)
 	updatedBefore := countEvent(extractEventTypes(t, hub), "anomaly.updated")
 
 	expAcked, err := ev.Ack(bRow.ID, AckMarkExpected, "user@example.com", "this is normal")
@@ -314,7 +314,7 @@ func TestLifecycleAck(t *testing.T) {
 		t.Errorf("anomaly.updated count after mark_expected = %d, want %d", got, updatedBefore+1)
 	}
 
-	logsAfter, _ := d.ListActivityLogs(100, "anomaly")
+	logsAfter, _ := d.ListActivityLogs(100, "health", 0)
 	if len(logsAfter) <= len(logsBefore) {
 		t.Errorf("expected a new anomaly activity row after mark_expected; before=%d after=%d",
 			len(logsBefore), len(logsAfter))
@@ -370,7 +370,7 @@ func TestLifecycleBulkAck(t *testing.T) {
 	assertEventCount(t, extractEventTypes(t, hub), "anomaly.bulk_acked", 1)
 
 	// A single summary activity_log row must have been written.
-	logs, err := d.ListActivityLogs(100, "anomaly")
+	logs, err := d.ListActivityLogs(100, "health", 0)
 	if err != nil {
 		t.Fatalf("ListActivityLogs: %v", err)
 	}
@@ -454,7 +454,7 @@ func TestLifecycleExpectedFloor(t *testing.T) {
 
 // ── TestLifecycleActivityLog ─────────────────────────────────────────────────
 
-// TestLifecycleActivityLog: after a raise and an ack, at least two anomaly-
+// TestLifecycleActivityLog: after a raise and an ack, at least two health-
 // category activity rows must exist.
 func TestLifecycleActivityLog(t *testing.T) {
 	d := openTestDB(t)
@@ -474,13 +474,13 @@ func TestLifecycleActivityLog(t *testing.T) {
 	// Ack.
 	_, _ = ev.Ack(row.ID, AckDismiss, "tester", "test reason")
 
-	// Query activity_log rows with category='anomaly'.
-	logs, err := d.ListActivityLogs(50, "anomaly")
+	// Query activity_log rows with category='health'.
+	logs, err := d.ListActivityLogs(50, "health", 0)
 	if err != nil {
 		t.Fatalf("ListActivityLogs: %v", err)
 	}
 	if len(logs) < 2 {
-		t.Errorf("expected at least 2 anomaly activity log entries, got %d", len(logs))
+		t.Errorf("expected at least 2 health activity log entries, got %d", len(logs))
 		for i, l := range logs {
 			t.Logf("  [%d] level=%s message=%s", i, l.Level, l.Message)
 		}
@@ -575,4 +575,60 @@ func buildContextForFloorTest(t *testing.T, d *db.DB, ev *Evaluator) (EvalContex
 			return v
 		},
 	}, nil
+}
+
+// TestLifecycleActivityLogCategoryAndLevel: every anomaly activity row is
+// written under the canonical "health" category at WARN, regardless of the
+// anomaly's severity (#328 r3 #11, #12).
+func TestLifecycleActivityLogCategoryAndLevel(t *testing.T) {
+	d := openTestDB(t)
+	clk := NewFakeClock(time.Date(2026, 1, 7, 0, 0, 0, 0, time.UTC))
+	ev := newEvaluatorWithBroadcaster(d, &recordingBroadcaster{}, &Registry{}, clk)
+
+	_, runID := seedJobAndRun(t, d)
+
+	// Raise anomalies at every severity via a table of cases, then ack one
+	// and bulk-ack the rest so every code path that writes a health-category
+	// row is exercised (#328 r3 #13: table-driven subtests).
+	cases := []struct {
+		name     string
+		severity Severity
+		suffix   string
+	}{
+		{name: "info", severity: SeverityInfo, suffix: "a"},
+		{name: "warning", severity: SeverityWarning, suffix: "b"},
+		{name: "critical", severity: SeverityCritical, suffix: "c"},
+	}
+	var ids []int64
+	for _, tc := range cases {
+		t.Run("raise-"+tc.name, func(t *testing.T) {
+			a := makeTestAnomaly(1, runID, "activity_metric")
+			a.Fingerprint = a.Fingerprint + "-" + tc.suffix
+			a.Severity = tc.severity
+			ev.persist(a)
+			row, err := d.GetOpenAnomalyByFingerprint(a.Fingerprint)
+			if err != nil {
+				t.Fatalf("GetOpenAnomalyByFingerprint: %v", err)
+			}
+			ids = append(ids, row.ID)
+		})
+	}
+	_, _ = ev.Ack(ids[0], AckDismiss, "tester", "single ack")
+	_, _, _ = ev.BulkAck(ids[1:], AckDismiss, "tester", "bulk ack")
+
+	logs, err := d.ListActivityLogs(50, "health", 0)
+	if err != nil {
+		t.Fatalf("ListActivityLogs: %v", err)
+	}
+	if len(logs) == 0 {
+		t.Fatal("expected health-category activity rows for anomaly transitions")
+	}
+	for _, l := range logs {
+		if l.Category != "health" {
+			t.Errorf("anomaly activity row category = %q, want %q (message %q)", l.Category, "health", l.Message)
+		}
+		if l.Level != "warn" {
+			t.Errorf("anomaly activity row level = %q, want %q (message %q)", l.Level, "warn", l.Message)
+		}
+	}
 }

--- a/internal/api/handlers/activity.go
+++ b/internal/api/handlers/activity.go
@@ -19,10 +19,12 @@ func NewActivityHandler(database *db.DB) *ActivityHandler {
 
 // List returns recent activity log entries.
 //
-//	GET /api/v1/activity?limit=100&category=backup
+//	GET /api/v1/activity?limit=100&category=backup&before_id=1234
 //
 // `limit` is clamped to [1, maxActivityLimit] to prevent
 // memory-exhaustion DoS from authenticated callers passing absurd values.
+// `before_id` pages backwards: only entries with a smaller id are returned
+// (0/absent = start from the newest).
 func (h *ActivityHandler) List(w http.ResponseWriter, r *http.Request) {
 	const maxActivityLimit = 1000
 	limit := 100
@@ -39,7 +41,17 @@ func (h *ActivityHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 	category := r.URL.Query().Get("category")
 
-	entries, err := h.db.ListActivityLogs(limit, category)
+	beforeID := int64(0)
+	if b := r.URL.Query().Get("before_id"); b != "" {
+		parsed, err := strconv.ParseInt(b, 10, 64)
+		if err != nil || parsed < 1 {
+			respondError(w, http.StatusBadRequest, "before_id must be a positive integer")
+			return
+		}
+		beforeID = parsed
+	}
+
+	entries, err := h.db.ListActivityLogs(limit, category, beforeID)
 	if err != nil {
 		respondInternalError(w, err)
 		return

--- a/internal/api/handlers/activity_test.go
+++ b/internal/api/handlers/activity_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/ruaan-deysel/vault/internal/db"
@@ -200,5 +201,152 @@ func TestActivityList_DBError(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want 500; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestActivityList_BeforeIDPagesBackwards(t *testing.T) {
+	d := newTestDB(t)
+	h := NewActivityHandler(d)
+
+	for i := 0; i < 5; i++ {
+		d.LogActivity("info", "backup", "msg", "{}")
+	}
+
+	get := func(t *testing.T, query string) []db.ActivityLogEntry {
+		t.Helper()
+		w := httptest.NewRecorder()
+		r := newReq(http.MethodGet, "/api/v1/activity"+query, nil)
+		h.List(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d; body: %s", w.Code, w.Body.String())
+		}
+		var resp []db.ActivityLogEntry
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return resp
+	}
+
+	// First page is the cursor harness: its last id seeds the backwards walk.
+	page1 := get(t, "?limit=2")
+	if len(page1) != 2 {
+		t.Fatalf("page1 len = %d, want 2", len(page1))
+	}
+
+	// Each row is one cursor-keyed page fetch and its expected page size.
+	pages := []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{name: "second page walks backwards from the first page's cursor", query: "?limit=2&before_id=" + strconv.FormatInt(page1[1].ID, 10), want: 2},
+		{name: "cursor at the oldest seeded id returns an empty page", query: "?before_id=1", want: 0},
+	}
+	var page2 []db.ActivityLogEntry
+	for _, tc := range pages {
+		t.Run(tc.name, func(t *testing.T) {
+			got := get(t, tc.query)
+			if len(got) != tc.want {
+				t.Fatalf("%s: len = %d, want %d", tc.name, len(got), tc.want)
+			}
+			if tc.want > 0 {
+				page2 = got
+			}
+		})
+	}
+
+	// Cross-page assertion: the two pages must not overlap and must cover
+	// 4 distinct ids.
+	seen := make(map[int64]bool)
+	for _, e := range append(append([]db.ActivityLogEntry{}, page1...), page2...) {
+		if seen[e.ID] {
+			t.Errorf("entry %d appeared on both pages", e.ID)
+		}
+		seen[e.ID] = true
+	}
+	if len(seen) != 4 {
+		t.Errorf("distinct ids across pages = %d, want 4", len(seen))
+	}
+}
+
+func TestActivityList_BeforeIDWithCategory(t *testing.T) {
+	d := newTestDB(t)
+	h := NewActivityHandler(d)
+
+	for i := 0; i < 3; i++ {
+		d.LogActivity("info", "backup", "msg", "{}")
+		d.LogActivity("info", "system", "msg", "{}")
+	}
+
+	get := func(t *testing.T, query string) []db.ActivityLogEntry {
+		t.Helper()
+		w := httptest.NewRecorder()
+		r := newReq(http.MethodGet, "/api/v1/activity"+query, nil)
+		h.List(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d; body: %s", w.Code, w.Body.String())
+		}
+		var resp []db.ActivityLogEntry
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return resp
+	}
+
+	// First page is the cursor harness: its id seeds the backwards walk.
+	first := get(t, "?category=system&limit=1")
+	if len(first) != 1 || first[0].Category != "system" {
+		t.Fatalf("first page = %+v, want 1 system entry", first)
+	}
+
+	// Each row is one category-filtered cursor-keyed page fetch.
+	pages := []struct {
+		name         string
+		query        string
+		wantCategory string
+	}{
+		{name: "second page walks backwards within the category", query: "?category=system&limit=1&before_id=" + strconv.FormatInt(first[0].ID, 10), wantCategory: "system"},
+	}
+	var second []db.ActivityLogEntry
+	for _, tc := range pages {
+		t.Run(tc.name, func(t *testing.T) {
+			got := get(t, tc.query)
+			if len(got) != 1 || got[0].Category != tc.wantCategory {
+				t.Fatalf("%s = %+v, want 1 %s entry", tc.name, got, tc.wantCategory)
+			}
+			second = got
+		})
+	}
+
+	// Cross-page assertion: the two pages must not overlap.
+	if first[0].ID == second[0].ID {
+		t.Errorf("pages overlapped at id %d", first[0].ID)
+	}
+}
+
+func TestActivityList_InvalidBeforeID(t *testing.T) {
+	d := newTestDB(t)
+	h := NewActivityHandler(d)
+	d.LogActivity("info", "backup", "msg", "{}")
+
+	tests := []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{"non-numeric", "/api/v1/activity?before_id=abc", http.StatusBadRequest},
+		{"negative", "/api/v1/activity?before_id=-5", http.StatusBadRequest},
+		{"zero", "/api/v1/activity?before_id=0", http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := newReq(http.MethodGet, tt.query, nil)
+			h.List(w, r)
+			if w.Code != tt.want {
+				t.Fatalf("status = %d, want %d", w.Code, tt.want)
+			}
+		})
 	}
 }

--- a/internal/api/handlers/history_test.go
+++ b/internal/api/handlers/history_test.go
@@ -191,7 +191,7 @@ func TestHistoryPurge_LogsActivity(t *testing.T) {
 	}
 
 	// The Purge method calls LogActivity; at minimum one entry should appear.
-	entries, err := d.ListActivityLogs(10, "system")
+	entries, err := d.ListActivityLogs(10, "system", 0)
 	if err != nil {
 		t.Fatalf("list activity: %v", err)
 	}

--- a/internal/api/handlers/runlog.go
+++ b/internal/api/handlers/runlog.go
@@ -1,0 +1,91 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+)
+
+// RunLogHandler serves per-run streaming log entries (issue #328).
+type RunLogHandler struct {
+	db *db.DB
+}
+
+// NewRunLogHandler creates a new RunLogHandler.
+func NewRunLogHandler(database *db.DB) *RunLogHandler {
+	return &RunLogHandler{db: database}
+}
+
+// List returns a run's log entries oldest-first.
+//
+//	GET /api/v1/runs/{runId}/logs?after=0&limit=500&tail=true
+//
+// `after` supports tailing: a client that already rendered entries up to
+// id N passes after=N and receives only newer lines, so live views poll
+// cheaply and WebSocket events reconcile after a reconnect. `limit` is
+// clamped the same way the activity handler clamps (positive integers
+// only; the repo clamps the ceiling to 1000). With `tail=true` the fetch
+// flips to the run's NEWEST lines: the response is the last `limit`
+// entries (oldest-first within that window), so the end-of-run summary —
+// the status/size/duration line the console must show — is always
+// included, even when the run's log exceeds the limit. The unified
+// console fetches tail-first for exactly this reason (#328). Unknown runs
+// return 404 so a deleted run reads differently from an empty one.
+func (h *RunLogHandler) List(w http.ResponseWriter, r *http.Request) {
+	runID, err := strconv.ParseInt(chi.URLParam(r, "runId"), 10, 64)
+	if err != nil || runID < 1 {
+		respondError(w, http.StatusBadRequest, "invalid run id")
+		return
+	}
+	afterID := int64(0)
+	if a := r.URL.Query().Get("after"); a != "" {
+		parsed, perr := strconv.ParseInt(a, 10, 64)
+		if perr != nil || parsed < 0 {
+			respondError(w, http.StatusBadRequest, "after must be a non-negative integer")
+			return
+		}
+		afterID = parsed
+	}
+	limit := 500
+	if l := r.URL.Query().Get("limit"); l != "" {
+		parsed, perr := strconv.Atoi(l)
+		if perr != nil || parsed < 1 {
+			respondError(w, http.StatusBadRequest, "limit must be a positive integer")
+			return
+		}
+		limit = parsed
+	}
+	tail := r.URL.Query().Get("tail") == "true"
+
+	if _, gerr := h.db.GetJobRun(runID); gerr != nil {
+		respondError(w, http.StatusNotFound, "run not found")
+		return
+	}
+
+	var entries []db.RunLogEntry
+	var lerr error
+	if tail {
+		entries, lerr = h.db.TailRunLogEntries(r.Context(), runID, limit)
+	} else {
+		entries, lerr = h.db.ListRunLogEntries(r.Context(), runID, afterID, limit)
+	}
+	if lerr != nil {
+		respondInternalError(w, lerr)
+		return
+	}
+	if entries == nil {
+		entries = []db.RunLogEntry{}
+	}
+	var lastID int64
+	if n := len(entries); n > 0 {
+		lastID = entries[n-1].ID
+	}
+	respondJSON(w, http.StatusOK, map[string]any{
+		"run_id":  runID,
+		"entries": entries,
+		"last_id": lastID,
+	})
+}

--- a/internal/api/handlers/runlog_test.go
+++ b/internal/api/handlers/runlog_test.go
@@ -1,0 +1,108 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+)
+
+// newRunLogTestServer builds a chi router with only the run-log route,
+// plus a seeded job/run pair.
+func newRunLogTestServer(t *testing.T, seedEntries bool) (*chi.Mux, int64) {
+	t.Helper()
+	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	jobID, err := database.CreateJob(db.Job{Name: "runlog-api"})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	runID, err := database.CreateJobRun(db.JobRun{JobID: jobID, Status: "running", BackupType: "full"})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if seedEntries {
+		for _, m := range []string{"Backup started", "Backed up web (container)"} {
+			if _, err := database.AppendRunLog(context.Background(), db.RunLogEntry{RunID: runID, Level: "info", Message: m}); err != nil {
+				t.Fatalf("seed entry: %v", err)
+			}
+		}
+	}
+
+	h := NewRunLogHandler(database)
+	r := chi.NewRouter()
+	r.Get("/runs/{runId}/logs", h.List)
+	return r, runID
+}
+
+func TestRunLogHandlerList(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string // %d replaced with seeded run ID when present
+		seed       bool
+		wantStatus int
+		wantCount  int
+		wantLastID int64
+	}{
+		{name: "seeded run returns entries oldest first with last id", path: "/runs/%d/logs", seed: true, wantStatus: http.StatusOK, wantCount: 2, wantLastID: 2},
+		{name: "after tails only newer entries", path: "/runs/%d/logs?after=1", seed: true, wantStatus: http.StatusOK, wantCount: 1, wantLastID: 2},
+		{name: "unseeded run returns empty entries and zero last id", path: "/runs/%d/logs", seed: false, wantStatus: http.StatusOK, wantCount: 0, wantLastID: 0},
+		{name: "unknown run returns 404", path: "/runs/999999/logs", seed: false, wantStatus: http.StatusNotFound},
+		{name: "non-numeric run id returns 400", path: "/runs/abc/logs", seed: false, wantStatus: http.StatusBadRequest},
+		{name: "zero limit returns 400", path: "/runs/%d/logs?limit=0", seed: true, wantStatus: http.StatusBadRequest},
+		{name: "negative after returns 400", path: "/runs/%d/logs?after=-1", seed: true, wantStatus: http.StatusBadRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, runID := newRunLogTestServer(t, tt.seed)
+			urlPath := tt.path
+			if strings.Contains(tt.path, "%d") {
+				urlPath = fmt.Sprintf(tt.path, runID)
+			}
+			req := httptest.NewRequest(http.MethodGet, urlPath, nil)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+			if tt.wantStatus != http.StatusOK {
+				return
+			}
+			var body struct {
+				RunID   int64            `json:"run_id"`
+				Entries []db.RunLogEntry `json:"entries"`
+				LastID  int64            `json:"last_id"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if len(body.Entries) != tt.wantCount {
+				t.Fatalf("entries = %d, want %d", len(body.Entries), tt.wantCount)
+			}
+			if body.LastID != tt.wantLastID {
+				t.Fatalf("last_id = %d, want %d", body.LastID, tt.wantLastID)
+			}
+			if body.RunID != runID {
+				t.Fatalf("run_id = %d, want %d", body.RunID, runID)
+			}
+			for i := 1; i < len(body.Entries); i++ {
+				if body.Entries[i].ID <= body.Entries[i-1].ID {
+					t.Fatalf("entries not ascending by id: %+v", body.Entries)
+				}
+			}
+		})
+	}
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -59,7 +59,7 @@ func newQuietRequestLogger(logger *log.Logger, slowThreshold time.Duration) func
 			// be logged. If header logging is added in future, redact the following
 			// keys: authorization, cookie, set-cookie, x-api-key, proxy-authorization.
 			logger.Printf(
-				"api: %s %s status=%d bytes=%d duration=%s remote=%s",
+				"api: %s %s, status=%d, bytes=%d, duration=%s, remote=%s",
 				r.Method,
 				requestPath(r),
 				status,

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -47,7 +47,7 @@ func TestQuietRequestLogger(t *testing.T) {
 		handler.ServeHTTP(w, req)
 
 		got := buf.String()
-		if !strings.Contains(got, "api: GET /missing status=404") {
+		if !strings.Contains(got, "api: GET /missing, status=404") {
 			t.Fatalf("expected 404 request log, got %q", got)
 		}
 	})
@@ -66,7 +66,7 @@ func TestQuietRequestLogger(t *testing.T) {
 		handler.ServeHTTP(w, req)
 
 		got := buf.String()
-		if !strings.Contains(got, "api: GET /api/v1/storage status=200") {
+		if !strings.Contains(got, "api: GET /api/v1/storage, status=200") {
 			t.Fatalf("expected slow request log, got %q", got)
 		}
 		if !strings.Contains(got, "remote=::1") {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -176,6 +176,9 @@ func (s *Server) setupRoutes() *chi.Mux {
 
 		r.Get("/runner/status", jobH.RunnerStatus)
 
+		runlogH := handlers.NewRunLogHandler(s.db)
+		r.Get("/runs/{runId}/logs", runlogH.List)
+
 		r.Route("/settings", func(r chi.Router) {
 			r.Get("/", settingsH.List)
 			r.Put("/", settingsH.Update)

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -250,7 +250,7 @@ var daemonCmd = &cobra.Command{
 			snapshotMgr = db.NewSnapshotManager(database, snapshotPath, defaultSnapPath)
 			restorationInfo := restoreWithFallback(snapshotMgr, snapshotPath, defaultSnapPath, dbPath, usbBackupPath)
 			snapshotMgr.SetRestorationInfo(restorationInfo)
-			log.Printf("Database restoration: source=%s path=%s (%s)",
+			log.Printf("Database restoration: source=%s, path=%s (%s)",
 				restorationInfo.Source, restorationInfo.Path, restorationInfo.Reason)
 
 			_ = database.Close()
@@ -308,7 +308,7 @@ var daemonCmd = &cobra.Command{
 				log.Printf("Database configuration validated: %d jobs, %d storage destinations, %d settings",
 					summary.Jobs, summary.StorageDests, summary.Settings)
 			} else {
-				log.Printf("WARNING: database contains no jobs or storage destinations — this is normal for a fresh install, but unexpected after an upgrade/restart. Fallback paths attempted: snapshot=%q usb_backup=%s. If you expected your previous configuration, see https://github.com/ruaan-deysel/vault/issues/108",
+				log.Printf("WARNING: database contains no jobs or storage destinations — this is normal for a fresh install, but unexpected after an upgrade/restart. Fallback paths attempted: snapshot=%q, usb_backup=%s. If you expected your previous configuration, see https://github.com/ruaan-deysel/vault/issues/108",
 					snapshotPath, usbBackupPath)
 			}
 		}
@@ -330,7 +330,7 @@ var daemonCmd = &cobra.Command{
 		if snapshotMgr != nil {
 			startupDiag.RestorationInfo = snapshotMgr.RestorationSource()
 		}
-		log.Printf("Startup diagnostics: hybrid=%v pool=%q pool_mounted=%v wait=%v boot_kind=%s has_config=%v",
+		log.Printf("Startup diagnostics: hybrid=%v, pool=%q, pool_mounted=%v, wait=%v, boot_kind=%s, has_config=%v",
 			startupDiag.HybridMode, startupDiag.DetectedPool, startupDiag.PoolMounted,
 			poolRetryWait.Round(time.Millisecond), startupDiag.UnraidBootKind, startupDiag.HasConfiguration)
 
@@ -373,9 +373,15 @@ var daemonCmd = &cobra.Command{
 			log.Printf("Cleaned up %d stale job run(s) from previous session", cleaned)
 		}
 
-		// Cap activity log to 10,000 rows to prevent unbounded growth.
-		if err := database.CapActivityLogs(10000); err != nil {
+		// Startup recovery cap for activity rows written before the live
+		// cap in CreateActivityLog existed (or by older versions).
+		if err := database.CapActivityLogs(db.MaxActivityLogRows); err != nil {
 			log.Printf("Warning: failed to cap activity logs: %v", err)
+		}
+		// Startup recovery cap for run-log entries; AppendRunLog already
+		// enforces the bound live on every insert.
+		if err := database.CapRunLogEntriesPerRun(cmd.Context(), db.MaxRunLogEntriesPerRun); err != nil {
+			log.Printf("Warning: failed to cap run logs: %v", err)
 		}
 
 		// Reclaim disk space after all cleanup operations.

--- a/internal/cli/replica.go
+++ b/internal/cli/replica.go
@@ -50,8 +50,13 @@ disaster recovery.`,
 		if err := database.DeleteOldActivityLogs(90); err != nil {
 			log.Printf("Warning: failed to prune old activity logs: %v", err)
 		}
-		if err := database.CapActivityLogs(10000); err != nil {
+		if err := database.CapActivityLogs(db.MaxActivityLogRows); err != nil {
 			log.Printf("Warning: failed to cap activity logs: %v", err)
+		}
+		// Startup recovery cap for run-log entries; AppendRunLog already
+		// enforces the bound live on every insert.
+		if err := database.CapRunLogEntriesPerRun(cmd.Context(), db.MaxRunLogEntriesPerRun); err != nil {
+			log.Printf("Warning: failed to cap run logs: %v", err)
 		}
 
 		// Load or generate the server key for sealing secrets at rest.

--- a/internal/db/activity_repo.go
+++ b/internal/db/activity_repo.go
@@ -1,31 +1,69 @@
 package db
 
-// CreateActivityLog inserts a new activity log entry.
+import "fmt"
+
+// MaxActivityLogRows is the total-row cap CreateActivityLog enforces on
+// every insert (10k, matching the daemon's startup CapActivityLogs call).
+// Enforcing it live — not only at startup — keeps the table bounded on
+// long-running daemons: per-container health entries alone can add dozens
+// of rows per backup run, so the startup-only cap could be exceeded within
+// weeks of continuous uptime.
+const MaxActivityLogRows = 10000
+
+// CreateActivityLog inserts a new activity log entry and returns its row ID.
+// The insert and the prune back to MaxActivityLogRows happen in one
+// transaction, mirroring AppendRunLog, so the cap holds while the daemon
+// keeps writing rather than only at the next process start.
 func (d *DB) CreateActivityLog(entry ActivityLogEntry) (int64, error) {
-	res, err := d.Exec(
+	tx, err := d.Begin()
+	if err != nil {
+		return 0, fmt.Errorf("create activity log: begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after a successful Commit is a no-op
+	res, err := tx.Exec(
 		"INSERT INTO activity_log (level, category, message, details) VALUES (?, ?, ?, ?)",
 		entry.Level, entry.Category, entry.Message, entry.Details,
 	)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("create activity log: %w", err)
 	}
-	return res.LastInsertId()
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("create activity log: last insert id: %w", err)
+	}
+	if _, err := tx.Exec(
+		`DELETE FROM activity_log WHERE id NOT IN (
+			SELECT id FROM activity_log ORDER BY created_at DESC, id DESC LIMIT ?
+		)`, MaxActivityLogRows,
+	); err != nil {
+		return 0, fmt.Errorf("prune activity log: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("create activity log: commit: %w", err)
+	}
+	return id, nil
 }
 
-// ListActivityLogs returns recent activity log entries with optional filtering.
-func (d *DB) ListActivityLogs(limit int, category string) ([]ActivityLogEntry, error) {
-	var query string
+// ListActivityLogs returns recent activity log entries with optional
+// filtering. beforeID, when > 0, pages backwards: only entries with a
+// smaller id are returned. Ids are assigned in insertion order, so the
+// id cursor composes cleanly with the created_at DESC ordering.
+func (d *DB) ListActivityLogs(limit int, category string, beforeID int64) ([]ActivityLogEntry, error) {
+	conds := "1=1"
 	var args []any
 
 	if category != "" {
-		query = `SELECT id, level, category, message, details, created_at
-			FROM activity_log WHERE category = ? ORDER BY created_at DESC LIMIT ?`
-		args = []any{category, limit}
-	} else {
-		query = `SELECT id, level, category, message, details, created_at
-			FROM activity_log ORDER BY created_at DESC LIMIT ?`
-		args = []any{limit}
+		conds += " AND category = ?"
+		args = append(args, category)
 	}
+	if beforeID > 0 {
+		conds += " AND id < ?"
+		args = append(args, beforeID)
+	}
+	query := `SELECT id, level, category, message, details, created_at
+		FROM activity_log WHERE ` + conds + `
+		ORDER BY created_at DESC, id DESC LIMIT ?`
+	args = append(args, limit)
 
 	rows, err := d.Query(query, args...)
 	if err != nil {
@@ -56,7 +94,7 @@ func (d *DB) DeleteOldActivityLogs(keepDays int) error {
 func (d *DB) CapActivityLogs(maxRows int) error {
 	_, err := d.Exec(
 		`DELETE FROM activity_log WHERE id NOT IN (
-			SELECT id FROM activity_log ORDER BY created_at DESC LIMIT ?
+			SELECT id FROM activity_log ORDER BY created_at DESC, id DESC LIMIT ?
 		)`, maxRows,
 	)
 	return err

--- a/internal/db/activity_repo_test.go
+++ b/internal/db/activity_repo_test.go
@@ -1,0 +1,89 @@
+package db
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func openActivityTestDB(t *testing.T) *DB {
+	t.Helper()
+	d, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	return d
+}
+
+// TestCreateActivityLogEnforcesCap mirrors TestAppendRunLogEnforcesPerRunCap:
+// with the table already at MaxActivityLogRows, one more insert through the
+// public API must trim back to the cap — oldest entry evicted, newest kept.
+func TestCreateActivityLogEnforcesCap(t *testing.T) {
+	d := openActivityTestDB(t)
+
+	// Seed exactly cap rows in one transaction via the internal Exec path
+	// (LogActivity would pay the prune cost on every seed row).
+	tx, err := d.Begin()
+	if err != nil {
+		t.Fatalf("begin seed tx: %v", err)
+	}
+	for i := 0; i < MaxActivityLogRows; i += 500 {
+		// Batch the seed with a multi-row insert to keep the test fast.
+		values := ""
+		args := make([]any, 0, 500*4)
+		for j := 0; j < 500 && i+j < MaxActivityLogRows; j++ {
+			if values != "" {
+				values += ","
+			}
+			values += "(?, 'backup', ?, '{}')"
+			args = append(args, fmt.Sprintf("info"), fmt.Sprintf("seed-%d", i+j))
+		}
+		if _, err := tx.Exec("INSERT INTO activity_log (level, category, message, details) VALUES "+values, args...); err != nil {
+			t.Fatalf("seed batch at %d: %v", i, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit seed: %v", err)
+	}
+
+	// One insert through the public API must trim the table back to the cap.
+	if _, err := d.CreateActivityLog(ActivityLogEntry{Level: "info", Category: "backup", Message: "newest", Details: "{}"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Single-scenario integration test: at the cap, one more insert through
+	// the public API must evict the oldest row and keep the newest.
+	cases := []struct {
+		name string
+	}{
+		{name: "insert at cap trims back to MaxActivityLogRows"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var n int
+			if err := d.QueryRow("SELECT COUNT(*) FROM activity_log").Scan(&n); err != nil {
+				t.Fatalf("count: %v", err)
+			}
+			if n != MaxActivityLogRows {
+				t.Fatalf("rows = %d, want cap %d", n, MaxActivityLogRows)
+			}
+
+			// The oldest seed row was evicted; the newest entry survived.
+			var oldest string
+			if err := d.QueryRow("SELECT message FROM activity_log ORDER BY id ASC LIMIT 1").Scan(&oldest); err != nil {
+				t.Fatalf("oldest: %v", err)
+			}
+			if oldest == "seed-0" {
+				t.Fatalf("oldest row is still seed-0; cap prune did not run")
+			}
+			var newest string
+			if err := d.QueryRow("SELECT message FROM activity_log ORDER BY id DESC LIMIT 1").Scan(&newest); err != nil {
+				t.Fatalf("newest: %v", err)
+			}
+			if newest != "newest" {
+				t.Fatalf("newest row = %q, want \"newest\"", newest)
+			}
+		})
+	}
+}

--- a/internal/db/coverage_test.go
+++ b/internal/db/coverage_test.go
@@ -28,7 +28,7 @@ func TestActivityLogLifecycle(t *testing.T) {
 	}
 
 	// ListActivityLogs (no filter)
-	all, err := d.ListActivityLogs(10, "")
+	all, err := d.ListActivityLogs(10, "", 0)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestActivityLogLifecycle(t *testing.T) {
 	}
 
 	// ListActivityLogs (with category filter)
-	filtered, err := d.ListActivityLogs(10, "system")
+	filtered, err := d.ListActivityLogs(10, "system", 0)
 	if err != nil {
 		t.Fatalf("list filtered: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestActivityLogLifecycle(t *testing.T) {
 	if err := d.CapActivityLogs(1); err != nil {
 		t.Errorf("cap: %v", err)
 	}
-	remaining, _ := d.ListActivityLogs(10, "")
+	remaining, _ := d.ListActivityLogs(10, "", 0)
 	if len(remaining) != 1 {
 		t.Errorf("expected 1 row after cap, got %d", len(remaining))
 	}

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -81,6 +81,19 @@ CREATE TABLE IF NOT EXISTS activity_log (
 	details TEXT DEFAULT '',
 	created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
+CREATE INDEX IF NOT EXISTS idx_activity_log_ts ON activity_log(created_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_log_cat ON activity_log(category);
+
+CREATE TABLE IF NOT EXISTS run_log_entries (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	run_id INTEGER NOT NULL REFERENCES job_runs(id) ON DELETE CASCADE,
+	ts DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	level TEXT NOT NULL DEFAULT 'info',
+	message TEXT NOT NULL,
+	data TEXT DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_log_entries_run ON run_log_entries(run_id, id);
 
 CREATE TABLE IF NOT EXISTS verify_runs (
 	id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -334,4 +347,18 @@ var dataMigrations = []string{
 	// run. Seed it from last_sync_at for rows whose last recorded status was a
 	// success, so the UI shows the historical timestamp immediately.
 	"UPDATE replication_sources SET last_sync_success_at = last_sync_at WHERE last_sync_success_at IS NULL AND last_sync_status = 'success' AND last_sync_at IS NOT NULL",
+	// Anomaly activity category + level normalization (#328 r3 #11, #12).
+	// Round 1 (7e62338) fixed the code to write anomaly activity rows at WARN,
+	// but rows written before that still sit in activity_log with the
+	// non-canonical category 'anomaly' (the console's categories are backup,
+	// restore, health, system) and/or level 'info'. Move every anomaly row
+	// under the canonical "health" category — anomaly detection is the
+	// run/storage health-monitoring subsystem — and promote its remaining
+	// INFO rows to WARN so anomaly reports never surface as INFO. The level
+	// UPDATE is scoped to anomaly messages so legitimate INFO rows from the
+	// health subsystem ("Storage health check ... status=ok", "Health check
+	// job=...") are left untouched. Both statements are idempotent: re-running
+	// them is a no-op.
+	"UPDATE activity_log SET category = 'health' WHERE category = 'anomaly'",
+	"UPDATE activity_log SET level = 'warn' WHERE category = 'health' AND level = 'info' AND (message LIKE 'Anomaly %' OR message LIKE '%anomaly(s) acknowledged%')",
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -201,6 +201,17 @@ type ActivityLogEntry struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// RunLogEntry is one line in a run's streaming log (issue #328).
+// Entries cascade-delete with their job_runs row.
+type RunLogEntry struct {
+	ID      int64     `json:"id"`
+	RunID   int64     `json:"run_id"`
+	Ts      time.Time `json:"ts"`
+	Level   string    `json:"level"`
+	Message string    `json:"message"`
+	Data    string    `json:"data"`
+}
+
 // VerifyRun records one execution of restore-point verification. Mode is
 // "quick" (storage HEAD + size compare) or "deep" (full read + SHA-256
 // re-compute). Status transitions running -> passed | failed | cancelled.

--- a/internal/db/run_log_repo.go
+++ b/internal/db/run_log_repo.go
@@ -1,0 +1,149 @@
+package db
+
+import (
+	"context"
+	"fmt"
+)
+
+// MaxRunLogEntriesPerRun is the per-run entry cap AppendRunLog enforces
+// on every insert. Normal retention is the ON DELETE CASCADE with the run
+// row; this bound stops a pathological run (e.g. a very verbose pre/post
+// script) from growing the table without limit before that cascade applies.
+const MaxRunLogEntriesPerRun = 10000
+
+// AppendRunLog inserts one run log entry and returns its row ID. The
+// insert and the run-scoped prune back to MaxRunLogEntriesPerRun happen in
+// one transaction, so the cap holds while a run is still writing — not
+// just at the next process start. Callers treat errors as non-fatal (a
+// logging failure must never abort a run), matching the fire-and-forget
+// style of LogActivity. The runner passes a detached context (see
+// Runner.runLog): terminal entries such as the end-of-run summary are
+// written exactly when the run's own context is being cancelled, so the
+// append must not inherit that cancellation.
+func (d *DB) AppendRunLog(ctx context.Context, entry RunLogEntry) (int64, error) {
+	tx, err := d.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("append run log for run %d: begin tx: %w", entry.RunID, err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after a successful Commit is a no-op
+	res, err := tx.ExecContext(ctx,
+		`INSERT INTO run_log_entries (run_id, level, message, data) VALUES (?, ?, ?, ?)`,
+		entry.RunID, entry.Level, entry.Message, entry.Data,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("append run log for run %d: %w", entry.RunID, err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("append run log for run %d: last insert id: %w", entry.RunID, err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM run_log_entries WHERE run_id = ? AND id NOT IN (
+			SELECT id FROM run_log_entries WHERE run_id = ? ORDER BY id DESC LIMIT ?
+		)`, entry.RunID, entry.RunID, MaxRunLogEntriesPerRun,
+	); err != nil {
+		return 0, fmt.Errorf("prune run log entries for run %d: %w", entry.RunID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("append run log for run %d: commit: %w", entry.RunID, err)
+	}
+	return id, nil
+}
+
+// ListRunLogEntries returns a run's log entries oldest-first. afterID
+// supports tailing: only entries with id > afterID are returned. limit
+// is clamped to [1, 1000].
+func (d *DB) ListRunLogEntries(ctx context.Context, runID int64, afterID int64, limit int) ([]RunLogEntry, error) {
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	rows, err := d.QueryContext(ctx,
+		`SELECT id, run_id, ts, level, message, data
+		FROM run_log_entries
+		WHERE run_id = ? AND id > ?
+		ORDER BY id ASC
+		LIMIT ?`,
+		runID, afterID, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list run log entries for run %d: %w", runID, err)
+	}
+	defer rows.Close()
+	var entries []RunLogEntry
+	for rows.Next() {
+		var e RunLogEntry
+		if err := rows.Scan(&e.ID, &e.RunID, &e.Ts, &e.Level, &e.Message, &e.Data); err != nil {
+			return nil, fmt.Errorf("scan run log entry for run %d: %w", runID, err)
+		}
+		entries = append(entries, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate run log entries for run %d: %w", runID, err)
+	}
+	return entries, nil
+}
+
+// TailRunLogEntries returns the LAST `limit` entries of a run's log,
+// oldest-first within that window. The unified console fetches the tail of
+// every terminal run: the head-first List path returns the oldest lines
+// first, so for a run with more lines than `limit` the end-of-run summary
+// (the newest line — the status/size/duration the console must show) would
+// never be fetched and the run would appear stuck mid-flight. limit is
+// clamped to [1, 1000] like ListRunLogEntries.
+func (d *DB) TailRunLogEntries(ctx context.Context, runID int64, limit int) ([]RunLogEntry, error) {
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	// Inner query takes the newest `limit` rows; the outer query re-sorts
+	// them oldest-first to match ListRunLogEntries' ordering contract.
+	rows, err := d.QueryContext(ctx,
+		`SELECT id, run_id, ts, level, message, data FROM (
+			SELECT id, run_id, ts, level, message, data
+			FROM run_log_entries
+			WHERE run_id = ?
+			ORDER BY id DESC
+			LIMIT ?
+		) ORDER BY id ASC`,
+		runID, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("tail run log entries for run %d: %w", runID, err)
+	}
+	defer rows.Close()
+	var entries []RunLogEntry
+	for rows.Next() {
+		var e RunLogEntry
+		if err := rows.Scan(&e.ID, &e.RunID, &e.Ts, &e.Level, &e.Message, &e.Data); err != nil {
+			return nil, fmt.Errorf("scan run log entry for run %d: %w", runID, err)
+		}
+		entries = append(entries, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate run log entries for run %d: %w", runID, err)
+	}
+	return entries, nil
+}
+
+// CapRunLogEntriesPerRun ensures no single run exceeds maxLines log
+// entries, deleting the older lines first. AppendRunLog already enforces
+// MaxRunLogEntriesPerRun on every insert, so this runs at process start
+// purely as recovery cleanup for rows written before the live cap existed.
+func (d *DB) CapRunLogEntriesPerRun(ctx context.Context, maxLines int) error {
+	if _, err := d.ExecContext(ctx,
+		`DELETE FROM run_log_entries WHERE id NOT IN (
+			SELECT id FROM (
+				SELECT id, ROW_NUMBER() OVER (PARTITION BY run_id ORDER BY id DESC) AS rn
+				FROM run_log_entries
+			) WHERE rn <= ?
+		)`, maxLines,
+	); err != nil {
+		return fmt.Errorf("cap run log entries per run at %d: %w", maxLines, err)
+	}
+	return nil
+}

--- a/internal/db/run_log_repo_test.go
+++ b/internal/db/run_log_repo_test.go
@@ -1,0 +1,386 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+// openRunLogTestDB opens a fresh database on a temp dir. The schema const
+// creates run_log_entries on open, so no extra setup is needed.
+func openRunLogTestDB(t *testing.T) *DB {
+	t.Helper()
+	d, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	return d
+}
+
+// seedRun inserts one job and one run row and returns the run ID.
+func seedRun(t *testing.T, d *DB, name string) int64 {
+	t.Helper()
+	jobID, err := d.CreateJob(Job{Name: name})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	runID, err := d.CreateJobRun(JobRun{JobID: jobID, Status: "running", BackupType: "full"})
+	if err != nil {
+		t.Fatalf("create job run: %v", err)
+	}
+	return runID
+}
+
+func TestListRunLogEntries(t *testing.T) {
+	tests := []struct {
+		name    string
+		inserts []RunLogEntry
+		afterID int64
+		limit   int
+		wantIDs []int64
+	}{
+		{
+			name: "returns entries oldest first",
+			inserts: []RunLogEntry{
+				{Level: "info", Message: "first"},
+				{Level: "info", Message: "second"},
+			},
+			limit:   100,
+			wantIDs: []int64{1, 2},
+		},
+		{
+			name: "after id tails only newer entries",
+			inserts: []RunLogEntry{
+				{Level: "info", Message: "first"},
+				{Level: "info", Message: "second"},
+				{Level: "info", Message: "third"},
+			},
+			afterID: 2,
+			limit:   100,
+			wantIDs: []int64{3},
+		},
+		{
+			name: "limit below one is clamped to one",
+			inserts: []RunLogEntry{
+				{Level: "info", Message: "first"},
+				{Level: "info", Message: "second"},
+			},
+			limit:   0,
+			wantIDs: []int64{1},
+		},
+		{
+			name:    "run without entries yields nil slice",
+			inserts: nil,
+			wantIDs: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := openRunLogTestDB(t)
+			runID := seedRun(t, d, "runlog-"+tt.name)
+			for _, ins := range tt.inserts {
+				ins.RunID = runID
+				if _, err := d.AppendRunLog(context.Background(), ins); err != nil {
+					t.Fatalf("append run log: %v", err)
+				}
+			}
+			got, err := d.ListRunLogEntries(context.Background(), runID, tt.afterID, tt.limit)
+			if err != nil {
+				t.Fatalf("list run log: %v", err)
+			}
+			var gotIDs []int64
+			for _, e := range got {
+				gotIDs = append(gotIDs, e.ID)
+			}
+			if len(gotIDs) != len(tt.wantIDs) {
+				t.Fatalf("got ids %v, want %v", gotIDs, tt.wantIDs)
+			}
+			for i := range gotIDs {
+				if gotIDs[i] != tt.wantIDs[i] {
+					t.Fatalf("got ids %v, want %v", gotIDs, tt.wantIDs)
+				}
+			}
+		})
+	}
+}
+
+func TestTailRunLogEntries(t *testing.T) {
+	tests := []struct {
+		name    string
+		inserts []RunLogEntry
+		limit   int
+		wantIDs []int64
+	}{
+		{
+			name: "returns the newest lines oldest-first within the window",
+			inserts: []RunLogEntry{
+				{Level: "info", Message: "first"},
+				{Level: "info", Message: "second"},
+				{Level: "info", Message: "third"},
+			},
+			limit:   2,
+			wantIDs: []int64{2, 3},
+		},
+		{
+			name: "limit above entry count returns the whole log",
+			inserts: []RunLogEntry{
+				{Level: "info", Message: "first"},
+				{Level: "info", Message: "second"},
+			},
+			limit:   100,
+			wantIDs: []int64{1, 2},
+		},
+		{
+			name: "limit below one is clamped to one",
+			inserts: []RunLogEntry{
+				{Level: "info", Message: "first"},
+				{Level: "info", Message: "second"},
+			},
+			limit:   0,
+			wantIDs: []int64{2},
+		},
+		{
+			name:    "run without entries yields nil slice",
+			inserts: nil,
+			limit:   100,
+			wantIDs: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := openRunLogTestDB(t)
+			runID := seedRun(t, d, "runlog-tail-"+tt.name)
+			for _, ins := range tt.inserts {
+				ins.RunID = runID
+				if _, err := d.AppendRunLog(context.Background(), ins); err != nil {
+					t.Fatalf("append run log: %v", err)
+				}
+			}
+			got, err := d.TailRunLogEntries(context.Background(), runID, tt.limit)
+			if err != nil {
+				t.Fatalf("tail run log: %v", err)
+			}
+			var gotIDs []int64
+			for _, e := range got {
+				gotIDs = append(gotIDs, e.ID)
+			}
+			if len(gotIDs) != len(tt.wantIDs) {
+				t.Fatalf("got ids %v, want %v", gotIDs, tt.wantIDs)
+			}
+			for i := range gotIDs {
+				if gotIDs[i] != tt.wantIDs[i] {
+					t.Fatalf("got ids %v, want %v", gotIDs, tt.wantIDs)
+				}
+			}
+		})
+	}
+}
+
+func TestAppendRunLogStoresData(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     string
+		wantData string
+	}{
+		{name: "json data round-trips", data: `{"k":"v"}`, wantData: `{"k":"v"}`},
+		{name: "empty data stays empty", data: "", wantData: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := openRunLogTestDB(t)
+			runID := seedRun(t, d, "runlog-data-"+tt.name)
+			if _, err := d.AppendRunLog(context.Background(), RunLogEntry{RunID: runID, Level: "info", Message: "m", Data: tt.data}); err != nil {
+				t.Fatalf("append: %v", err)
+			}
+			got, err := d.ListRunLogEntries(context.Background(), runID, 0, 100)
+			if err != nil {
+				t.Fatalf("list: %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("got %d entries, want 1", len(got))
+			}
+			if got[0].Data != tt.wantData {
+				t.Fatalf("data = %q, want %q", got[0].Data, tt.wantData)
+			}
+			if got[0].RunID != runID {
+				t.Fatalf("run_id = %d, want %d", got[0].RunID, runID)
+			}
+		})
+	}
+}
+
+func TestRunLogEntriesCascadeWithJob(t *testing.T) {
+	t.Parallel()
+	d := openRunLogTestDB(t)
+	runID := seedRun(t, d, "runlog-cascade")
+	if _, err := d.AppendRunLog(context.Background(), RunLogEntry{RunID: runID, Level: "info", Message: "doomed"}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	run, err := d.GetJobRun(runID)
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if err := d.DeleteJob(run.JobID); err != nil {
+		t.Fatalf("delete job: %v", err)
+	}
+
+	// Single-scenario integration test: run_log_entries carries an ON DELETE
+	// CASCADE on the run row, so deleting the job must delete the entries.
+	cases := []struct {
+		name string
+	}{
+		{name: "deleting the job cascades to the run's log entries"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := d.ListRunLogEntries(context.Background(), runID, 0, 100)
+			if err != nil {
+				t.Fatalf("list after delete: %v", err)
+			}
+			if len(got) != 0 {
+				t.Fatalf("expected cascade-deleted entries, got %d", len(got))
+			}
+		})
+	}
+}
+
+func TestCapRunLogEntriesPerRun(t *testing.T) {
+	tests := []struct {
+		name        string
+		primary     int
+		second      int
+		maxLines    int
+		wantPrimary int
+		wantSecond  int
+	}{
+		{name: "run under the cap keeps all lines", primary: 3, second: 0, maxLines: 5, wantPrimary: 3, wantSecond: 0},
+		{name: "run over the cap keeps only the newest lines", primary: 5, second: 0, maxLines: 2, wantPrimary: 2, wantSecond: 0},
+		{name: "cap of one keeps the latest line", primary: 4, second: 0, maxLines: 1, wantPrimary: 1, wantSecond: 0},
+		{name: "runs are capped independently", primary: 6, second: 3, maxLines: 2, wantPrimary: 2, wantSecond: 2},
+		{name: "zero max lines deletes every line", primary: 2, second: 0, maxLines: 0, wantPrimary: 0, wantSecond: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := openRunLogTestDB(t)
+			runID := seedRun(t, d, "runlog-cap-"+tt.name)
+			var otherID int64
+			if tt.second > 0 {
+				otherID = seedRun(t, d, "runlog-cap-other-"+tt.name)
+			}
+			for i := 0; i < tt.primary; i++ {
+				if _, err := d.AppendRunLog(context.Background(), RunLogEntry{RunID: runID, Level: "info", Message: fmt.Sprintf("line-%d", i)}); err != nil {
+					t.Fatalf("append primary: %v", err)
+				}
+			}
+			for i := 0; i < tt.second; i++ {
+				if _, err := d.AppendRunLog(context.Background(), RunLogEntry{RunID: otherID, Level: "info", Message: fmt.Sprintf("other-%d", i)}); err != nil {
+					t.Fatalf("append second: %v", err)
+				}
+			}
+			if err := d.CapRunLogEntriesPerRun(context.Background(), tt.maxLines); err != nil {
+				t.Fatalf("cap: %v", err)
+			}
+			got, err := d.ListRunLogEntries(context.Background(), runID, 0, 1000)
+			if err != nil {
+				t.Fatalf("list primary: %v", err)
+			}
+			if len(got) != tt.wantPrimary {
+				t.Fatalf("primary run: got %d entries, want %d", len(got), tt.wantPrimary)
+			}
+			if tt.wantPrimary > 0 {
+				wantFirst := fmt.Sprintf("line-%d", tt.primary-tt.wantPrimary)
+				if got[0].Message != wantFirst {
+					t.Fatalf("oldest survivor = %q, want %q (newest N must survive)", got[0].Message, wantFirst)
+				}
+			}
+			if tt.second > 0 {
+				other, err := d.ListRunLogEntries(context.Background(), otherID, 0, 1000)
+				if err != nil {
+					t.Fatalf("list second: %v", err)
+				}
+				if len(other) != tt.wantSecond {
+					t.Fatalf("second run: got %d entries, want %d", len(other), tt.wantSecond)
+				}
+			}
+		})
+	}
+}
+
+func TestAppendRunLogEnforcesPerRunCap(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "cap enforced after seeding at limit"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := openRunLogTestDB(t)
+			ctx := context.Background()
+			runID := seedRun(t, d, "runlog-live-cap")
+			otherID := seedRun(t, d, "runlog-live-cap-other")
+
+			// Seed exactly cap rows directly in one transaction — paying for 10k
+			// individual AppendRunLog calls would slow the test for no gain.
+			tx, err := d.BeginTx(ctx, nil)
+			if err != nil {
+				t.Fatalf("begin seed tx: %v", err)
+			}
+			stmt, err := tx.PrepareContext(ctx, `INSERT INTO run_log_entries (run_id, level, message) VALUES (?, 'info', ?)`)
+			if err != nil {
+				t.Fatalf("prepare seed: %v", err)
+			}
+			for i := 0; i < MaxRunLogEntriesPerRun; i++ {
+				if _, err := stmt.ExecContext(ctx, runID, fmt.Sprintf("seed-%d", i)); err != nil {
+					t.Fatalf("seed row %d: %v", i, err)
+				}
+			}
+			if err := stmt.Close(); err != nil {
+				t.Fatalf("close seed stmt: %v", err)
+			}
+			if _, err := tx.ExecContext(ctx, `INSERT INTO run_log_entries (run_id, level, message) VALUES (?, 'info', 'untouched')`, otherID); err != nil {
+				t.Fatalf("seed other run: %v", err)
+			}
+			if err := tx.Commit(); err != nil {
+				t.Fatalf("commit seed: %v", err)
+			}
+
+			// One append through the public API must trim the run back to the cap:
+			// the oldest seed goes, the new entry survives, the other run is untouched.
+			id, err := d.AppendRunLog(ctx, RunLogEntry{RunID: runID, Level: "info", Message: "newest"})
+			if err != nil {
+				t.Fatalf("append: %v", err)
+			}
+
+			var n int
+			if err := d.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_log_entries WHERE run_id = ?`, runID).Scan(&n); err != nil {
+				t.Fatalf("count: %v", err)
+			}
+			if n != MaxRunLogEntriesPerRun {
+				t.Fatalf("entries = %d, want cap %d", n, MaxRunLogEntriesPerRun)
+			}
+			var oldest string
+			if err := d.QueryRowContext(ctx, `SELECT message FROM run_log_entries WHERE run_id = ? ORDER BY id ASC LIMIT 1`, runID).Scan(&oldest); err != nil {
+				t.Fatalf("oldest: %v", err)
+			}
+			if oldest != "seed-1" {
+				t.Fatalf("oldest survivor = %q, want %q (seed-0 must be evicted)", oldest, "seed-1")
+			}
+			var newest string
+			if err := d.QueryRowContext(ctx, `SELECT message FROM run_log_entries WHERE id = ?`, id).Scan(&newest); err != nil {
+				t.Fatalf("newest: %v", err)
+			}
+			if newest != "newest" {
+				t.Fatalf("appended entry message = %q, want %q", newest, "newest")
+			}
+			var otherN int
+			if err := d.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_log_entries WHERE run_id = ?`, otherID).Scan(&otherN); err != nil {
+				t.Fatalf("count other: %v", err)
+			}
+			if otherN != 1 {
+				t.Fatalf("other run entries = %d, want 1 (prune must be run-scoped)", otherN)
+			}
+		})
+	}
+}

--- a/internal/diagnostics/collector.go
+++ b/internal/diagnostics/collector.go
@@ -211,7 +211,7 @@ func (c *Collector) Collect() (*DiagnosticBundle, error) {
 	}
 
 	// Activity logs (last 200).
-	if logs, err := c.db.ListActivityLogs(200, ""); err == nil {
+	if logs, err := c.db.ListActivityLogs(200, "", 0); err == nil {
 		for _, l := range logs {
 			bundle.Activity = append(bundle.Activity, ActivityInfo{
 				ID:        l.ID,

--- a/internal/engine/container_milestones_test.go
+++ b/internal/engine/container_milestones_test.go
@@ -1,0 +1,72 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ruaan-deysel/vault/internal/dedup"
+)
+
+// TestContainerBackup_ProgressMilestones: container backups narrate every
+// phase through the progress callback — these are the messages the runner
+// mirrors into the run log (#328 QA). Table-driven over the classic and
+// chunked (dedup) paths, which share the narration contract (#328 r3 #13).
+func TestContainerBackup_ProgressMilestones(t *testing.T) {
+	cases := []struct {
+		name string
+		want []string
+		run  func(t *testing.T, h *ContainerHandler, progress func(string, int, string)) error
+	}{
+		{
+			name: "classic",
+			want: []string{"inspecting container", "saving image", "backing up volumes", "backup complete"},
+			run: func(t *testing.T, h *ContainerHandler, progress func(string, int, string)) error {
+				item := BackupItem{Name: "test", Type: "container", Settings: map[string]any{"id": "abc123"}}
+				_, err := h.Backup(context.Background(), item, t.TempDir(), progress)
+				return err
+			},
+		},
+		{
+			name: "chunked",
+			want: []string{"inspecting container", "backing up volumes", "manifest written"},
+			run: func(t *testing.T, h *ContainerHandler, progress func(string, int, string)) error {
+				r, _, cleanup := dedup.NewTestRepoForEngine(t)
+				defer cleanup()
+				item := BackupItem{Name: "test", Type: "container", Settings: map[string]any{"id": "abc123"}}
+				if _, err := h.BackupChunked(context.Background(), item, r, progress); err != nil {
+					return err
+				}
+				return r.Flush()
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			volSrc := t.TempDir()
+			if err := os.WriteFile(filepath.Join(volSrc, "data.txt"), []byte("hello"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			mock := newClassicMock(t, false, volSrc, time.Now().Add(-48*time.Hour).UTC().Format(time.RFC3339Nano))
+			h := &ContainerHandler{cli: mock}
+
+			var msgs []string
+			progress := func(_ string, _ int, msg string) { msgs = append(msgs, msg) }
+
+			if err := tc.run(t, h, progress); err != nil {
+				t.Fatalf("backup: %v", err)
+			}
+
+			joined := strings.Join(msgs, "\n")
+			for _, want := range tc.want {
+				if !strings.Contains(joined, want) {
+					t.Errorf("%s backup milestone missing %q; got:\n%s", tc.name, want, joined)
+				}
+			}
+		})
+	}
+}

--- a/internal/engine/container_mock_test.go
+++ b/internal/engine/container_mock_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -179,6 +180,7 @@ func TestContainerBackupSurfacesImageSaveError(t *testing.T) {
 				State: &containertypes.State{Running: false},
 			},
 		},
+		imageSaveErr: errors.New("mockDockerClient: ImageSave not implemented"),
 	}
 	h := &ContainerHandler{cli: mock}
 
@@ -219,6 +221,10 @@ func TestContainerBackupSurfacesStopError(t *testing.T) {
 				State: &containertypes.State{Running: true},
 			},
 		},
+		// The mock's ContainerStop returns an error, which Backup surfaces as
+		// "stopping container" — drives the stop-and-restart wrapper that only
+		// fires when wasRunning && !no_stop.
+		stopErr: errors.New("mockDockerClient: ContainerStop not implemented"),
 	}
 	h := &ContainerHandler{cli: mock}
 
@@ -250,6 +256,7 @@ func TestContainerBackupNoStopSkipsStop(t *testing.T) {
 				State: &containertypes.State{Running: true},
 			},
 		},
+		imageSaveErr: errors.New("mockDockerClient: ImageSave not implemented"),
 	}
 	h := &ContainerHandler{cli: mock}
 

--- a/internal/engine/container_test.go
+++ b/internal/engine/container_test.go
@@ -573,6 +573,10 @@ type mockDockerClient struct {
 	stopCalled  bool
 	startCalled bool
 	stopErr     error
+	// imageSaveErr makes ImageSave fail; when nil ImageSave succeeds with a
+	// synthetic tar body so tests can drive the full classic Backup pipeline
+	// (the milestone-pinning test) without a real daemon.
+	imageSaveErr error
 }
 
 func (m *mockDockerClient) ContainerInspect(ctx context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
@@ -618,7 +622,10 @@ func (m *mockDockerClient) ContainerStats(ctx context.Context, _ string, _ clien
 	return client.ContainerStatsResult{}, errors.New("mockDockerClient: ContainerStats not implemented")
 }
 func (m *mockDockerClient) ImageSave(ctx context.Context, _ []string, _ ...client.ImageSaveOption) (client.ImageSaveResult, error) {
-	return nil, errors.New("mockDockerClient: ImageSave not implemented")
+	if m.imageSaveErr != nil {
+		return nil, m.imageSaveErr
+	}
+	return io.NopCloser(strings.NewReader("mock image tar\n")), nil
 }
 func (m *mockDockerClient) ImageLoad(ctx context.Context, _ io.Reader, _ ...client.ImageLoadOption) (client.ImageLoadResult, error) {
 	return nil, errors.New("mockDockerClient: ImageLoad not implemented")

--- a/internal/engine/folder.go
+++ b/internal/engine/folder.go
@@ -83,6 +83,8 @@ func (h *FolderHandler) Backup(ctx context.Context, item BackupItem, destDir str
 		return nil, fmt.Errorf("source path not accessible: %w", err)
 	}
 
+	progress(item.Name, 5, "resolved source path "+srcPath)
+
 	if err := os.MkdirAll(destDir, 0750); err != nil {
 		return nil, fmt.Errorf("creating dest dir: %w", err)
 	}
@@ -142,6 +144,8 @@ func (h *FolderHandler) Backup(ctx context.Context, item BackupItem, destDir str
 	// Store source path metadata so restore knows the original location.
 	// Use the pre-resolution path so restores target the user-configured
 	// share path, not the internal symlink target.
+	progress(item.Name, 90, "writing folder metadata")
+
 	metaPath := filepath.Join(destDir, "folder_meta.json")
 	metaJSON := fmt.Sprintf(`{"path":%q,"name":%q}`, originalPath, item.Name)
 	if err := os.WriteFile(metaPath, []byte(metaJSON), 0600); err != nil {
@@ -282,6 +286,9 @@ func (h *FolderHandler) buildChunkedManifest(ctx context.Context, item BackupIte
 	m := dedup.Manifest{Version: dedup.ManifestVersion, Item: item.Name, Files: map[string]dedup.ManifestEntry{}}
 	var totalBytes int64
 	var skipped int
+	if progress != nil {
+		progress(item.Name, 10, "walking source tree "+srcPath)
+	}
 	err = filepath.Walk(srcPath, func(p string, info os.FileInfo, walkErr error) error {
 		if walkErr != nil {
 			// An inaccessible SOURCE ROOT is a broken backup, not a skip —
@@ -362,6 +369,10 @@ func (h *FolderHandler) buildChunkedManifest(ctx context.Context, item BackupIte
 	})
 	if err != nil {
 		return dedup.Manifest{}, 0, 0, fmt.Errorf("folder: walk %q: %w", item.Name, err)
+	}
+
+	if progress != nil {
+		progress(item.Name, 90, fmt.Sprintf("chunking complete (%d entries, %s)", len(m.Files), humanizeBytes(float64(totalBytes))))
 	}
 
 	if skipped > 0 {

--- a/internal/engine/folder_chunked_milestones_test.go
+++ b/internal/engine/folder_chunked_milestones_test.go
@@ -1,0 +1,84 @@
+//go:build !windows
+
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+	"github.com/ruaan-deysel/vault/internal/dedup"
+	"github.com/ruaan-deysel/vault/internal/storage"
+)
+
+// TestFolderBackupChunked_PhaseMilestones: the dedup folder walk narrates
+// its phases with pct >= 0 milestones (walk start, chunking complete) in
+// addition to the terminal manifest-written line, so a flash-drive backup on
+// a dedup destination stops being a single-line log. The per-file -1
+// heartbeats stay heartbeats — the runner drops them from the run log
+// (#328 QA).
+func TestFolderBackupChunked_PhaseMilestones(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "vault.cfg"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "notes.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	repoDir := t.TempDir()
+	adapter, err := storage.NewAdapter("local", `{"path":"`+repoDir+`"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer storage.CloseAdapter(adapter)
+	destID, err := database.CreateStorageDestination(db.StorageDestination{
+		Name: "milestones", Type: "local", Config: `{"path":"` + repoDir + `"}`, DedupEnabled: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := make([]byte, 32)
+	repo, err := dedup.InitRepo(database, adapter, destID, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var msgs []string
+	progress := func(_ string, _ int, msg string) { msgs = append(msgs, msg) }
+
+	h := &FolderHandler{}
+	item := BackupItem{Name: "Flash Drive", Type: "folder", Settings: map[string]any{"path": src}}
+	if _, err := h.BackupChunked(context.Background(), item, repo, progress); err != nil {
+		t.Fatalf("BackupChunked: %v", err)
+	}
+	if err := repo.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	joined := strings.Join(msgs, "\n")
+	cases := []struct {
+		name string
+		want string
+	}{
+		{name: "walk phase milestone narrated", want: "walking source tree"},
+		{name: "chunking phase milestone narrated", want: "chunking complete"},
+		{name: "manifest milestone narrated", want: "manifest written"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(joined, tc.want) {
+				t.Errorf("phase milestone missing %q; got:\n%s", tc.want, joined)
+			}
+		})
+	}
+}

--- a/internal/engine/folder_test.go
+++ b/internal/engine/folder_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ruaan-deysel/vault/internal/dedup"
@@ -555,4 +556,49 @@ func TestFolderBackupFollowsSymlinkSource(t *testing.T) {
 			t.Errorf("manifest missing subdir/file2.txt")
 		}
 	})
+}
+
+// TestFolderBackup_ProgressMilestones: folder backups (incl. the Flash
+// Drive preset) narrate their phases so the run log has ample lines (#328 QA).
+func TestFolderBackup_ProgressMilestones(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "vault.cfg"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dest := t.TempDir()
+
+	var msgs []string
+	progress := func(_ string, _ int, msg string) { msgs = append(msgs, msg) }
+
+	h, err := NewFolderHandler()
+	if err != nil {
+		t.Fatalf("NewFolderHandler: %v", err)
+	}
+	item := BackupItem{
+		Name:        "Flash Drive",
+		Type:        "folder",
+		Settings:    map[string]any{"path": src, "preset": "flash"},
+		Compression: "none",
+	}
+	if _, err := h.Backup(context.Background(), item, dest, progress); err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+
+	joined := strings.Join(msgs, "\n")
+	cases := []struct {
+		name string
+		want string
+	}{
+		{name: "source resolution milestone narrated", want: "resolved source path"},
+		{name: "archiving milestone narrated", want: "archiving"},
+		{name: "metadata milestone narrated", want: "writing folder metadata"},
+		{name: "completion milestone narrated", want: "backup complete"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(joined, tc.want) {
+				t.Errorf("progress milestones missing %q; got:\n%s", tc.want, joined)
+			}
+		})
+	}
 }

--- a/internal/engine/plugin.go
+++ b/internal/engine/plugin.go
@@ -49,7 +49,7 @@ func (h *PluginHandler) ListItems() ([]BackupItem, error) {
 		return nil, fmt.Errorf("reading plugins directory: %w", err)
 	}
 
-	var items []BackupItem
+	items := make([]BackupItem, 0)
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".plg") {
 			continue

--- a/internal/engine/vm.go
+++ b/internal/engine/vm.go
@@ -1291,7 +1291,7 @@ func (h *VMHandler) waitForBackupCompletion(ctx context.Context, dom libvirt.Dom
 			switch typeValue {
 			case libvirt.DomainJobCompleted, libvirt.DomainJobFailed, libvirt.DomainJobCancelled:
 				if jobErr := backupJobError(typeValue, params); jobErr != nil {
-					log.Printf("engine/vm: backup job for %s ended with type=%s params=%+v", name, typeValue, params)
+					log.Printf("engine/vm: backup job for %s ended, type=%s, params=%+v", name, typeValue, params)
 					return jobErr
 				}
 				return nil
@@ -1317,7 +1317,7 @@ func (h *VMHandler) waitForBackupCompletion(ctx context.Context, dom libvirt.Dom
 				}
 				if time.Since(lastMilestone) >= milestoneInterval {
 					lastMilestone = time.Now()
-					log.Printf("engine/vm: %s backup progress: %d%% (%s) elapsed=%s",
+					log.Printf("engine/vm: %s backup progress: %d%% (%s), elapsed=%s",
 						name, pct, msg, time.Since(started).Round(time.Second))
 				}
 				progress(name, pct, msg)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -110,6 +110,7 @@ func (s *MCPServer) registerTools() {
 	s.addGetHealthSummaryTool()
 	s.addGetRunnerStatusTool()
 	s.addGetActivityLogTool()
+	s.addGetRunLogsTool()
 
 	// Restore tools
 	s.addListRestorePointsTool()
@@ -373,20 +374,65 @@ func (s *MCPServer) addGetRunnerStatusTool() {
 type getActivityLogInput struct {
 	Limit    int    `json:"limit,omitempty"`
 	Category string `json:"category,omitempty"`
+	BeforeID int64  `json:"before_id,omitempty"`
 }
 
 func (s *MCPServer) addGetActivityLogTool() {
 	mcp.AddTool(s.server, &mcp.Tool{
 		Name:        "get_activity_log",
-		Description: "Retrieve recent activity log entries from Vault",
+		Description: "Retrieve recent activity log entries from Vault. Pass before_id (the id of the last entry of the previous page) to page backwards through history.",
 	}, func(_ context.Context, _ *mcp.CallToolRequest, input getActivityLogInput) (*mcp.CallToolResult, any, error) {
 		limit := input.Limit
 		if limit <= 0 {
 			limit = 50
 		}
-		entries, err := s.db.ListActivityLogs(limit, input.Category)
+		if input.BeforeID < 0 {
+			return nil, nil, fmt.Errorf("before_id must be a non-negative integer")
+		}
+		entries, err := s.db.ListActivityLogs(limit, input.Category, input.BeforeID)
 		if err != nil {
 			return nil, nil, fmt.Errorf("listing activity log: %w", err)
+		}
+		r, _ := textResult(entries)
+		return r, nil, nil
+	})
+}
+
+// --- Run Log Tools ---
+
+type getRunLogsInput struct {
+	RunID int64 `json:"run_id"`
+	After int64 `json:"after,omitempty"`
+	Limit int   `json:"limit,omitempty"`
+}
+
+func (s *MCPServer) addGetRunLogsTool() {
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "get_run_logs",
+		Description: "Retrieve streaming log entries for a specific backup or restore run",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input getRunLogsInput) (*mcp.CallToolResult, any, error) {
+		if input.RunID < 1 {
+			return nil, nil, fmt.Errorf("run_id is required and must be positive")
+		}
+		if input.After < 0 {
+			return nil, nil, fmt.Errorf("after must be a non-negative integer")
+		}
+		if input.Limit < 0 {
+			return nil, nil, fmt.Errorf("limit must be a non-negative integer")
+		}
+		if _, err := s.db.GetJobRun(input.RunID); err != nil {
+			return nil, nil, fmt.Errorf("run %d not found: %w", input.RunID, err)
+		}
+		limit := input.Limit
+		if limit == 0 {
+			limit = 500
+		}
+		entries, err := s.db.ListRunLogEntries(ctx, input.RunID, input.After, limit)
+		if err != nil {
+			return nil, nil, fmt.Errorf("listing run logs: %w", err)
+		}
+		if entries == nil {
+			entries = []db.RunLogEntry{}
 		}
 		r, _ := textResult(entries)
 		return r, nil, nil

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -65,7 +65,7 @@ func TestListTools(t *testing.T) {
 		"list_jobs", "get_job", "create_job", "update_job", "delete_job", "run_job", "get_job_history",
 		"list_storage", "get_storage", "create_storage", "update_storage", "delete_storage", "test_storage", "list_storage_files",
 		"list_containers", "list_vms", "list_folders", "list_plugins",
-		"get_health", "get_health_summary", "get_runner_status", "get_activity_log",
+		"get_health", "get_health_summary", "get_runner_status", "get_activity_log", "get_run_logs",
 		"list_restore_points", "restore_item",
 		"list_replication", "get_replication", "delete_replication",
 		"list_anomalies", "get_anomaly", "acknowledge_anomaly",
@@ -439,6 +439,61 @@ func TestActivityLog(t *testing.T) {
 	if len(entries) != 0 {
 		t.Errorf("get_activity_log count = %d, want 0", len(entries))
 	}
+
+	// Negative before_id is rejected like the REST endpoint.
+	if result := callToolExpectError(t, session, ctx, "get_activity_log", map[string]any{"before_id": float64(-1)}); result == "" {
+		t.Fatal("negative before_id: expected an error result")
+	}
+}
+
+func TestGetRunLogs(t *testing.T) {
+	session, database := setupTest(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	jobID, err := database.CreateJob(db.Job{Name: "runlog-mcp"})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	runID, err := database.CreateJobRun(db.JobRun{JobID: jobID, Status: "running", BackupType: "full"})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	for _, m := range []string{"Backup started", "Backed up web (container)"} {
+		if _, err := database.AppendRunLog(ctx, db.RunLogEntry{RunID: runID, Level: "info", Message: m}); err != nil {
+			t.Fatalf("seed entry: %v", err)
+		}
+	}
+
+	tests := []struct {
+		name    string
+		args    map[string]any
+		wantErr bool
+		wantN   int
+	}{
+		{name: "full log returns all entries", args: map[string]any{"run_id": runID}, wantN: 2},
+		{name: "after tails only newer entries", args: map[string]any{"run_id": runID, "after": 1}, wantN: 1},
+		{name: "zero limit falls back to default", args: map[string]any{"run_id": runID, "limit": 0}, wantN: 2},
+		{name: "negative after is rejected", args: map[string]any{"run_id": runID, "after": -1}, wantErr: true},
+		{name: "negative limit is rejected", args: map[string]any{"run_id": runID, "limit": -5}, wantErr: true},
+		{name: "non-positive run id is rejected", args: map[string]any{"run_id": 0}, wantErr: true},
+		{name: "unknown run is rejected", args: map[string]any{"run_id": 999999}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr {
+				result := callToolExpectError(t, session, ctx, "get_run_logs", tt.args)
+				if result == "" {
+					t.Fatalf("expected an error result for %v", tt.args)
+				}
+				return
+			}
+			entries := jsonArray(t, callTool(t, session, ctx, "get_run_logs", tt.args))
+			if len(entries) != tt.wantN {
+				t.Fatalf("entries = %d, want %d", len(entries), tt.wantN)
+			}
+		})
+	}
 }
 
 // --- Helpers ---
@@ -466,6 +521,30 @@ func callTool(t *testing.T, session *mcp.ClientSession, ctx context.Context, nam
 		t.Fatalf("CallTool(%s) content is not TextContent, got %T", name, result.Content[0])
 	}
 	return tc.Text
+}
+
+// callToolExpectError calls an MCP tool that is expected to return an
+// error result, and returns the text content (the error message).
+func callToolExpectError(t *testing.T, session *mcp.ClientSession, ctx context.Context, name string, args map[string]any) string {
+	t.Helper()
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      name,
+		Arguments: args,
+	})
+	if err != nil {
+		t.Fatalf("CallTool(%s): %v", name, err)
+	}
+	if !result.IsError {
+		t.Fatalf("CallTool(%s) expected error result, got success", name)
+	}
+	if len(result.Content) == 0 {
+		return ""
+	}
+	if tc, ok := result.Content[0].(*mcp.TextContent); ok {
+		return tc.Text
+	}
+	return ""
 }
 
 // jsonField extracts a top-level field from a JSON string.

--- a/internal/runner/backup_item_coverage_test.go
+++ b/internal/runner/backup_item_coverage_test.go
@@ -22,6 +22,7 @@ func TestBackupItem_UnknownType(t *testing.T) {
 
 	_, _, err := r.backupItem(
 		context.Background(),
+		0,
 		engine.BackupItem{Name: "x", Type: "garbage-type"},
 		dest,
 		"sp",
@@ -46,6 +47,7 @@ func TestBackupItem_VMHandlerError(t *testing.T) {
 
 	_, _, err := r.backupItem(
 		context.Background(),
+		0,
 		engine.BackupItem{Name: "x", Type: "vm"},
 		dest,
 		"sp",
@@ -86,7 +88,7 @@ func TestBackupItem_FolderHappyPath(t *testing.T) {
 		},
 	}
 
-	_, checksums, err := r.backupItem(context.Background(), item, dest, "rp-test", false, "", "none", 1)
+	_, checksums, err := r.backupItem(context.Background(), 0, item, dest, "rp-test", false, "", "none", 1)
 	if err != nil {
 		t.Fatalf("backupItem: %v", err)
 	}

--- a/internal/runner/folder_runlog_test.go
+++ b/internal/runner/folder_runlog_test.go
@@ -1,0 +1,149 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+	"github.com/ruaan-deysel/vault/internal/engine"
+)
+
+// TestStageItemLocally_FolderRunLogMilestones: engine progress milestones
+// for folder items are mirrored into the run log, so flash-drive backups
+// produce ample output instead of two generic lines (#328 QA).
+func TestStageItemLocally_FolderRunLogMilestones(t *testing.T) {
+	t.Parallel()
+	r, d := newTestRunner(t)
+
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "vault.cfg"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _ := json.Marshal(map[string]string{"path": filepath.Join(t.TempDir(), "store")})
+	dest := db.StorageDestination{Type: "local", Config: string(cfg)}
+
+	var runID int64
+	item := engine.BackupItem{
+		Name:        "Flash Drive",
+		Type:        "folder",
+		Settings:    map[string]any{"path": src, "preset": "flash"},
+		Compression: "none",
+	}
+
+	// runLog persists to run_log_entries, which carries a foreign key on
+	// runs — seed a real job + run so the mirrored milestones can be stored.
+	jobID, err := d.CreateJob(db.Job{Name: "folder-runlog"})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	runID, err = d.CreateJobRun(db.JobRun{JobID: jobID, Status: "running", BackupType: "full"})
+	if err != nil {
+		t.Fatalf("CreateJobRun: %v", err)
+	}
+
+	_, _, cleanup, err := r.stageItemLocally(context.Background(), runID, item, dest)
+	if err != nil {
+		t.Fatalf("stageItemLocally: %v", err)
+	}
+	cleanup()
+
+	entries, err := d.ListRunLogEntries(context.Background(), runID, 0, 100)
+	if err != nil {
+		t.Fatalf("ListRunLogEntries: %v", err)
+	}
+	var msgs []string
+	for _, e := range entries {
+		msgs = append(msgs, e.Message)
+	}
+	joined := strings.Join(msgs, "\n")
+	cases := []struct {
+		name string
+		want string
+	}{
+		{name: "archiving milestone narrated", want: "archiving"},
+		{name: "metadata milestone narrated", want: "writing folder metadata"},
+		{name: "completion milestone narrated", want: "backup complete"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(joined, tc.want) {
+				t.Errorf("run log missing milestone %q; got:\n%s", tc.want, joined)
+			}
+		})
+	}
+}
+
+// TestBackupItem_FolderDedupRunLogMilestones: the dedup/chunked backup path
+// also mirrors folder milestones into the run log, and the -1 per-file
+// heartbeats are suppressed (they would flood) (#328 QA).
+func TestBackupItem_FolderDedupRunLogMilestones(t *testing.T) {
+	t.Parallel()
+	r, d := newTestRunner(t)
+	r.serverKey = testServerKey()
+
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "vault.cfg"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	storageDir := t.TempDir()
+	cfg, _ := json.Marshal(map[string]string{"path": storageDir})
+	dest := db.StorageDestination{Name: "dedup", Type: "local", Config: string(cfg), DedupEnabled: true}
+	destID, err := d.CreateStorageDestination(dest)
+	if err != nil {
+		t.Fatalf("CreateStorageDestination: %v", err)
+	}
+	dest.ID = destID
+
+	jobID, err := d.CreateJob(db.Job{Name: "folder-dedup"})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	runID, err := d.CreateJobRun(db.JobRun{JobID: jobID, Status: "running", BackupType: "full"})
+	if err != nil {
+		t.Fatalf("CreateJobRun: %v", err)
+	}
+
+	item := engine.BackupItem{
+		Name:        "Flash Drive",
+		Type:        "folder",
+		Settings:    map[string]any{"path": src, "preset": "flash"},
+		Compression: "none",
+	}
+	if _, _, err := r.backupItem(context.Background(), runID, item, dest, "rp", false, "", "none", 1); err != nil {
+		t.Fatalf("backupItem (dedup): %v", err)
+	}
+
+	entries, err := d.ListRunLogEntries(context.Background(), runID, 0, 200)
+	if err != nil {
+		t.Fatalf("ListRunLogEntries: %v", err)
+	}
+	var msgs []string
+	for _, e := range entries {
+		msgs = append(msgs, e.Message)
+	}
+	joined := strings.Join(msgs, "\n")
+
+	// Each row is one assertion about the joined run-log output: the
+	// completion milestone must be present, per-file -1 heartbeats must be
+	// absent (they would flood the log) (#328 QA).
+	cases := []struct {
+		name     string
+		fragment string
+		want     bool
+	}{
+		{name: "completion milestone narrated", fragment: "manifest written", want: true},
+		{name: "per-file heartbeat dropped", fragment: "chunked ", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := strings.Contains(joined, tc.fragment)
+			if got != tc.want {
+				t.Errorf("run log contains %q = %v, want %v; got:\n%s", tc.fragment, got, tc.want, joined)
+			}
+		})
+	}
+}

--- a/internal/runner/health.go
+++ b/internal/runner/health.go
@@ -2,7 +2,9 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"time"
 
@@ -15,6 +17,32 @@ import (
 // timeouts (5 min metadata, 4 h upload, etc.) so this is mostly a safety
 // net for storage backends that hang their own TCP dial.
 const healthCheckTimeout = 30 * time.Second
+
+// healthCheckActivity builds the activity-log fields for one destination
+// health check so the wording is unit-testable and shared between the daily
+// sweep and single-destination "Check now" path (issue #328).
+func healthCheckActivity(dest db.StorageDestination, status, errMsg string, duration time.Duration) (level, message, details string) {
+	level = "info"
+	message = fmt.Sprintf("Storage health check, destination=%s, status=%s", dest.Name, status)
+	if status != "ok" {
+		level = "warn"
+		if errMsg != "" {
+			message = fmt.Sprintf("Storage health check, destination=%s, status=%s, error=%s", dest.Name, status, errMsg)
+		} else {
+			message = fmt.Sprintf("Storage health check, destination=%s, status=%s", dest.Name, status)
+		}
+	}
+	raw, err := json.Marshal(map[string]any{
+		"storage_dest_id": dest.ID,
+		"status":          status,
+		"error":           errMsg,
+		"duration_ms":     duration.Milliseconds(),
+	})
+	if err != nil {
+		return level, message, "{}"
+	}
+	return level, message, string(raw)
+}
 
 // RunHealthChecks calls TestConnection on every configured storage
 // destination, records the outcome via UpdateStorageDestinationHealth, and
@@ -49,12 +77,15 @@ func (r *Runner) CheckStorageDestination(dest db.StorageDestination) (string, st
 }
 
 func (r *Runner) checkOneStorage(dest db.StorageDestination) (string, string) {
+	started := time.Now()
 	adapter, err := storage.NewAdapter(dest.Type, dest.Config)
 	if err != nil {
 		msg := err.Error()
 		_ = r.db.UpdateStorageDestinationHealth(dest.ID, "failed", msg)
 		r.recordBreakerOutcome(dest.ID, false)
 		r.broadcastStorageHealth(dest.ID, "failed", msg)
+		lv, ms, dt := healthCheckActivity(dest, "failed", msg, time.Since(started))
+		r.logActivity(lv, "health", ms, dt)
 		log.Printf("runner: health check FAILED for %q (id=%d): adapter construction: %v", dest.Name, dest.ID, err)
 		return "failed", msg
 	}
@@ -72,6 +103,8 @@ func (r *Runner) checkOneStorage(dest db.StorageDestination) (string, string) {
 			_ = r.db.UpdateStorageDestinationHealth(dest.ID, "failed", msg)
 			r.recordBreakerOutcome(dest.ID, false)
 			r.broadcastStorageHealth(dest.ID, "failed", msg)
+			lv, ms, dt := healthCheckActivity(dest, "failed", msg, time.Since(started))
+			r.logActivity(lv, "health", ms, dt)
 			log.Printf("runner: health check FAILED for %q (id=%d): %v", dest.Name, dest.ID, checkErr)
 			return "failed", msg
 		}
@@ -80,6 +113,8 @@ func (r *Runner) checkOneStorage(dest db.StorageDestination) (string, string) {
 		_ = r.db.UpdateStorageDestinationHealth(dest.ID, "failed", msg)
 		r.recordBreakerOutcome(dest.ID, false)
 		r.broadcastStorageHealth(dest.ID, "failed", msg)
+		lv, ms, dt := healthCheckActivity(dest, "failed", msg, time.Since(started))
+		r.logActivity(lv, "health", ms, dt)
 		log.Printf("runner: health check TIMEOUT for %q (id=%d)", dest.Name, dest.ID)
 		return "failed", msg
 	}
@@ -89,6 +124,8 @@ func (r *Runner) checkOneStorage(dest db.StorageDestination) (string, string) {
 	}
 	r.recordBreakerOutcome(dest.ID, true)
 	r.broadcastStorageHealth(dest.ID, "ok", "")
+	lv, ms, dt := healthCheckActivity(dest, "ok", "", time.Since(started))
+	r.logActivity(lv, "health", ms, dt)
 
 	// Capacity probe runs ONLY when TestConnection succeeded. Failures
 	// here NEVER flip the health verdict — capacity is informational.

--- a/internal/runner/health_test.go
+++ b/internal/runner/health_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -397,5 +398,57 @@ func TestBroadcastPayloadShape(t *testing.T) {
 	}
 	if out["storage_id"] != float64(7) {
 		t.Errorf("storage_id = %v, want 7", out["storage_id"])
+	}
+}
+
+func TestHealthCheckActivity(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   string
+		errMsg   string
+		wantLvl  string
+		wantSub  []string
+		wantJSON []string
+	}{
+		{
+			name:     "ok check is info without error text",
+			status:   "ok",
+			wantLvl:  "info",
+			wantSub:  []string{"Storage health check", "destination=nas-backup", "status=ok"},
+			wantJSON: []string{`"status":"ok"`, `"duration_ms"`},
+		},
+		{
+			name:     "failed check is warn and includes error",
+			status:   "failed",
+			errMsg:   "dial tcp: connection refused",
+			wantLvl:  "warn",
+			wantSub:  []string{"destination=nas-backup", "status=failed", "error=dial tcp: connection refused"},
+			wantJSON: []string{`"status":"failed"`, `"error":"dial tcp: connection refused"`},
+		},
+		{
+			name:    "failed check without error message still renders",
+			status:  "failed",
+			wantLvl: "warn",
+			wantSub: []string{"destination=nas-backup", "status=failed"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dest := db.StorageDestination{ID: 7, Name: "nas-backup"}
+			lvl, msg, details := healthCheckActivity(dest, tt.status, tt.errMsg, 1500*time.Millisecond)
+			if lvl != tt.wantLvl {
+				t.Fatalf("level = %q, want %q", lvl, tt.wantLvl)
+			}
+			for _, sub := range tt.wantSub {
+				if !strings.Contains(msg, sub) {
+					t.Fatalf("message %q missing substring %q", msg, sub)
+				}
+			}
+			for _, sub := range tt.wantJSON {
+				if !strings.Contains(details, sub) {
+					t.Fatalf("details %q missing substring %q", details, sub)
+				}
+			}
+		})
 	}
 }

--- a/internal/runner/orphans.go
+++ b/internal/runner/orphans.go
@@ -127,7 +127,7 @@ func (r *Runner) DeleteStorageOrphans(dest db.StorageDestination, paths []string
 		}
 		deleted++
 	}
-	log.Printf("runner: orphan GC for %q: requested=%d deleted=%d errors=%d", dest.Name, len(paths), deleted, len(errors))
+	log.Printf("runner: orphan GC for %q: requested=%d, deleted=%d, errors=%d", dest.Name, len(paths), deleted, len(errors))
 	return deleted, errors
 }
 

--- a/internal/runner/restore_notification_test.go
+++ b/internal/runner/restore_notification_test.go
@@ -74,7 +74,7 @@ func TestChainRestoreNotifiesOnce(t *testing.T) {
 		t.Fatalf("restore item: %v", err)
 	}
 
-	logs, err := d.ListActivityLogs(100, "restore")
+	logs, err := d.ListActivityLogs(100, "restore", 0)
 	if err != nil {
 		t.Fatalf("list activity logs: %v", err)
 	}

--- a/internal/runner/restore_runlog_test.go
+++ b/internal/runner/restore_runlog_test.go
@@ -1,0 +1,121 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+)
+
+// TestRunRestore_RunLogLines drives a real backup + restore cycle end to end
+// (classic tar, folder item, incremental chain) and asserts the restore run
+// log narrates its phases: engine restore milestones mirrored from the
+// handler, chain replay steps, and the download phase (issue #328 QA).
+func TestRunRestore_RunLogLines(t *testing.T) {
+	t.Parallel()
+	r, d := newTestRunner(t)
+
+	sourceDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceDir, "keep.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	storageDir := t.TempDir()
+	destCfg, _ := json.Marshal(map[string]string{"path": storageDir})
+	destID, err := d.CreateStorageDestination(db.StorageDestination{
+		Name: "restore-rl", Type: "local", Config: string(destCfg),
+	})
+	if err != nil {
+		t.Fatalf("create dest: %v", err)
+	}
+	jobID, err := d.CreateJob(db.Job{
+		Name:            "restore-rl-job",
+		StorageDestID:   destID,
+		BackupTypeChain: "incremental",
+		Compression:     "none",
+		Encryption:      "none",
+		Enabled:         true,
+	})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	itemSettings, _ := json.Marshal(map[string]any{"path": sourceDir})
+	if _, err := d.AddJobItem(db.JobItem{
+		JobID: jobID, ItemType: "folder", ItemName: "src", Settings: string(itemSettings),
+	}); err != nil {
+		t.Fatalf("add item: %v", err)
+	}
+
+	r.RunJob(jobID) // base full
+	r.RunJob(jobID) // incremental
+
+	rps, err := d.ListRestorePoints(jobID) // newest-first (created_at DESC)
+	if err != nil || len(rps) < 2 {
+		t.Fatalf("expected >= 2 restore points, got %d (err=%v)", len(rps), err)
+	}
+	var inc db.RestorePoint
+	for _, rp := range rps {
+		if rp.BackupType == "incremental" {
+			inc = rp
+		}
+	}
+	if inc.ID == 0 {
+		t.Fatal("no incremental restore point")
+	}
+
+	destPath := t.TempDir()
+	r.RunRestore(inc, []RestoreTarget{{Name: "src", Type: "folder"}}, destPath, "")
+	if _, err := os.Stat(filepath.Join(destPath, "keep.txt")); err != nil {
+		t.Fatalf("restored file missing: %v", err)
+	}
+
+	runs, err := d.GetJobRuns(jobID, 10)
+	if err != nil {
+		t.Fatalf("GetJobRuns: %v", err)
+	}
+	var restoreRunID int64
+	for _, run := range runs {
+		if run.RunType == "restore" {
+			restoreRunID = run.ID
+		}
+	}
+	if restoreRunID == 0 {
+		t.Fatal("no restore run found")
+	}
+
+	entries, err := d.ListRunLogEntries(context.Background(), restoreRunID, 0, 500)
+	if err != nil {
+		t.Fatalf("ListRunLogEntries: %v", err)
+	}
+	var msgs []string
+	for _, e := range entries {
+		msgs = append(msgs, e.Message)
+	}
+	joined := strings.Join(msgs, "\n")
+	cases := []struct {
+		name string
+		want string
+	}{
+		{name: "per-item start narrated", want: "Restoring src (folder) — item 1 of 1"},
+		{name: "metadata read milestone narrated", want: "src: reading metadata"},                  // FolderHandler.Restore milestone (Task 6)
+		{name: "completion milestone narrated", want: "src: restore complete"},                     // FolderHandler.Restore milestone (Task 6)
+		{name: "chain step 1 narrated", want: "Restore chain step 1/2"},                            // Task 7
+		{name: "chain step 2 narrated", want: "Restore chain step 2/2"},                            // Task 7
+		{name: "chain replay summary narrated", want: "Restore chain replayed for src: 2 step(s)"}, // Task 7
+		{name: "download phase start narrated", want: "Downloading src:"},                          // Task 8
+		{name: "download phase per-file narrated", want: "Downloaded src, file="},                  // Task 8
+		{name: "download phase ready narrated", want: "Restore data ready for src:"},               // Task 8
+		{name: "per-item completion narrated", want: "Restored src (folder) in"},
+		{name: "terminal summary narrated", want: "Restore finished"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(joined, tc.want) {
+				t.Errorf("run log missing %q; got:\n%s", tc.want, joined)
+			}
+		})
+	}
+}

--- a/internal/runner/run_job_single_item_runlog_test.go
+++ b/internal/runner/run_job_single_item_runlog_test.go
@@ -1,0 +1,143 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+)
+
+// TestRunJob_PerItemBackedUpLineSuppressedForSingleItem verifies QA
+// requirement #2 (duplicate logs): a single-item run must NOT emit the
+// per-item "Backed up ... item=1/1" line (the terminal "Backup finished"
+// summary already carries status/size/duration/items), while a multi-item
+// run must still emit each per-item completion line (#328).
+func TestRunJob_PerItemBackedUpLineSuppressedForSingleItem(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		itemCount    int
+		wantBackedUp []string // expected "item=N/M" suffixes on "Backed up" lines
+	}{
+		{
+			name:         "single item suppresses per-item line",
+			itemCount:    1,
+			wantBackedUp: nil,
+		},
+		{
+			name:         "two items keep both per-item lines",
+			itemCount:    2,
+			wantBackedUp: []string{"item=1/2", "item=2/2"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r, d := newTestRunner(t)
+
+			storageDir := filepath.Join(t.TempDir(), "store")
+			if err := os.MkdirAll(storageDir, 0o755); err != nil {
+				t.Fatalf("mkdir storage: %v", err)
+			}
+			destCfg, _ := json.Marshal(map[string]string{"path": storageDir})
+			destID, err := d.CreateStorageDestination(db.StorageDestination{
+				Name:   "single-" + nextUniqueRunner(t),
+				Type:   "local",
+				Config: string(destCfg),
+			})
+			if err != nil {
+				t.Fatalf("create dest: %v", err)
+			}
+
+			jobID, err := d.CreateJob(db.Job{
+				Name:            "single-item-" + nextUniqueRunner(t),
+				StorageDestID:   destID,
+				BackupTypeChain: "full",
+				Enabled:         true,
+				Compression:     "none",
+				Encryption:      "none",
+			})
+			if err != nil {
+				t.Fatalf("create job: %v", err)
+			}
+
+			for i := 0; i < tc.itemCount; i++ {
+				src := t.TempDir()
+				if err := os.WriteFile(filepath.Join(src, "a.txt"), []byte("content"), 0o644); err != nil {
+					t.Fatalf("setup source: %v", err)
+				}
+				itemSettings, _ := json.Marshal(map[string]any{"path": src})
+				if _, err := d.AddJobItem(db.JobItem{
+					JobID:    jobID,
+					ItemType: "folder",
+					ItemName: "src-" + string(rune('a'+i)),
+					Settings: string(itemSettings),
+				}); err != nil {
+					t.Fatalf("add job item %d: %v", i, err)
+				}
+			}
+
+			// RunJob is synchronous.
+			r.RunJob(jobID)
+
+			runs, err := d.GetJobRuns(jobID, 1)
+			if err != nil {
+				t.Fatalf("GetJobRuns: %v", err)
+			}
+			if len(runs) != 1 {
+				t.Fatalf("expected 1 run, got %d", len(runs))
+			}
+			runID := runs[0].ID
+
+			entries, err := d.ListRunLogEntries(context.Background(), runID, 0, 1000)
+			if err != nil {
+				t.Fatalf("ListRunLogEntries: %v", err)
+			}
+
+			var backedUp []string
+			var hasSummary bool
+			for _, e := range entries {
+				if strings.Contains(e.Message, "Backup finished, job=") {
+					hasSummary = true
+				}
+				if strings.HasPrefix(e.Message, "Backed up ") {
+					backedUp = append(backedUp, e.Message)
+				}
+			}
+
+			if !hasSummary {
+				t.Errorf("missing terminal \"Backup finished\" summary; got %d entries", len(entries))
+			}
+
+			if len(tc.wantBackedUp) == 0 {
+				if len(backedUp) != 0 {
+					t.Errorf("single-item run emitted per-item line(s): %q", backedUp)
+				}
+				return
+			}
+
+			if len(backedUp) != len(tc.wantBackedUp) {
+				t.Fatalf("expected %d per-item line(s), got %d: %q", len(tc.wantBackedUp), len(backedUp), backedUp)
+			}
+			for _, want := range tc.wantBackedUp {
+				found := false
+				for _, got := range backedUp {
+					if strings.Contains(got, want) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("missing per-item line containing %q; got: %q", want, backedUp)
+				}
+			}
+		})
+	}
+}

--- a/internal/runner/run_restore_coverage_test.go
+++ b/internal/runner/run_restore_coverage_test.go
@@ -138,6 +138,7 @@ func TestStageItemLocally_UnknownType(t *testing.T) {
 	r, _ := newTestRunner(t)
 	_, _, cleanup, err := r.stageItemLocally(
 		context.Background(),
+		0,
 		engine.BackupItem{Name: "unknown-x", Type: "definitely-not-a-real-type"},
 		db.StorageDestination{Type: "local"},
 	)
@@ -156,6 +157,7 @@ func TestStageItemLocally_VMHandlerError(t *testing.T) {
 	r, _ := newTestRunner(t)
 	_, _, cleanup, err := r.stageItemLocally(
 		context.Background(),
+		0,
 		engine.BackupItem{Name: "any-vm", Type: "vm"},
 		db.StorageDestination{Type: "local"},
 	)

--- a/internal/runner/runlog.go
+++ b/internal/runner/runlog.go
@@ -1,0 +1,140 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+	"github.com/ruaan-deysel/vault/internal/format"
+)
+
+// Run-log levels. Stored as TEXT in run_log_entries.
+const (
+	runLogLevelInfo  = "info"
+	runLogLevelWarn  = "warn"
+	runLogLevelError = "error"
+)
+
+// runLog appends one entry to a run's streaming log (issue #328): the
+// entry is persisted to run_log_entries and broadcast to WebSocket clients
+// as a "run_log" event so open UIs append the line in real time. data may
+// be nil; when present it is marshalled to JSON and stored alongside the
+// human-readable message.
+//
+// Uses the reliable broadcast path (not BroadcastLossy): every line is
+// unique information emitted at per-item frequency, so volume is low —
+// dropping one would leave a visible gap in the stream.
+//
+// Failures are non-fatal by design: logging must never take a run down,
+// matching logActivity's fire-and-forget behaviour.
+//
+// The append deliberately uses a detached context rather than the run's
+// context: terminal entries (end-of-run summary, stall warnings, panic
+// recovery) are written exactly when the run's context is being or has
+// been cancelled, and those are the lines an operator needs most. It is
+// still bounded: with SetMaxOpenConns(1) a pool wait is not covered by
+// SQLite's busy_timeout, so an unbounded context could stall the run
+// goroutine forever on a stuck pool acquisition. 30s matches the
+// busy_timeout scale; a timed-out append is logged and dropped, never
+// fatal.
+func (r *Runner) runLog(runID int64, level, message string, data map[string]any) {
+	if runID == 0 || r.db == nil {
+		return
+	}
+	dataJSON := ""
+	if data != nil {
+		raw, err := json.Marshal(data)
+		if err != nil {
+			log.Printf("runner: run %d: marshal run-log data: %v", runID, err)
+		} else {
+			dataJSON = string(raw)
+		}
+	}
+	entry := db.RunLogEntry{
+		RunID:   runID,
+		Level:   level,
+		Message: message,
+		Data:    dataJSON,
+	}
+	appendCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	id, err := r.db.AppendRunLog(appendCtx, entry)
+	if err != nil {
+		log.Printf("runner: run %d: append run log: %v", runID, err)
+		return
+	}
+	entry.ID = id
+	entry.Ts = time.Now().UTC()
+	r.broadcast(map[string]any{
+		"type":  "run_log",
+		"entry": entry,
+	})
+}
+
+// mirrorEngineMilestone mirrors an engine progress milestone into the run
+// log for the item types whose phases operators expect narrated — folder
+// (incl. the Flash Drive preset) and container (issue #328 QA). Engine
+// progress otherwise feeds only the WebSocket overlay; without this, a
+// container backup's run log holds just the generic runner lines.
+//
+// pct < 0 marks per-file heartbeats from the chunked walks ("chunked <rel>",
+// "restored <fp>") and is dropped: those fire once per file and would flood
+// the log. runID 0 (tests, unpersisted runs) no-ops inside runLog.
+func (r *Runner) mirrorEngineMilestone(runID int64, itemType, name string, pct int, msg string) {
+	if pct < 0 {
+		return
+	}
+	if itemType != "folder" && itemType != "container" {
+		return
+	}
+	r.runLog(runID, runLogLevelInfo, name+": "+msg, nil)
+}
+
+// runSummaryMessage builds the terminal log line, level, and structured
+// data for a finished run. Extracted so the wording and percentages are
+// unit-testable and shared verbatim by the backup and restore paths.
+func runSummaryMessage(kind, jobName, status string, done, failed, total int, sizeBytes int64, duration time.Duration) (level string, message string, data map[string]any) {
+	level = runLogLevelInfo
+	switch status {
+	case "failed":
+		level = runLogLevelError
+	case "partial", "cancelled":
+		level = runLogLevelWarn
+	}
+	pct := 0.0
+	if total > 0 {
+		pct = float64(done) / float64(total) * 100
+	}
+	// Include the job name on the summary line so the terminal "finished" log
+	// carries the same job identity as the "started" line (#328 r9). Restore
+	// summaries pass an empty jobName and keep the job-less wording.
+	if jobName != "" {
+		message = fmt.Sprintf(
+			"%s finished, job=%q, status=%s, items=%d/%d, failed=%d, size=%s, duration=%s",
+			kind, jobName, status, done, total, failed,
+			format.Bytes(float64(sizeBytes)), duration.Truncate(time.Second),
+		)
+	} else {
+		message = fmt.Sprintf(
+			"%s finished, status=%s, items=%d/%d, failed=%d, size=%s, duration=%s",
+			kind, status, done, total, failed,
+			format.Bytes(float64(sizeBytes)), duration.Truncate(time.Second),
+		)
+	}
+	data = map[string]any{
+		"status":           status,
+		"items_done":       done,
+		"items_failed":     failed,
+		"items_total":      total,
+		"size_bytes":       sizeBytes,
+		"duration_seconds": int(duration.Seconds()),
+		"percent_success":  pct,
+	}
+	if jobName != "" {
+		data["job_name"] = jobName
+	}
+	return level, message, data
+}

--- a/internal/runner/runlog_mirror_test.go
+++ b/internal/runner/runlog_mirror_test.go
@@ -1,0 +1,210 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+	"github.com/ruaan-deysel/vault/internal/engine"
+)
+
+// TestMirrorEngineMilestone_ContainerAndFolderPersisted: engine progress
+// milestones for container and folder items are persisted to the run log
+// (this is what makes a container backup's run log narrate its phases),
+// while per-file heartbeats (pct -1) and non-narrated item types (vm, zfs,
+// plugin) are dropped (#328 QA).
+func TestMirrorEngineMilestone_ContainerAndFolderPersisted(t *testing.T) {
+	t.Parallel()
+	r, d := newTestRunner(t)
+
+	jobID, err := d.CreateJob(db.Job{Name: "mirror-runlog"})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	runID, err := d.CreateJobRun(db.JobRun{JobID: jobID, Status: "running", BackupType: "full"})
+	if err != nil {
+		t.Fatalf("CreateJobRun: %v", err)
+	}
+
+	r.mirrorEngineMilestone(runID, "container", "Plex", 60, "backing up volumes")
+	r.mirrorEngineMilestone(runID, "folder", "Flash Drive", 10, "archiving /boot")
+	// Dropped: per-file heartbeats and non-narrated item types.
+	r.mirrorEngineMilestone(runID, "container", "Plex", -1, "chunked var/lib/foo.db")
+	r.mirrorEngineMilestone(runID, "vm", "Windows", 50, "snapshotting")
+	r.mirrorEngineMilestone(runID, "zfs", "pool", 50, "snapshotting")
+	r.mirrorEngineMilestone(runID, "plugin", "Fix Common Problems", 50, "archiving")
+
+	entries, err := d.ListRunLogEntries(context.Background(), runID, 0, 100)
+	if err != nil {
+		t.Fatalf("ListRunLogEntries: %v", err)
+	}
+	var msgs []string
+	for _, e := range entries {
+		msgs = append(msgs, e.Message)
+	}
+	joined := strings.Join(msgs, "\n")
+
+	// Each row is one assertion about the joined run-log output: a narrated
+	// fragment must be present, a dropped fragment must be absent. The
+	// entry-count check below is the harness-level guard that only the two
+	// narrated milestones were persisted.
+	cases := []struct {
+		name     string
+		fragment string
+		want     bool
+	}{
+		{name: "container milestone narrated", fragment: "Plex: backing up volumes", want: true},
+		{name: "folder milestone narrated", fragment: "Flash Drive: archiving /boot", want: true},
+		{name: "per-file heartbeat dropped", fragment: "chunked var/lib", want: false},
+		{name: "non-narrated item type dropped", fragment: "snapshotting", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := strings.Contains(joined, tc.fragment)
+			if got != tc.want {
+				t.Errorf("run log contains %q = %v, want %v; got:\n%s", tc.fragment, got, tc.want, joined)
+			}
+		})
+	}
+	if len(entries) != 2 {
+		t.Errorf("run log entries = %d, want 2", len(entries))
+	}
+}
+
+// TestUploadStagedFiles_RunLogLines: the classic upload phase narrates
+// start, per-file completion, and the verify step in the run log (#328 QA).
+func TestUploadStagedFiles_RunLogLines(t *testing.T) {
+	t.Parallel()
+	r, d := newTestRunner(t)
+
+	jobID, err := d.CreateJob(db.Job{Name: "upload-runlog"})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	runID, err := d.CreateJobRun(db.JobRun{JobID: jobID, Status: "running", BackupType: "full"})
+	if err != nil {
+		t.Fatalf("CreateJobRun: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "volume_0.tar"), []byte("payload-A"), 0600); err != nil {
+		t.Fatalf("stage file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(`{}`), 0600); err != nil {
+		t.Fatalf("stage file: %v", err)
+	}
+	cfg, _ := json.Marshal(map[string]string{"path": filepath.Join(t.TempDir(), "store")})
+	dest := db.StorageDestination{Type: "local", Config: string(cfg)}
+
+	if _, err := r.uploadStagedFilesN(context.Background(), runID, tmpDir, dest, "rp", true, "", "none", "container", "Plex", 1); err != nil {
+		t.Fatalf("uploadStagedFilesN: %v", err)
+	}
+
+	entries, err := d.ListRunLogEntries(context.Background(), runID, 0, 100)
+	if err != nil {
+		t.Fatalf("ListRunLogEntries: %v", err)
+	}
+	var msgs []string
+	for _, e := range entries {
+		msgs = append(msgs, e.Message)
+	}
+	joined := strings.Join(msgs, "\n")
+	cases := []struct {
+		name string
+		want string
+	}{
+		{name: "upload start narrated", want: "Uploading Plex (container): 2 file(s)"},
+		{name: "per-file completion narrated", want: "Uploaded Plex, file=volume_0.tar"},
+		{name: "per-file completion narrated (config)", want: "Uploaded Plex, file=config.json"},
+		{name: "verify step narrated", want: "Verifying Plex (container): 2 file(s)"},
+		{name: "verified step narrated", want: "Verified Plex (container): 2 file(s) checksum OK"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(joined, tc.want) {
+				t.Errorf("run log missing %q; got:\n%s", tc.want, joined)
+			}
+		})
+	}
+}
+
+// TestBackupItem_FolderDedupPhaseAndStatsLog: the dedup path narrates the
+// folder walk phases (Task 2) AND logs per-item session stats, so a
+// flash-drive backup on a dedup destination produces an ample run log
+// (#328 QA).
+func TestBackupItem_FolderDedupPhaseAndStatsLog(t *testing.T) {
+	t.Parallel()
+	r, d := newTestRunner(t)
+	r.serverKey = testServerKey()
+
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "vault.cfg"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "notes.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	storageDir := t.TempDir()
+	cfg, _ := json.Marshal(map[string]string{"path": storageDir})
+	dest := db.StorageDestination{Name: "dedup", Type: "local", Config: string(cfg), DedupEnabled: true}
+	destID, err := d.CreateStorageDestination(dest)
+	if err != nil {
+		t.Fatalf("CreateStorageDestination: %v", err)
+	}
+	dest.ID = destID
+
+	jobID, err := d.CreateJob(db.Job{Name: "folder-dedup-phases"})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	runID, err := d.CreateJobRun(db.JobRun{JobID: jobID, Status: "running", BackupType: "full"})
+	if err != nil {
+		t.Fatalf("CreateJobRun: %v", err)
+	}
+
+	item := engine.BackupItem{
+		Name:        "Flash Drive",
+		Type:        "folder",
+		Settings:    map[string]any{"path": src, "preset": "flash"},
+		Compression: "none",
+	}
+	if _, _, err := r.backupItem(context.Background(), runID, item, dest, "rp", false, "", "none", 1); err != nil {
+		t.Fatalf("backupItem (dedup): %v", err)
+	}
+
+	entries, err := d.ListRunLogEntries(context.Background(), runID, 0, 200)
+	if err != nil {
+		t.Fatalf("ListRunLogEntries: %v", err)
+	}
+	var msgs []string
+	for _, e := range entries {
+		msgs = append(msgs, e.Message)
+	}
+	joined := strings.Join(msgs, "\n")
+
+	// Each row is one assertion about the joined run-log output: a phase
+	// narration must be present, a per-file -1 heartbeat must be absent.
+	cases := []struct {
+		name     string
+		fragment string
+		want     bool
+	}{
+		{name: "folder walk phase narrated", fragment: "Flash Drive: walking source tree", want: true},
+		{name: "chunking phase narrated", fragment: "Flash Drive: chunking complete", want: true},
+		{name: "manifest phase narrated", fragment: "Flash Drive: manifest written", want: true},
+		{name: "session stats logged", fragment: "Dedup Flash Drive: chunks=", want: true},
+		{name: "per-file heartbeat dropped", fragment: "chunked ", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := strings.Contains(joined, tc.fragment)
+			if got != tc.want {
+				t.Errorf("run log contains %q = %v, want %v; got:\n%s", tc.fragment, got, tc.want, joined)
+			}
+		})
+	}
+}

--- a/internal/runner/runlog_progress_fraction_test.go
+++ b/internal/runner/runlog_progress_fraction_test.go
@@ -1,0 +1,117 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+)
+
+// TestRunLogItemProgressIsFractionOnly drives a classic folder backup and
+// asserts the per-item run-log narration reports position as an "item X/Y"
+// fraction only — the redundant "progress=Z%" suffix must be gone (#328 QA
+// round 6 #5).
+func TestRunLogItemProgressIsFractionOnly(t *testing.T) {
+	t.Parallel()
+	r, d := newTestRunner(t)
+
+	// Two items: the single-item per-item "Backed up" line is suppressed
+	// (QA #2 — the terminal summary already carries status/size/duration),
+	// so the fraction narration is only observable on a multi-item run.
+	sourceDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceDir, "a.txt"), []byte("content"), 0o644); err != nil {
+		t.Fatalf("setup source: %v", err)
+	}
+	sourceDir2 := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceDir2, "b.txt"), []byte("content2"), 0o644); err != nil {
+		t.Fatalf("setup source 2: %v", err)
+	}
+	storageDir := filepath.Join(t.TempDir(), "store")
+	if err := os.MkdirAll(storageDir, 0o755); err != nil {
+		t.Fatalf("mkdir storage: %v", err)
+	}
+	destCfg, _ := json.Marshal(map[string]string{"path": storageDir})
+	destID, err := d.CreateStorageDestination(db.StorageDestination{
+		Name:   "progress-frac-" + nextUniqueRunner(t),
+		Type:   "local",
+		Config: string(destCfg),
+	})
+	if err != nil {
+		t.Fatalf("create dest: %v", err)
+	}
+	jobID, err := d.CreateJob(db.Job{
+		Name:            "progress-frac-job-" + nextUniqueRunner(t),
+		StorageDestID:   destID,
+		BackupTypeChain: "full",
+		Enabled:         true,
+		Compression:     "none",
+		Encryption:      "none",
+	})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	itemSettings, _ := json.Marshal(map[string]any{"path": sourceDir})
+	if _, err := d.AddJobItem(db.JobItem{
+		JobID:    jobID,
+		ItemType: "folder",
+		ItemName: "src-classic",
+		Settings: string(itemSettings),
+	}); err != nil {
+		t.Fatalf("add job item: %v", err)
+	}
+	itemSettings2, _ := json.Marshal(map[string]any{"path": sourceDir2})
+	if _, err := d.AddJobItem(db.JobItem{
+		JobID:    jobID,
+		ItemType: "folder",
+		ItemName: "src-classic-2",
+		Settings: string(itemSettings2),
+	}); err != nil {
+		t.Fatalf("add job item 2: %v", err)
+	}
+
+	r.RunJob(jobID)
+
+	runs, err := d.GetJobRuns(jobID, 1)
+	if err != nil {
+		t.Fatalf("GetJobRuns: %v", err)
+	}
+	if len(runs) == 0 {
+		t.Fatalf("expected 1 run, got 0")
+	}
+	runID := runs[0].ID
+
+	entries, err := d.ListRunLogEntries(context.Background(), runID, 0, 1000)
+	if err != nil {
+		t.Fatalf("ListRunLogEntries: %v", err)
+	}
+	var msgs []string
+	for _, e := range entries {
+		msgs = append(msgs, e.Message)
+	}
+	joined := strings.Join(msgs, "\n")
+
+	// Each row is one assertion about the joined run-log output: the item
+	// fractions must be present, the redundant progress percentage must be
+	// gone (#328 QA round 6 #5).
+	cases := []struct {
+		name     string
+		fragment string
+		want     bool
+	}{
+		{name: "no progress percentage suffix", fragment: "progress=", want: false},
+		{name: "first item fraction present", fragment: "item=1/2", want: true},
+		{name: "second item fraction present", fragment: "item=2/2", want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := strings.Contains(joined, tc.fragment)
+			if got != tc.want {
+				t.Errorf("run log contains %q = %v, want %v; got:\n%s", tc.fragment, got, tc.want, joined)
+			}
+		})
+	}
+}

--- a/internal/runner/runlog_separator_test.go
+++ b/internal/runner/runlog_separator_test.go
@@ -1,0 +1,133 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+)
+
+// TestRunSummaryMessageSeparator is table-driven over the backup and restore
+// kinds: the terminal summary must separate the human-readable verb
+// ("Backup"/"Restore" + "finished") from the key=value metadata with a comma,
+// never glue "status=" directly onto the verb (#328 QA round 8 #2).
+func TestRunSummaryMessageSeparator(t *testing.T) {
+	cases := []struct {
+		name string
+		kind string
+	}{
+		{name: "backup summary", kind: "Backup"},
+		{name: "restore summary", kind: "Restore"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, msg, _ := runSummaryMessage(tc.kind, "", "partial", 1, 1, 4, 1024, time.Minute)
+
+			want := tc.kind + " finished, status=partial, items=1/4, failed=1"
+			if !strings.Contains(msg, want) {
+				t.Fatalf("summary %q missing %q", msg, want)
+			}
+			if strings.Contains(msg, tc.kind+" finished status=") {
+				t.Fatalf("summary %q still glues status= onto the verb", msg)
+			}
+		})
+	}
+}
+
+// TestRunLogNarrationSeparators drives a real two-item folder backup and
+// asserts, table-driven, that every run-log narration line separates the
+// human-readable message from its key=value metadata with a comma (#328 QA
+// round 8 #1 + #2): the per-item "Backed up" and "Uploaded" lines, and the
+// terminal "finished" summary. (The run-level "started" line was removed as a
+// duplicate of the activity-feed entry and is no longer part of the run-log.)
+func TestRunLogNarrationSeparators(t *testing.T) {
+	t.Parallel()
+	r, d := newTestRunner(t)
+
+	storageDir := filepath.Join(t.TempDir(), "store")
+	if err := os.MkdirAll(storageDir, 0o755); err != nil {
+		t.Fatalf("mkdir storage: %v", err)
+	}
+	destCfg, _ := json.Marshal(map[string]string{"path": storageDir})
+	destID, err := d.CreateStorageDestination(db.StorageDestination{
+		Name: "sep-" + nextUniqueRunner(t), Type: "local", Config: string(destCfg),
+	})
+	if err != nil {
+		t.Fatalf("create dest: %v", err)
+	}
+	jobID, err := d.CreateJob(db.Job{
+		Name:            "sep-job-" + nextUniqueRunner(t),
+		StorageDestID:   destID,
+		BackupTypeChain: "full",
+		Enabled:         true,
+		Compression:     "none",
+		Encryption:      "none",
+	})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	for _, name := range []string{"src-a", "src-b"} {
+		src := t.TempDir()
+		if err := os.WriteFile(filepath.Join(src, name+".txt"), []byte("content"), 0o644); err != nil {
+			t.Fatalf("setup source %s: %v", name, err)
+		}
+		itemSettings, _ := json.Marshal(map[string]any{"path": src})
+		if _, err := d.AddJobItem(db.JobItem{
+			JobID: jobID, ItemType: "folder", ItemName: name, Settings: string(itemSettings),
+		}); err != nil {
+			t.Fatalf("add job item %s: %v", name, err)
+		}
+	}
+
+	r.RunJob(jobID)
+
+	runs, err := d.GetJobRuns(jobID, 1)
+	if err != nil {
+		t.Fatalf("GetJobRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(runs))
+	}
+	runID := runs[0].ID
+
+	entries, err := d.ListRunLogEntries(context.Background(), runID, 0, 1000)
+	if err != nil {
+		t.Fatalf("ListRunLogEntries: %v", err)
+	}
+	var msgs []string
+	for _, e := range entries {
+		msgs = append(msgs, e.Message)
+	}
+	joined := strings.Join(msgs, "\n")
+
+	// Each row is one assertion about the joined run-log output: a fragment
+	// that must be present (want true) or must be absent (want false).
+	cases := []struct {
+		name     string
+		fragment string
+		want     bool
+	}{
+		{name: "per-item backed up line uses a comma", fragment: "Backed up src-a (folder), size=", want: true},
+		{name: "per-item backed up line uses a comma (second item)", fragment: "Backed up src-b (folder), size=", want: true},
+		{name: "uploaded line uses a comma", fragment: "Uploaded src-a, file=", want: true},
+		{name: "terminal summary uses a comma", fragment: "Backup finished, job=", want: true},
+		{name: "backed up line does not glue size= onto the message", fragment: "Backed up src-a (folder) size=", want: false},
+		{name: "backed up line does not glue size= onto the message (second item)", fragment: "Backed up src-b (folder) size=", want: false},
+		{name: "uploaded line does not glue file= onto the message", fragment: "Uploaded src-a file=", want: false},
+		{name: "terminal summary does not glue status= onto the verb", fragment: "Backup finished status=", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := strings.Contains(joined, tc.fragment)
+			if got != tc.want {
+				t.Errorf("run log contains %q = %v, want %v; got:\n%s", tc.fragment, got, tc.want, joined)
+			}
+		})
+	}
+}

--- a/internal/runner/runlog_started_test.go
+++ b/internal/runner/runlog_started_test.go
@@ -1,0 +1,116 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+)
+
+// TestBackupStartedNarrationSeparator asserts the activity feed narrates a
+// run's start with the comma-separated phrase "Backup started, job=…" (never
+// gluing job= directly onto "started"), and that the run-log stream does NOT
+// emit its own duplicate "Backup started" line (#328 QA round 8 #1; the
+// run-log "started" line was removed as a duplicate of the activity entry).
+func TestBackupStartedNarrationSeparator(t *testing.T) {
+	t.Parallel()
+	r, d := newTestRunner(t)
+
+	sourceDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceDir, "keep.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	storageDir := t.TempDir()
+	destCfg, _ := json.Marshal(map[string]string{"path": storageDir})
+	destID, err := d.CreateStorageDestination(db.StorageDestination{
+		Name: "started-" + nextUniqueRunner(t), Type: "local", Config: string(destCfg),
+	})
+	if err != nil {
+		t.Fatalf("create dest: %v", err)
+	}
+	jobID, err := d.CreateJob(db.Job{
+		Name: "started-job-" + nextUniqueRunner(t), StorageDestID: destID,
+		BackupTypeChain: "full", Compression: "none", Encryption: "none", Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	itemSettings, _ := json.Marshal(map[string]any{"path": sourceDir})
+	if _, err := d.AddJobItem(db.JobItem{
+		JobID: jobID, ItemType: "folder", ItemName: "src", Settings: string(itemSettings),
+	}); err != nil {
+		t.Fatalf("add item: %v", err)
+	}
+
+	r.RunJob(jobID)
+
+	runs, err := d.GetJobRuns(jobID, 1)
+	if err != nil {
+		t.Fatalf("GetJobRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(runs))
+	}
+	runID := runs[0].ID
+
+	entries, err := d.ListRunLogEntries(context.Background(), runID, 0, 1000)
+	if err != nil {
+		t.Fatalf("ListRunLogEntries: %v", err)
+	}
+	var runLogMsgs []string
+	for _, e := range entries {
+		runLogMsgs = append(runLogMsgs, e.Message)
+	}
+
+	activities, err := d.ListActivityLogs(200, "backup", 0)
+	if err != nil {
+		t.Fatalf("ListActivityLogs: %v", err)
+	}
+	var activityMsgs []string
+	for _, a := range activities {
+		activityMsgs = append(activityMsgs, a.Message)
+	}
+
+	// One row per stream under test: fragments the stream must contain and
+	// fragments it must not. The activity feed narrates the start with the
+	// comma-separated phrase; the run-log stream must NOT carry its own
+	// duplicate "Backup started" line (the activity feed is the single
+	// source of the start narration).
+	cases := []struct {
+		name   string
+		msgs   []string
+		want   []string
+		banned []string
+	}{
+		{
+			name:   "activity feed narrates the start with a comma",
+			msgs:   activityMsgs,
+			want:   []string{"Backup started, job="},
+			banned: []string{"Backup started job="},
+		},
+		{
+			name:   "run-log stream has no duplicate started line",
+			msgs:   runLogMsgs,
+			banned: []string{"Backup started"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			joined := strings.Join(tc.msgs, "\n")
+			for _, w := range tc.want {
+				if !strings.Contains(joined, w) {
+					t.Errorf("missing %q; got:\n%s", w, joined)
+				}
+			}
+			for _, b := range tc.banned {
+				if strings.Contains(joined, b) {
+					t.Errorf("banned fragment %q present; got:\n%s", b, joined)
+				}
+			}
+		})
+	}
+}

--- a/internal/runner/runlog_terminal_test.go
+++ b/internal/runner/runlog_terminal_test.go
@@ -1,0 +1,91 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+)
+
+// TestTerminalDetails_RunLogFlag: terminalDetails always stamps the run_log
+// flag that gates run-log expansion in the UI (#328 r3).
+func TestTerminalDetails_RunLogFlag(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]any
+	}{
+		{"empty", map[string]any{}},
+		{"with fields", map[string]any{"job_id": 1, "run_id": 2, "status": "completed"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := terminalDetails(tc.in)
+			if !strings.Contains(got, `"run_log":true`) {
+				t.Errorf("terminalDetails(%v) = %q, want it to contain %q", tc.in, got, `"run_log":true`)
+			}
+		})
+	}
+}
+
+// TestBackupRun_WritesTerminalActivityEntry: a completed backup must write a
+// terminal activity row (category backup) whose details carry run_log:true,
+// so the UI expands the run-log stream on reload (#328 r3 regression).
+func TestBackupRun_WritesTerminalActivityEntry(t *testing.T) {
+	t.Parallel()
+	r, d := newTestRunner(t)
+
+	sourceDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceDir, "keep.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	storageDir := t.TempDir()
+	destCfg, _ := json.Marshal(map[string]string{"path": storageDir})
+	destID, err := d.CreateStorageDestination(db.StorageDestination{
+		Name: "terminal-rl", Type: "local", Config: string(destCfg),
+	})
+	if err != nil {
+		t.Fatalf("create dest: %v", err)
+	}
+	jobID, err := d.CreateJob(db.Job{
+		Name: "terminal-rl-job", StorageDestID: destID,
+		BackupTypeChain: "full", Compression: "none", Encryption: "none", Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	itemSettings, _ := json.Marshal(map[string]any{"path": sourceDir})
+	if _, err := d.AddJobItem(db.JobItem{
+		JobID: jobID, ItemType: "folder", ItemName: "src", Settings: string(itemSettings),
+	}); err != nil {
+		t.Fatalf("add item: %v", err)
+	}
+
+	r.RunJob(jobID)
+
+	logs, err := d.ListActivityLogs(200, "backup", 0)
+	if err != nil {
+		t.Fatalf("ListActivityLogs: %v", err)
+	}
+
+	// Single-scenario integration test: a completed backup must write a
+	// terminal activity row whose details carry run_log:true, so the UI
+	// expands the run-log stream on reload (#328 r3 regression).
+	cases := []struct {
+		name string
+	}{
+		{name: "completed backup writes a terminal (run_log:true) activity entry"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, l := range logs {
+				if strings.Contains(l.Details, `"run_log":true`) {
+					return // terminal marker present
+				}
+			}
+			t.Fatal("completed backup wrote no terminal (run_log:true) activity entry")
+		})
+	}
+}

--- a/internal/runner/runlog_test.go
+++ b/internal/runner/runlog_test.go
@@ -1,0 +1,187 @@
+package runner
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ruaan-deysel/vault/internal/db"
+)
+
+// openRunLogRunnerDB opens a fresh DB and a Runner wired to it with a nil
+// hub — runLog must tolerate a nil hub (broadcast no-ops).
+func openRunLogRunnerDB(t *testing.T) (*Runner, *db.DB) {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	return New(d, nil, nil), d
+}
+
+func TestHumanBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int64
+		want string
+	}{
+		{name: "plain bytes", in: 512, want: "512 B"},
+		{name: "two kib", in: 2048, want: "2.0 KiB"},
+		{name: "fractional mib", in: 5*1024*1024 + 300*1024, want: "5.3 MiB"},
+		{name: "one gib", in: 1024 * 1024 * 1024, want: "1.0 GiB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := humanBytes(tt.in); got != tt.want {
+				t.Fatalf("humanBytes(%d) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunSummaryMessage(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       string
+		jobName    string
+		status     string
+		done       int
+		failed     int
+		total      int
+		sizeBytes  int64
+		duration   time.Duration
+		wantLevel  string
+		wantPct    float64
+		wantSubstr []string
+	}{
+		{
+			name: "completed run is info with full percent", kind: "Backup", status: "completed",
+			done: 3, failed: 0, total: 3, sizeBytes: 2048, duration: 90 * time.Second,
+			wantLevel: runLogLevelInfo, wantPct: 100,
+			wantSubstr: []string{"Backup finished", "status=completed", "items=3/3", "2 KB", "failed=0"},
+		},
+		{
+			name: "partial run is warn with partial percent", kind: "Backup", status: "partial",
+			done: 1, failed: 1, total: 4, sizeBytes: 1024, duration: time.Minute,
+			wantLevel: runLogLevelWarn, wantPct: 25,
+			wantSubstr: []string{"status=partial", "failed=1"},
+		},
+		{
+			name: "failed run is error", kind: "Restore", status: "failed",
+			done: 0, failed: 2, total: 2, sizeBytes: 0, duration: 5 * time.Second,
+			wantLevel: runLogLevelError, wantPct: 0,
+			wantSubstr: []string{"Restore finished", "status=failed"},
+		},
+		{
+			name: "cancelled run is warn", kind: "Backup", status: "cancelled",
+			done: 0, failed: 0, total: 0, sizeBytes: 0, duration: 2 * time.Second,
+			wantLevel: runLogLevelWarn, wantPct: 0,
+			wantSubstr: []string{"status=cancelled"},
+		},
+		{
+			name: "completed run includes job name", kind: "Backup", jobName: "plugs", status: "completed",
+			done: 1, failed: 0, total: 1, sizeBytes: 128, duration: time.Second,
+			wantLevel: runLogLevelInfo, wantPct: 100,
+			wantSubstr: []string{"Backup finished, job=\"plugs\"", "status=completed"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			level, msg, data := runSummaryMessage(tt.kind, tt.jobName, tt.status, tt.done, tt.failed, tt.total, tt.sizeBytes, tt.duration)
+			if level != tt.wantLevel {
+				t.Fatalf("level = %q, want %q", level, tt.wantLevel)
+			}
+			for _, sub := range tt.wantSubstr {
+				if !stringsContains(msg, sub) {
+					t.Fatalf("message %q missing substring %q", msg, sub)
+				}
+			}
+			if tt.jobName != "" && data["job_name"] != tt.jobName {
+				t.Fatalf("job_name = %v, want %q", data["job_name"], tt.jobName)
+			}
+			if data["percent_success"] != tt.wantPct {
+				t.Fatalf("percent_success = %v, want %v", data["percent_success"], tt.wantPct)
+			}
+			if data["items_total"] != tt.total || data["items_done"] != tt.done || data["items_failed"] != tt.failed {
+				t.Fatalf("item counters in data wrong: %+v", data)
+			}
+		})
+	}
+}
+
+func TestRunLogPersistsEntry(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     map[string]any
+		wantData string
+	}{
+		{name: "nil data stores empty string", data: nil, wantData: ""},
+		{name: "map data stores json", data: map[string]any{"item_name": "web"}, wantData: `{"item_name":"web"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, d := openRunLogRunnerDB(t)
+			jobID, err := d.CreateJob(db.Job{Name: "runlog-runner-" + tt.name})
+			if err != nil {
+				t.Fatalf("create job: %v", err)
+			}
+			runID, err := d.CreateJobRun(db.JobRun{JobID: jobID, Status: "running", BackupType: "full"})
+			if err != nil {
+				t.Fatalf("create run: %v", err)
+			}
+
+			r.runLog(runID, runLogLevelInfo, "hello", tt.data)
+
+			got, err := d.ListRunLogEntries(context.Background(), runID, 0, 100)
+			if err != nil {
+				t.Fatalf("list: %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("got %d entries, want 1 (nil hub must not break the write)", len(got))
+			}
+			if got[0].Message != "hello" || got[0].Level != runLogLevelInfo {
+				t.Fatalf("entry = %+v", got[0])
+			}
+			if got[0].Data != tt.wantData {
+				t.Fatalf("data = %q, want %q", got[0].Data, tt.wantData)
+			}
+		})
+	}
+}
+
+func TestRunLogInvalidRunIDIgnored(t *testing.T) {
+	tests := []struct {
+		name  string
+		runID int64
+	}{
+		{name: "zero run id means no run row yet", runID: 0},
+		{name: "negative run id fails the insert without panicking", runID: -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, d := openRunLogRunnerDB(t)
+			// Must not panic or abort — invalid run ids are silently ignored
+			// (a negative id trips the run_id foreign key, which runLog
+			// treats as non-fatal, same as any other append failure).
+			r.runLog(tt.runID, runLogLevelInfo, "noop", nil)
+			got, err := d.ListRunLogEntries(context.Background(), tt.runID, 0, 100)
+			if err != nil {
+				t.Fatalf("list: %v", err)
+			}
+			if len(got) != 0 {
+				t.Fatalf("got %d entries for run id %d, want 0", len(got), tt.runID)
+			}
+		})
+	}
+}
+
+func stringsContains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -674,6 +674,7 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 			openedAt = dest.BreakerOpenedAt.Format(time.RFC3339)
 		}
 		skipped.Log = fmt.Sprintf("Breaker open for destination %q since %s", dest.Name, openedAt)
+		r.runLog(runID, runLogLevelWarn, skipped.Log, nil)
 		// Breaker-open skip: do NOT schedule retry. The breaker exists
 		// precisely to avoid hammering an unhealthy destination.
 		if updErr := r.db.UpdateJobRun(skipped); updErr != nil {
@@ -710,6 +711,7 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 		}
 		skippedRun.ID = runID
 		skippedRun.Log = fmt.Sprintf("Pre-flight check failed: %v", pfErr)
+		r.runLog(runID, runLogLevelWarn, skippedRun.Log, nil)
 		// Preflight failure is potentially transient (DNS blip, mount
 		// remount, etc.) — schedule a retry per policy.
 		r.scheduleRetryIfDue(&skippedRun, job, dest, opts)
@@ -840,12 +842,13 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 		}
 		failed.ID = runID
 		failed.Log = errMsg
+		r.runLog(runID, runLogLevelError, errMsg, map[string]any{"missing_items": staleNames})
 		if updErr := r.db.UpdateJobRun(failed); updErr != nil {
 			log.Printf("runner: failed to update all-stale failed run %d: %v", runID, updErr)
 		}
 		r.logActivity("error", "backup",
-			fmt.Sprintf("Backup failed: %s", job.Name),
-			structuredDetails(map[string]any{
+			fmt.Sprintf("Backup failed, job=%q", job.Name),
+			terminalDetails(map[string]any{
 				"job_id": jobID, "run_id": runID, "error": errMsg,
 				"missing_items": staleNames,
 			}))
@@ -906,6 +909,7 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 			log.Printf("runner: PANIC during job %d run %d: %v", jobID, runID, rec)
 			run.Status = "failed"
 			run.Log = fmt.Sprintf("Internal error (panic): %v", rec)
+			r.runLog(runID, runLogLevelError, fmt.Sprintf("Internal error (panic): %v", rec), nil)
 			// Panic is potentially transient; schedule a retry. The
 			// breaker check inside scheduleRetryIfDue prevents storms
 			// against a broken destination.
@@ -973,7 +977,7 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 	if job.Schedule != "" {
 		startedDetails["schedule"] = job.Schedule
 	}
-	r.logActivity("info", "backup", fmt.Sprintf("Backup started: %s", job.Name),
+	r.logActivity("info", "backup", fmt.Sprintf("Backup started, job=%q", job.Name),
 		structuredDetails(startedDetails))
 
 	timestamp := time.Now().Format("2006-01-02_150405")
@@ -987,6 +991,7 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 			log.Printf("runner: job %d has encryption=age but no passphrase configured", jobID)
 			run.Status = "failed"
 			run.Log = "Encryption enabled but no passphrase configured in settings\n"
+			r.runLog(runID, runLogLevelError, "Encryption enabled but no passphrase configured in settings", nil)
 			r.scheduleRetryIfDue(&run, job, dest, opts)
 			_ = r.db.UpdateJobRun(run)
 			return
@@ -1004,11 +1009,13 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 			log.Printf("runner: job %d pre-script failed: %v", jobID, err)
 			run.Status = "failed"
 			run.Log = fmt.Sprintf("Pre-script failed: %v\nOutput: %s", err, output)
+			r.runLog(runID, runLogLevelError, fmt.Sprintf("Pre-script failed: %v", err),
+				map[string]any{"output": strings.TrimSpace(output)})
 			r.scheduleRetryIfDue(&run, job, dest, opts)
 			_ = r.db.UpdateJobRun(run)
 			r.logActivity("error", "backup",
-				fmt.Sprintf("Pre-script failed: %s", job.Name),
-				structuredDetails(map[string]any{
+				fmt.Sprintf("Pre-script failed, job=%q", job.Name),
+				terminalDetails(map[string]any{
 					"job_id": jobID, "run_id": runID, "script": job.PreScript, "error": err.Error(),
 				}))
 			return
@@ -1016,12 +1023,13 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 	}
 
 	var (
-		totalSize     int64
-		itemsDone     int
-		itemsFailed   int
-		itemResults   []map[string]any
-		itemChecksums = make(map[string]map[string]string)
-		vmCheckpoints = make(map[string]string)
+		totalSize      int64
+		itemsDone      int
+		itemsFailed    int
+		itemsProcessed int
+		itemResults    []map[string]any
+		itemChecksums  = make(map[string]map[string]string)
+		vmCheckpoints  = make(map[string]string)
 		// zfsSnapshots records the ZFS snapshot created per item so the next
 		// incremental/differential run can resolve its -i parent from the
 		// restore point instead of guessing (issue #180).
@@ -1082,6 +1090,8 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 				"job_id": jobID,
 				"count":  len(containerIDs),
 			})
+			r.runLog(runID, runLogLevelInfo,
+				fmt.Sprintf("Stopping %d container(s) (stop_all mode)", len(containerIDs)), nil)
 			stopped, err := engine.StopContainers(containerIDs)
 			stoppedContainerIDs = stopped
 			if err != nil {
@@ -1122,7 +1132,7 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 		log.Printf("runner: reading label_exclusions_enabled: %v", lblErr)
 	}
 
-	for _, item := range items {
+	for itemIdx, item := range items {
 		// Check for cancellation between items.
 		if ctx.Err() != nil {
 			log.Printf("runner: job %d cancelled between items", jobID)
@@ -1237,6 +1247,11 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 
 		r.updateRunProgress(itemsDone, itemsFailed, item.ItemName)
 		r.updateCurrentItemProgress(item.ItemType, 0, "Starting...")
+		itemStart := time.Now()
+		r.runLog(runID, runLogLevelInfo,
+			fmt.Sprintf("Backing up %s (%s) — item %d of %d",
+				item.ItemName, item.ItemType, itemIdx+1, len(items)),
+			map[string]any{"item_name": item.ItemName, "item_type": item.ItemType})
 
 		if deferred {
 			r.broadcast(map[string]any{
@@ -1247,12 +1262,13 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 				"item_name": item.ItemName,
 				"item_type": item.ItemType,
 			})
-			tmpDir, stageResult, cleanup, stageErr := r.stageItemLocally(ctx, backupItem, dest)
+			tmpDir, stageResult, cleanup, stageErr := r.stageItemLocally(ctx, runID, backupItem, dest)
 			if stageErr != nil {
 				if ctx.Err() != nil {
 					log.Printf("runner: job %d item %s cancelled during staging: %v", jobID, item.ItemName, stageErr)
 					break
 				}
+				itemsProcessed++
 				itemsFailed++
 				failedNames = append(failedNames, item.ItemName)
 				itemResults = append(itemResults, map[string]any{
@@ -1271,6 +1287,9 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 					"items_done":  itemsDone,
 					"error":       stageErr.Error(),
 				})
+				r.runLog(runID, runLogLevelError,
+					fmt.Sprintf("Staging failed: %s (%s): %v, item=%d/%d", item.ItemName, item.ItemType, stageErr, itemsProcessed, len(items)),
+					map[string]any{"item_name": item.ItemName, "item_type": item.ItemType, "error": stageErr.Error()})
 			} else {
 				stagedItems = append(stagedItems, stagedItemEntry{
 					engineItem: backupItem,
@@ -1288,19 +1307,23 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 					"item_type":   item.ItemType,
 					"items_total": len(items),
 				})
+				r.runLog(runID, runLogLevelInfo,
+					fmt.Sprintf("Staged %s (%s) locally (deferred upload mode)", item.ItemName, item.ItemType),
+					map[string]any{"item_name": item.ItemName, "item_type": item.ItemType})
 			}
 			_ = r.db.UpdateJobRunProgress(runID, itemsDone, itemsFailed, totalSize)
 			r.updateRunProgress(itemsDone, itemsFailed, "")
 			continue
 		}
 
-		result, checksums, backupErr := r.backupItem(ctx, backupItem, dest, itemPath, job.VerifyBackup, encryptPassphrase, job.Compression, job.EffectiveUploadConcurrency())
+		result, checksums, backupErr := r.backupItem(ctx, runID, backupItem, dest, itemPath, job.VerifyBackup, encryptPassphrase, job.Compression, job.EffectiveUploadConcurrency())
 		if backupErr != nil {
 			// If the context was cancelled, stop processing remaining items.
 			if ctx.Err() != nil {
 				log.Printf("runner: job %d item %s cancelled: %v", jobID, item.ItemName, backupErr)
 				break
 			}
+			itemsProcessed++
 			itemsFailed++
 			failedNames = append(failedNames, item.ItemName)
 			itemResults = append(itemResults, map[string]any{
@@ -1320,8 +1343,12 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 				"items_done":  itemsDone,
 				"error":       backupErr.Error(),
 			})
+			r.runLog(runID, runLogLevelError,
+				fmt.Sprintf("Failed: %s (%s): %v, item=%d/%d", item.ItemName, item.ItemType, backupErr, itemsProcessed, len(items)),
+				map[string]any{"item_name": item.ItemName, "item_type": item.ItemType, "error": backupErr.Error()})
 		} else {
 			itemsDone++
+			itemsProcessed++
 			var itemSize int64
 			if result != nil {
 				for _, f := range result.Files {
@@ -1382,6 +1409,22 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 				"size_bytes":  itemSize,
 				"verified":    job.VerifyBackup,
 			})
+			// Single-item run: the terminal "Backup finished" summary already
+			// carries status/size/duration/items, so a per-item completion line
+			// would read as a duplicate (issue #328 QA). Only narrate per-item
+			// completion when there are 2+ items, where each line is distinct.
+			if len(items) > 1 {
+				r.runLog(runID, runLogLevelInfo,
+					fmt.Sprintf("Backed up %s (%s), size=%s, duration=%s, item=%d/%d",
+						item.ItemName, item.ItemType, format.Bytes(float64(itemSize)), time.Since(itemStart).Truncate(time.Second), itemsProcessed, len(items)),
+					map[string]any{
+						"item_name":   item.ItemName,
+						"item_type":   item.ItemType,
+						"size_bytes":  itemSize,
+						"items_total": len(items),
+						"items_done":  itemsDone,
+					})
+			}
 
 			// After successful backup of a container item (per-item mode), verify health.
 			// In per-item mode the engine handler restarts each container after backup.
@@ -1401,12 +1444,17 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 						"message":     result.Message,
 						"duration_ms": result.Duration.Milliseconds(),
 					})
+					// "running" means the container has no Docker HEALTHCHECK
+					// defined and is up — that is a passing check, not a warning.
 					hcLevel := "info"
-					if result.Status != "healthy" {
+					if result.Status == "unhealthy" || result.Status == "failed" {
 						hcLevel = "warn"
 					}
-					r.logActivity(hcLevel, "health",
-						fmt.Sprintf("Health check: %s", result.ContainerName),
+					hcMsg := fmt.Sprintf("Health check, container=%s, status=%s", result.ContainerName, result.Status)
+					if hcLevel == "warn" && result.Message != "" {
+						hcMsg = fmt.Sprintf("Health check, container=%s, status=%s, error=%s", result.ContainerName, result.Status, result.Message)
+					}
+					r.logActivity(hcLevel, "health", hcMsg,
 						structuredDetails(map[string]any{
 							"job_id":         jobID,
 							"run_id":         runID,
@@ -1431,6 +1479,8 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 			"job_id": jobID,
 			"count":  len(stoppedContainerIDs),
 		})
+		r.runLog(runID, runLogLevelInfo,
+			fmt.Sprintf("Restarting %d container(s)", len(stoppedContainerIDs)), nil)
 		if errs := engine.StartContainers(stoppedContainerIDs); len(errs) > 0 {
 			for _, e := range errs {
 				log.Printf("runner: stop_all restart error for job %d: %v", jobID, e)
@@ -1492,7 +1542,7 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 				}
 			}
 			r.logActivity("info", "health",
-				fmt.Sprintf("Health check: %s", job.Name),
+				fmt.Sprintf("Health check, job=%s", job.Name),
 				structuredDetails(map[string]any{
 					"summary": map[string]any{
 						"job_id":               jobID,
@@ -1518,6 +1568,8 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 			"phase":  "uploading",
 			"count":  len(stagedItems),
 		})
+		r.runLog(runID, runLogLevelInfo,
+			fmt.Sprintf("Upload phase, count=%d, destination=%q", len(stagedItems), dest.Name), nil)
 		for _, s := range stagedItems {
 			if ctx.Err() != nil {
 				log.Printf("runner: job %d cancelled before uploading %s", jobID, s.dbItem.ItemName)
@@ -1530,12 +1582,14 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 				"item_name": s.dbItem.ItemName,
 				"item_type": s.dbItem.ItemType,
 			})
-			checksums, uploadErr := r.uploadStagedFilesN(ctx, s.tmpDir, dest, s.itemPath, job.VerifyBackup, encryptPassphrase, job.Compression, s.dbItem.ItemType, s.dbItem.ItemName, job.EffectiveUploadConcurrency())
+			uploadStart := time.Now()
+			checksums, uploadErr := r.uploadStagedFilesN(ctx, runID, s.tmpDir, dest, s.itemPath, job.VerifyBackup, encryptPassphrase, job.Compression, s.dbItem.ItemType, s.dbItem.ItemName, job.EffectiveUploadConcurrency())
 			if uploadErr != nil {
 				if ctx.Err() != nil {
 					log.Printf("runner: job %d upload of %s cancelled: %v", jobID, s.dbItem.ItemName, uploadErr)
 					break
 				}
+				itemsProcessed++
 				itemsFailed++
 				failedNames = append(failedNames, s.dbItem.ItemName)
 				itemResults = append(itemResults, map[string]any{
@@ -1554,8 +1608,12 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 					"items_done":  itemsDone,
 					"error":       uploadErr.Error(),
 				})
+				r.runLog(runID, runLogLevelError,
+					fmt.Sprintf("Upload failed: %s (%s): %v, item=%d/%d", s.dbItem.ItemName, s.dbItem.ItemType, uploadErr, itemsProcessed, len(items)),
+					map[string]any{"item_name": s.dbItem.ItemName, "item_type": s.dbItem.ItemType, "error": uploadErr.Error()})
 			} else {
 				itemsDone++
+				itemsProcessed++
 				var itemSize int64
 				if s.result != nil {
 					for _, f := range s.result.Files {
@@ -1599,6 +1657,15 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 					"size_bytes":  itemSize,
 					"verified":    job.VerifyBackup,
 				})
+				r.runLog(runID, runLogLevelInfo,
+					fmt.Sprintf("Uploaded %s (%s), size=%s, duration=%s, item=%d/%d",
+						s.dbItem.ItemName, s.dbItem.ItemType, format.Bytes(float64(itemSize)), time.Since(uploadStart).Truncate(time.Second), itemsDone, len(items)),
+					map[string]any{
+						"item_name":        s.dbItem.ItemName,
+						"item_type":        s.dbItem.ItemType,
+						"size_bytes":       itemSize,
+						"duration_seconds": int(time.Since(uploadStart).Seconds()),
+					})
 			}
 			_ = r.db.UpdateJobRunProgress(runID, itemsDone, itemsFailed, totalSize)
 			r.updateRunProgress(itemsDone, itemsFailed, "")
@@ -1832,7 +1899,7 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 			log.Printf("runner: job %d post-script failed: %v", jobID, err)
 			r.logActivity("warn", "backup",
 				fmt.Sprintf("Post-script failed: %s", job.Name),
-				structuredDetails(map[string]any{
+				terminalDetails(map[string]any{
 					"job_id": jobID, "run_id": runID, "script": job.PostScript, "error": err.Error(),
 				}))
 		}
@@ -1864,9 +1931,16 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 	log.Printf("runner: job %d run %d finished: %s (done=%d, failed=%d, size=%d)",
 		jobID, runID, status, itemsDone, itemsFailed, totalSize)
 
+	// Terminal activity entry: marks the run complete and carries run_log:true
+	// so the UI expands this run's run-log stream on (re)load. Without it a
+	// reload shows only "Backup started" — the run-log lines (container
+	// milestones, per-item lines, and the summary below) are never fetched
+	// (#328 r3). The summary is ALSO written to the run log below so it
+	// streams live during the run; the two do not double-display (the UI
+	// dedupes the activity row once run-log lines exist).
 	r.logActivity(logLevelForStatus(status), "backup",
 		fmt.Sprintf("Backup %s: %s", status, job.Name),
-		structuredDetails(map[string]any{
+		terminalDetails(map[string]any{
 			"job_id": jobID, "job_name": job.Name,
 			"run_id": runID, "backup_type": btResult.BackupType,
 			"destination": dest.Name,
@@ -1874,6 +1948,15 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 			"size_bytes": totalSize, "duration_seconds": int(time.Since(jobStart).Seconds()),
 			"failed_items": failedNames,
 		}))
+
+	level, msg, summaryData := runSummaryMessage("Backup", job.Name, status, itemsDone, itemsFailed, run.ItemsTotal, totalSize, time.Since(jobStart))
+	summaryData["job_id"] = jobID
+	summaryData["backup_type"] = btResult.BackupType
+	summaryData["destination"] = dest.Name
+	if len(failedNames) > 0 {
+		summaryData["failed_items"] = failedNames
+	}
+	r.runLog(runID, level, msg, summaryData)
 
 	// Send Unraid + Discord notifications. notify.Send is now bounded (30s
 	// exec timeout). Belt-and-braces: wrap the whole sendNotification call in
@@ -2080,7 +2163,7 @@ func (r *Runner) RunDedupGC(dest db.StorageDestination, runID string) {
 		errMsg = gcErr.Error()
 		log.Printf("gc: %q: %v", dest.Name, gcErr)
 	}
-	log.Printf("gc: dest=%q run=%s freed_packs=%d freed_bytes=%d compacted_packs=%d reclaimed_bytes=%d rewritable=%d errors=%d",
+	log.Printf("gc: dest=%q, run=%s, freed_packs=%d, freed_bytes=%d, compacted_packs=%d, reclaimed_bytes=%d, rewritable=%d, errors=%d",
 		dest.Name, runID, result.FreedPacks, result.FreedBytes,
 		result.CompactedPacks, result.ReclaimedBytes,
 		result.RewritableBytes, len(result.Errors))
@@ -2209,25 +2292,25 @@ func (r *Runner) collectLiveManifestIDs(repo *dedup.Repo, destID int64) ([]dedup
 // engine.ChunkedHandler, the call is routed to backupItemChunked instead of
 // the classic tar pipeline. Handlers that don't support chunking (vm, zfs)
 // transparently fall through to the classic path even on dedup destinations.
-func (r *Runner) backupItem(ctx context.Context, item engine.BackupItem, dest db.StorageDestination, storagePath string, verify bool, passphrase string, compression string, concurrency int) (*engine.BackupResult, map[string]string, error) {
+func (r *Runner) backupItem(ctx context.Context, runID int64, item engine.BackupItem, dest db.StorageDestination, storagePath string, verify bool, passphrase string, compression string, concurrency int) (*engine.BackupResult, map[string]string, error) {
 	if dest.DedupEnabled {
 		handler, err := newHandler(item.Type)
 		if err != nil {
 			return nil, nil, err
 		}
 		if chunked, ok := handler.(engine.ChunkedHandler); ok {
-			return r.backupItemChunked(ctx, item, dest, chunked)
+			return r.backupItemChunked(ctx, runID, item, dest, chunked)
 		}
 		// Fall through to classic tar for non-chunked handlers (VM, ZFS).
 	}
 
-	tmpDir, result, cleanup, err := r.stageItemLocally(ctx, item, dest)
+	tmpDir, result, cleanup, err := r.stageItemLocally(ctx, runID, item, dest)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer cleanup()
 
-	checksums, err := r.uploadStagedFilesN(ctx, tmpDir, dest, storagePath, verify, passphrase, compression, item.Type, item.Name, concurrency)
+	checksums, err := r.uploadStagedFilesN(ctx, runID, tmpDir, dest, storagePath, verify, passphrase, compression, item.Type, item.Name, concurrency)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2239,7 +2322,7 @@ func (r *Runner) backupItem(ctx context.Context, item engine.BackupItem, dest db
 // handler's BackupChunked, flushes any pending pack, and returns a
 // BackupResult whose Meta carries the manifest ID for the runner to
 // persist on the resulting restore_points row.
-func (r *Runner) backupItemChunked(ctx context.Context, item engine.BackupItem, dest db.StorageDestination, handler engine.ChunkedHandler) (*engine.BackupResult, map[string]string, error) {
+func (r *Runner) backupItemChunked(ctx context.Context, runID int64, item engine.BackupItem, dest db.StorageDestination, handler engine.ChunkedHandler) (*engine.BackupResult, map[string]string, error) {
 	adapter, err := storage.NewAdapter(dest.Type, dest.Config)
 	if err != nil {
 		return nil, nil, fmt.Errorf("adapter: %w", err)
@@ -2267,6 +2350,12 @@ func (r *Runner) backupItemChunked(ctx context.Context, item engine.BackupItem, 
 		r.lastProgressMu.Unlock()
 
 		r.updateCurrentItemProgress(item.Type, pct, msg)
+		// Mirror engine milestones into the run log on the chunked/dedup
+		// path (the classic path mirrors them in stageItemLocally) for the
+		// narrated item types (folder + container). pct < 0 per-file
+		// heartbeats ("chunked <rel>") are dropped inside
+		// mirrorEngineMilestone — they would flood the log.
+		r.mirrorEngineMilestone(runID, item.Type, name, pct, msg)
 		if !admit(pct) {
 			return
 		}
@@ -2289,8 +2378,29 @@ func (r *Runner) backupItemChunked(ctx context.Context, item engine.BackupItem, 
 
 	stats := repo.Stats()
 	itemLogical := repo.SessionLogicalBytes()
-	log.Printf("runner: dedup item=%q manifest=%x chunks_total=%d packs_total=%d session_logical=%dB physical=%dB",
+	log.Printf("runner: dedup, item=%q, manifest=%x, chunks_total=%d, packs_total=%d, session_logical=%dB, physical=%dB",
 		item.Name, manifestID[:8], stats.TotalChunks, stats.TotalPacks, itemLogical, stats.PhysicalBytes)
+
+	// Dedup session stats belong in the run log too — the classic path's
+	// upload/verify lines are the dedup path's closest analogue, and these
+	// numbers are exactly what an operator wants to audit after a run
+	// (issue #328 QA).
+	dedupRatio := 0.0
+	if stats.PhysicalBytes > 0 {
+		dedupRatio = float64(itemLogical) / float64(stats.PhysicalBytes)
+	}
+	r.runLog(runID, runLogLevelInfo,
+		fmt.Sprintf("Dedup %s: chunks=%d, packs=%d, logical=%s, physical=%s, ratio=%.2f",
+			item.Name, stats.TotalChunks, stats.TotalPacks,
+			format.Bytes(float64(itemLogical)), format.Bytes(float64(stats.PhysicalBytes)), dedupRatio),
+		map[string]any{
+			"item_name":      item.Name,
+			"chunks":         stats.TotalChunks,
+			"packs":          stats.TotalPacks,
+			"logical_bytes":  itemLogical,
+			"physical_bytes": stats.PhysicalBytes,
+			"dedup_ratio":    dedupRatio,
+		})
 
 	midCopy := append([]byte(nil), manifestID[:]...)
 	// The existing per-item byte accounting in RunJob sums result.Files[].Size
@@ -2324,7 +2434,7 @@ func (r *Runner) backupItemChunked(ctx context.Context, item engine.BackupItem, 
 // dir, the backup result, and a cleanup func the caller must invoke when the
 // staged files are no longer needed (callers may defer it immediately for the
 // non-deferred path, or hold it across the upload phase for deferred mode).
-func (r *Runner) stageItemLocally(ctx context.Context, item engine.BackupItem, dest db.StorageDestination) (string, *engine.BackupResult, func(), error) {
+func (r *Runner) stageItemLocally(ctx context.Context, runID int64, item engine.BackupItem, dest db.StorageDestination) (string, *engine.BackupResult, func(), error) {
 	stageOverride, _ := r.db.GetSetting("staging_dir_override", docsmeta.DefaultFor("staging_dir_override"))
 	tmpDir, cleanup, err := tempdir.CreateBackupDir(tempdir.StorageConfig{Type: dest.Type, Config: dest.Config}, stageOverride)
 	if err != nil {
@@ -2359,6 +2469,11 @@ func (r *Runner) stageItemLocally(ctx context.Context, item engine.BackupItem, d
 		r.lastProgressMu.Unlock()
 
 		r.updateCurrentItemProgress(item.Type, pct, msg)
+		// Mirror engine milestones into the run log on the classic tar path
+		// for the narrated item types (folder + container). Classic backups
+		// emit only pct >= 0 milestones; the chunked path's -1 per-file
+		// heartbeats are dropped inside mirrorEngineMilestone.
+		r.mirrorEngineMilestone(runID, item.Type, name, pct, msg)
 		if !admit(pct) {
 			return
 		}
@@ -2401,7 +2516,7 @@ func (r *Runner) stageItemLocally(ctx context.Context, item engine.BackupItem, d
 // wrap. The restore path peels it off content-based via
 // decompressStoredReader, the same mechanism used for legacy double-wrapped
 // backups.
-func (r *Runner) uploadStagedFilesN(ctx context.Context, tmpDir string, dest db.StorageDestination, storagePath string, verify bool, passphrase string, compression string, itemType string, itemName string, concurrency int) (map[string]string, error) {
+func (r *Runner) uploadStagedFilesN(ctx context.Context, runID int64, tmpDir string, dest db.StorageDestination, storagePath string, verify bool, passphrase string, compression string, itemType string, itemName string, concurrency int) (map[string]string, error) {
 	transportCompression := "none"
 	if itemType == "vm" || itemType == "zfs" {
 		transportCompression = compression
@@ -2447,6 +2562,9 @@ func (r *Runner) uploadStagedFilesN(ctx context.Context, tmpDir string, dest db.
 	if concurrency < 1 {
 		concurrency = 1
 	}
+	r.runLog(runID, runLogLevelInfo,
+		fmt.Sprintf("Uploading %s (%s): %d file(s)", itemName, itemType, len(entries)),
+		map[string]any{"item_name": itemName, "item_type": itemType, "files": len(entries)})
 	var (
 		mu        sync.Mutex
 		checksums = make(map[string]string)
@@ -2475,7 +2593,27 @@ func (r *Runner) uploadStagedFilesN(ctx context.Context, tmpDir string, dest db.
 					errOnce.Do(func() { firstErr = fmt.Errorf("upload worker for %s panicked: %v", entryName, rec) })
 				}
 			}()
+			// Per-file run-log narration (issue #328 QA): stat the staged
+			// file for a size figure and time the upload. Both are cheap;
+			// runLog no-ops when runID is 0.
+			var fileSize int64
+			if fi, err := os.Stat(filepath.Join(tmpDir, entryName)); err == nil {
+				fileSize = fi.Size()
+			}
+			upStart := time.Now()
 			storageName, checksum, upErr := r.uploadOneStaged(ctx, adapter, tmpDir, entryName, storagePath, passphrase, transportCompression, itemType, itemName, progress)
+			if upErr == nil {
+				dur := time.Since(upStart)
+				r.runLog(runID, runLogLevelInfo,
+					fmt.Sprintf("Uploaded %s, file=%s, size=%s, duration=%s",
+						itemName, storageName, format.Bytes(float64(fileSize)), dur.Truncate(time.Second)),
+					map[string]any{
+						"item_name":        itemName,
+						"file":             storageName,
+						"size_bytes":       fileSize,
+						"duration_seconds": int(dur.Seconds()),
+					})
+			}
 			if storageName != "" {
 				mu.Lock()
 				checksums[storageName] = checksum // checksum is "" on error; key still enables cleanup
@@ -2499,6 +2637,9 @@ func (r *Runner) uploadStagedFilesN(ctx context.Context, tmpDir string, dest db.
 
 	// Verify: read files back from storage and re-compute SHA-256.
 	if verify {
+		r.runLog(runID, runLogLevelInfo,
+			fmt.Sprintf("Verifying %s (%s): %d file(s)", itemName, itemType, len(checksums)),
+			map[string]any{"item_name": itemName, "item_type": itemType, "files": len(checksums)})
 		for fileName, expectedHash := range checksums {
 			destPath := filepath.Join(storagePath, fileName)
 			reader, err := adapter.Read(destPath)
@@ -2535,6 +2676,9 @@ func (r *Runner) uploadStagedFilesN(ctx context.Context, tmpDir string, dest db.
 				return nil, fmt.Errorf("verification failed for %s: expected %s, got %s", fileName, expectedHash, actualHash)
 			}
 		}
+		r.runLog(runID, runLogLevelInfo,
+			fmt.Sprintf("Verified %s (%s): %d file(s) checksum OK", itemName, itemType, len(checksums)),
+			map[string]any{"item_name": itemName, "item_type": itemType, "files": len(checksums)})
 	}
 
 	return checksums, nil
@@ -2777,6 +2921,7 @@ func (r *Runner) markRunStalled(runID, jobID int64, reason string) {
 		"run_id": runID,
 		"reason": reason,
 	})
+	r.runLog(runID, runLogLevelWarn, fmt.Sprintf("Run stalled: %s", reason), nil)
 }
 
 // RunRestore executes a tracked restore operation. It creates a job_run
@@ -2884,6 +3029,7 @@ func (r *Runner) RunRestore(restorePoint db.RestorePoint, targets []RestoreTarge
 			log.Printf("runner: PANIC during restore run %d: %v", runID, rec)
 			run.Status = "failed"
 			run.Log = fmt.Sprintf("Internal error (panic): %v", rec)
+			r.runLog(runID, runLogLevelError, fmt.Sprintf("Internal error (panic): %v", rec), nil)
 			_ = r.db.UpdateJobRun(run)
 			r.broadcast(map[string]any{
 				"type":     "job_run_completed",
@@ -2924,6 +3070,10 @@ func (r *Runner) RunRestore(restorePoint db.RestorePoint, targets []RestoreTarge
 		})
 		r.updateRunProgress(itemsDone, itemsFailed, t.Name)
 		r.reportRestoreProgress(reporter, 0, "Starting...")
+		r.runLog(runID, runLogLevelInfo,
+			fmt.Sprintf("Restoring %s (%s) — item %d of %d",
+				t.Name, t.Type, itemsDone+itemsFailed+1, len(targets)),
+			map[string]any{"item_name": t.Name, "item_type": t.Type})
 
 		start := time.Now()
 		restoreErr := r.restoreItemWithReporter(ctx, restorePoint, t.Name, t.Type, destination, passphrase, t.FilePaths, reporter)
@@ -2950,6 +3100,9 @@ func (r *Runner) RunRestore(restorePoint db.RestorePoint, targets []RestoreTarge
 				"items_failed": itemsFailed,
 				"items_total":  len(targets),
 			})
+			r.runLog(runID, runLogLevelError,
+				fmt.Sprintf("Restore failed: %s (%s): %v", t.Name, t.Type, restoreErr),
+				map[string]any{"item_name": t.Name, "item_type": t.Type, "error": restoreErr.Error()})
 		} else {
 			itemsDone++
 			result["status"] = "ok"
@@ -2963,6 +3116,9 @@ func (r *Runner) RunRestore(restorePoint db.RestorePoint, targets []RestoreTarge
 				"items_failed": itemsFailed,
 				"items_total":  len(targets),
 			})
+			r.runLog(runID, runLogLevelInfo,
+				fmt.Sprintf("Restored %s (%s) in %s", t.Name, t.Type, elapsed.Truncate(time.Second)),
+				map[string]any{"item_name": t.Name, "item_type": t.Type, "duration_seconds": int(elapsed.Seconds())})
 		}
 
 		itemResults = append(itemResults, result)
@@ -2998,26 +3154,22 @@ func (r *Runner) RunRestore(restorePoint db.RestorePoint, targets []RestoreTarge
 		"size_bytes":   restorePoint.SizeBytes,
 	})
 
-	level := "info"
-	msg := fmt.Sprintf("Restore completed: %s (%d/%d items)", status, itemsDone, len(targets))
-	if itemsFailed > 0 {
-		level = "warning"
-	}
-	if status == "failed" {
-		level = "error"
-		msg = fmt.Sprintf("Restore failed: all %d items failed", len(targets))
-	}
-	r.logActivity(level, "restore", msg,
-		structuredDetails(map[string]any{
+	// Terminal activity entry gates run-log expansion in the UI (same
+	// rationale as the backup path above) (#328 r3).
+	r.logActivity(logLevelForStatus(status), "restore",
+		fmt.Sprintf("Restore %s: %d item(s) from restore point %d", status, itemsDone, restorePoint.ID),
+		terminalDetails(map[string]any{
 			"job_id":           restorePoint.JobID,
-			"job_name":         jobName,
 			"run_id":           runID,
+			"restore_point_id": restorePoint.ID,
 			"items_done":       itemsDone,
 			"items_failed":     itemsFailed,
-			"items_total":      len(targets),
 			"size_bytes":       restorePoint.SizeBytes,
-			"duration_seconds": int(time.Since(restoreStart).Seconds()),
 		}))
+
+	sumLevel, sumMsg, sumData := runSummaryMessage("Restore", "", status, itemsDone, itemsFailed, len(targets), restorePoint.SizeBytes, time.Since(restoreStart))
+	sumData["restore_point_id"] = restorePoint.ID
+	r.runLog(runID, sumLevel, sumMsg, sumData)
 }
 
 // RestoreItem restores a single item from a restore point.
@@ -3057,6 +3209,9 @@ func (r *Runner) restoreItemChain(ctx context.Context, restorePoint db.RestorePo
 		// take the single-point chunked restore path.
 		if _, ok := resolveManifestID(restorePoint, itemName); ok {
 			log.Printf("runner: dedup restore point %d has a complete manifest — restoring it directly (no chain replay)", restorePoint.ID)
+			r.runLog(reporter.RunID, runLogLevelInfo,
+				fmt.Sprintf("Restore point %d carries a complete dedup manifest — restoring %s directly (no chain replay)", restorePoint.ID, itemName),
+				map[string]any{"restore_point_id": restorePoint.ID, "item_name": itemName})
 			return r.restoreSinglePoint(ctx, restorePoint, itemName, itemType, destination, passphrase, filePaths, reporter)
 		}
 		if usesMergedRestoreChain(itemType) {
@@ -3064,12 +3219,18 @@ func (r *Runner) restoreItemChain(ctx context.Context, restorePoint db.RestorePo
 		}
 		replayStart := time.Now()
 		for i, rp := range chain {
+			r.runLog(reporter.RunID, runLogLevelInfo,
+				fmt.Sprintf("Restore chain step %d/%d (type=%s, id=%d)", i+1, len(chain), rp.BackupType, rp.ID),
+				map[string]any{"step": i + 1, "steps": len(chain), "backup_type": rp.BackupType, "restore_point_id": rp.ID})
 			log.Printf("runner: restoring chain step %d/%d (type=%s, id=%d)",
 				i+1, len(chain), rp.BackupType, rp.ID)
 			if err := r.restoreSinglePoint(ctx, rp, itemName, itemType, destination, passphrase, filePaths, reporter); err != nil {
 				return fmt.Errorf("restoring chain step %d (id=%d): %w", i+1, rp.ID, err)
 			}
 		}
+		r.runLog(reporter.RunID, runLogLevelInfo,
+			fmt.Sprintf("Restore chain replayed for %s: %d step(s)", itemName, len(chain)),
+			map[string]any{"item_name": itemName, "steps": len(chain)})
 		// Classic folder chains overlay without deletion tracking; prune
 		// files the overlay wrote that are absent from the newest point's
 		// authoritative listing (issue #231). Whole-item restores only — a
@@ -3304,6 +3465,9 @@ func (r *Runner) restoreMergedChain(ctx context.Context, chain []db.RestorePoint
 	if itemType == "vm" && len(chain) > 1 {
 		stepDirs := make([]string, 0, len(chain))
 		for i, rp := range chain {
+			r.runLog(reporter.RunID, runLogLevelInfo,
+				fmt.Sprintf("Staging chain step %d/%d (type=%s, id=%d)", i+1, len(chain), rp.BackupType, rp.ID),
+				map[string]any{"step": i + 1, "steps": len(chain), "backup_type": rp.BackupType, "restore_point_id": rp.ID})
 			log.Printf("runner: staging VM chain step %d/%d (type=%s, id=%d)", i+1, len(chain), rp.BackupType, rp.ID)
 			stepDir := filepath.Join(tmpDir, fmt.Sprintf("step_%d", i))
 			if err := os.MkdirAll(stepDir, 0o755); err != nil {
@@ -3326,6 +3490,9 @@ func (r *Runner) restoreMergedChain(ctx context.Context, chain []db.RestorePoint
 	}
 
 	for i, rp := range chain {
+		r.runLog(reporter.RunID, runLogLevelInfo,
+			fmt.Sprintf("Staging chain step %d/%d (type=%s, id=%d)", i+1, len(chain), rp.BackupType, rp.ID),
+			map[string]any{"step": i + 1, "steps": len(chain), "backup_type": rp.BackupType, "restore_point_id": rp.ID})
 		log.Printf("runner: staging chain step %d/%d (type=%s, id=%d)", i+1, len(chain), rp.BackupType, rp.ID)
 		phaseStart := (i * 40) / len(chain)
 		phaseEnd := ((i + 1) * 40) / len(chain)
@@ -3464,9 +3631,10 @@ func (r *Runner) restoreSinglePointChunked(ctx context.Context, rp db.RestorePoi
 		r.lastProgress = time.Now()
 		r.lastProgressMu.Unlock()
 		reporter.ItemName = name
-		// RestoreChunked reports once per restored file. The stall watchdog is
-		// fed above on every call; the status update and broadcast (which
-		// reportRestoreProgress does together, clamping percent) run at ~1 Hz.
+		// Mirror engine restore milestones into the run log (folder and
+		// container; the chunked restore walk's -1 per-file "restored <fp>"
+		// heartbeats are dropped inside mirrorEngineMilestone) (#328 QA).
+		r.mirrorEngineMilestone(reporter.RunID, itemType, name, pct, msg)
 		if !admit(pct) {
 			return
 		}
@@ -3519,10 +3687,15 @@ func (r *Runner) stageRestorePointItem(ctx context.Context, restorePoint db.Rest
 
 	if len(restoreFiles) == 0 {
 		r.reportRestoreProgress(reporter, phaseEnd, "Restore data ready")
+		r.runLog(reporter.RunID, runLogLevelWarn,
+			fmt.Sprintf("No restore data found for %s (restore point %d)", itemName, restorePoint.ID), nil)
 		return nil
 	}
 
 	r.reportRestoreProgress(reporter, phaseStart, "Preparing restore data")
+	r.runLog(reporter.RunID, runLogLevelInfo,
+		fmt.Sprintf("Downloading %s: %d file(s), size=%s", itemName, len(restoreFiles), format.Bytes(float64(totalBytes))),
+		map[string]any{"item_name": itemName, "files": len(restoreFiles), "size_bytes": totalBytes})
 
 	concurrency := job.EffectiveUploadConcurrency()
 	if concurrency < 1 {
@@ -3573,9 +3746,19 @@ func (r *Runner) stageRestorePointItem(ctx context.Context, restorePoint db.Rest
 					errOnce.Do(func() { firstErr = fmt.Errorf("download worker for %s panicked: %v", fi.Path, rec) })
 				}
 			}()
+			dlStart := time.Now()
 			if err := r.downloadRestoreFile(ctx, adapter, fi, tmpDir, passphrase, job.Compression, expectedChecksums, heartbeat, storage.RestorePartSize, concurrency); err != nil {
 				errOnce.Do(func() { firstErr = err })
+				return
 			}
+			// Per-file run-log narration (issue #328 QA). Classic restore
+			// downloads are few per item (archive + sidecars); the chunked
+			// restore path narrates per-file via its own -1 heartbeats,
+			// which mirrorEngineMilestone drops.
+			r.runLog(reporter.RunID, runLogLevelInfo,
+				fmt.Sprintf("Downloaded %s, file=%s, size=%s, duration=%s",
+					itemName, filepath.Base(fi.Path), format.Bytes(float64(fi.Size)), time.Since(dlStart).Truncate(time.Second)),
+				map[string]any{"item_name": itemName, "file": filepath.Base(fi.Path), "size_bytes": fi.Size})
 		}(fi)
 	}
 	wg.Wait()
@@ -3588,6 +3771,9 @@ func (r *Runner) stageRestorePointItem(ctx context.Context, restorePoint db.Rest
 	}
 
 	r.reportRestoreProgress(reporter, phaseEnd, "Restore data ready")
+	r.runLog(reporter.RunID, runLogLevelInfo,
+		fmt.Sprintf("Restore data ready for %s: %d file(s)", itemName, len(restoreFiles)),
+		map[string]any{"item_name": itemName, "files": len(restoreFiles)})
 
 	return nil
 }
@@ -3750,6 +3936,7 @@ func (r *Runner) restoreStagedItem(ctx context.Context, jobID int64, itemName, i
 	progress := func(name string, pct int, msg string) {
 		scaledPct := phaseStart + ((pct * (phaseEnd - phaseStart)) / 100)
 		reporter.ItemName = name
+		r.mirrorEngineMilestone(reporter.RunID, itemType, name, pct, msg)
 		r.reportRestoreProgress(reporter, scaledPct, msg)
 	}
 
@@ -4186,7 +4373,7 @@ func (r *Runner) enforceRetentionLTR(ctx context.Context, dest db.StorageDestina
 	}
 
 	protected := ltrProtectedRestorePointIDs(allRestorePoints, policy, time.Local)
-	log.Printf("runner: LTR retention for job %d: keeping %d of %d restore points (policy: latest=%d daily=%d weekly=%d monthly=%d yearly=%d)",
+	log.Printf("runner: LTR retention for job %d: keeping %d of %d restore points (policy: latest=%d, daily=%d, weekly=%d, monthly=%d, yearly=%d)",
 		jobID, len(protected), len(allRestorePoints),
 		policy.KeepLatest, policy.KeepDaily, policy.KeepWeekly, policy.KeepMonthly, policy.KeepYearly)
 	for _, rp := range allRestorePoints {
@@ -4877,6 +5064,7 @@ func (r *Runner) ImportBackups(storageDestID int64, backups []map[string]any) (i
 			itemsDone = int(v)
 		}
 		itemsFailed := 0
+
 		if v, ok := b["items_failed"].(float64); ok {
 			itemsFailed = int(v)
 		}
@@ -5199,6 +5387,17 @@ func structuredDetails(data any) string {
 		return fmt.Sprint(data)
 	}
 	return string(b)
+}
+
+// terminalDetails wraps structuredDetails for activity entries that
+// represent the terminal state of a backup run (completed, failed,
+// partial, cancelled). The "run_log" flag gates inline run-log expansion
+// in the unified console UI — only terminal entries carry the flag, so
+// the run's log renders once instead of once per activity row when a
+// "Backup started" and "Backup completed" entry share the same run_id.
+func terminalDetails(data map[string]any) string {
+	data["run_log"] = true
+	return structuredDetails(data)
 }
 
 // jobItemNames extracts item names from a slice of job items.

--- a/internal/runner/runner_formatters_test.go
+++ b/internal/runner/runner_formatters_test.go
@@ -214,7 +214,7 @@ func TestSendRestoreNotificationDisabled(t *testing.T) {
 	r.sendRestoreNotification("plex", "container", errExampleRestore{})
 
 	// No activity log entries should have been written.
-	logs, err := database.ListActivityLogs(10, "")
+	logs, err := database.ListActivityLogs(10, "", 0)
 	if err != nil {
 		t.Fatalf("ListActivityLogs: %v", err)
 	}
@@ -234,7 +234,7 @@ func TestSendRestoreNotificationSuccess(t *testing.T) {
 	}
 	r.sendRestoreNotification("plex", "container", nil)
 
-	logs, err := database.ListActivityLogs(10, "")
+	logs, err := database.ListActivityLogs(10, "", 0)
 	if err != nil {
 		t.Fatalf("ListActivityLogs: %v", err)
 	}
@@ -258,7 +258,7 @@ func TestSendRestoreNotificationFailure(t *testing.T) {
 	}
 	r.sendRestoreNotification("plex", "container", errExampleRestore{})
 
-	logs, err := database.ListActivityLogs(10, "")
+	logs, err := database.ListActivityLogs(10, "", 0)
 	if err != nil {
 		t.Fatalf("ListActivityLogs: %v", err)
 	}

--- a/internal/runner/upload_staged_test.go
+++ b/internal/runner/upload_staged_test.go
@@ -34,7 +34,7 @@ func TestUploadStagedFiles_UpdatesLastProgress(t *testing.T) {
 	r.lastProgress = stale
 	r.lastProgressMu.Unlock()
 
-	if _, err := r.uploadStagedFilesN(context.Background(), tmpDir, dest, "rp", false, "", "none", "folder", "Test", 1); err != nil {
+	if _, err := r.uploadStagedFilesN(context.Background(), 0, tmpDir, dest, "rp", false, "", "none", "folder", "Test", 1); err != nil {
 		t.Fatalf("uploadStagedFiles: %v", err)
 	}
 
@@ -56,7 +56,7 @@ func TestUploadStagedFiles_BadAdapterConfig(t *testing.T) {
 		Type:   "local",
 		Config: `{not valid json`,
 	}
-	_, err := r.uploadStagedFilesN(context.Background(), t.TempDir(), dest, "rp", false, "", "none", "folder", "Test Folder", 1)
+	_, err := r.uploadStagedFilesN(context.Background(), 0, t.TempDir(), dest, "rp", false, "", "none", "folder", "Test Folder", 1)
 	if err == nil {
 		t.Fatal("expected NewAdapter error for corrupt config")
 	}
@@ -73,7 +73,7 @@ func TestUploadStagedFiles_MissingTmpDir(t *testing.T) {
 		Type:   "local",
 		Config: string(cfg),
 	}
-	_, err := r.uploadStagedFilesN(context.Background(), filepath.Join(t.TempDir(), "no-such-dir"), dest, "rp", false, "", "none", "folder", "Test", 1)
+	_, err := r.uploadStagedFilesN(context.Background(), 0, filepath.Join(t.TempDir(), "no-such-dir"), dest, "rp", false, "", "none", "folder", "Test", 1)
 	if err == nil {
 		t.Fatal("expected ReadDir error for missing tmpDir")
 	}
@@ -92,7 +92,7 @@ func TestUploadStagedFiles_EmptyTmpDirReturnsEmptyChecksums(t *testing.T) {
 		Type:   "local",
 		Config: string(cfg),
 	}
-	checksums, err := r.uploadStagedFilesN(context.Background(), t.TempDir(), dest, "rp", false, "", "none", "folder", "Test", 1)
+	checksums, err := r.uploadStagedFilesN(context.Background(), 0, t.TempDir(), dest, "rp", false, "", "none", "folder", "Test", 1)
 	if err != nil {
 		t.Fatalf("uploadStagedFiles(empty tmpDir): %v", err)
 	}
@@ -120,7 +120,7 @@ func TestUploadStagedFiles_HappyPath_NoEncryption(t *testing.T) {
 		Type:   "local",
 		Config: string(cfg),
 	}
-	checksums, err := r.uploadStagedFilesN(context.Background(), tmpDir, dest, "rp-x", false, "", "none", "folder", "Test", 1)
+	checksums, err := r.uploadStagedFilesN(context.Background(), 0, tmpDir, dest, "rp-x", false, "", "none", "folder", "Test", 1)
 	if err != nil {
 		t.Fatalf("uploadStagedFiles: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestUploadStagedFiles_HappyPath_WithEncryption(t *testing.T) {
 		Type:   "local",
 		Config: string(cfg),
 	}
-	checksums, err := r.uploadStagedFilesN(context.Background(), tmpDir, dest, "rp-y", false, "secret", "none", "container", "MyContainer", 1)
+	checksums, err := r.uploadStagedFilesN(context.Background(), 0, tmpDir, dest, "rp-y", false, "secret", "none", "container", "MyContainer", 1)
 	if err != nil {
 		t.Fatalf("uploadStagedFiles: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestUploadStagedFiles_ParallelAllChecksums(t *testing.T) {
 	cfg, _ := json.Marshal(map[string]string{"path": filepath.Join(t.TempDir(), "store")})
 	dest := db.StorageDestination{Type: "local", Config: string(cfg)}
 
-	sums, err := r.uploadStagedFilesN(context.Background(), tmp, dest, "rp", false, "", "none", "folder", "Test", 3)
+	sums, err := r.uploadStagedFilesN(context.Background(), 0, tmp, dest, "rp", false, "", "none", "folder", "Test", 3)
 	if err != nil {
 		t.Fatalf("uploadStagedFilesN: %v", err)
 	}
@@ -221,7 +221,7 @@ func TestUploadStagedFiles_TransportCompression(t *testing.T) {
 			cfg, _ := json.Marshal(map[string]string{"path": storeDir})
 			dest := db.StorageDestination{Type: "local", Config: string(cfg)}
 
-			checksums, err := r.uploadStagedFilesN(context.Background(), tmpDir, dest, "rp", false, "", "zstd", tt.itemType, "item", 1)
+			checksums, err := r.uploadStagedFilesN(context.Background(), 0, tmpDir, dest, "rp", false, "", "zstd", tt.itemType, "item", 1)
 			if err != nil {
 				t.Fatalf("uploadStagedFiles: %v", err)
 			}

--- a/internal/runner/verify.go
+++ b/internal/runner/verify.go
@@ -386,7 +386,7 @@ func (r *Runner) verifyOneFile(adapter storage.Adapter, storagePath string, want
 		return VerifyResult{Path: storagePath, Err: fmt.Errorf("stat: %w", err)}
 	}
 	if want.Size > 0 && info.Size != want.Size {
-		return VerifyResult{Path: storagePath, Size: 0, Err: fmt.Errorf("size mismatch: storage=%d recorded=%d", info.Size, want.Size)}
+		return VerifyResult{Path: storagePath, Size: 0, Err: fmt.Errorf("size mismatch: storage=%d, recorded=%d", info.Size, want.Size)}
 	}
 	if mode == VerifyModeQuick {
 		// Quick mode performs no data transfer — Size: 0 ensures

--- a/internal/runner/verify_gap_test.go
+++ b/internal/runner/verify_gap_test.go
@@ -134,7 +134,7 @@ func TestRunScheduledVerifyBackupContention(t *testing.T) {
 			if tc.wantRuns == 0 {
 				// Deferral must be surfaced in the activity log so the user can
 				// see why the deep verify did not run.
-				entries, err := database.ListActivityLogs(10, "verify")
+				entries, err := database.ListActivityLogs(10, "verify", 0)
 				if err != nil {
 					t.Fatalf("ListActivityLogs: %v", err)
 				}

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -167,7 +167,7 @@ func (l *LocalAdapter) ReadRange(p string, offset, length int64) (io.ReadCloser,
 		return nil, err
 	}
 	if offset < 0 || length < 0 {
-		return nil, fmt.Errorf("invalid range offset=%d length=%d", offset, length)
+		return nil, fmt.Errorf("invalid range offset=%d, length=%d", offset, length)
 	}
 	if offset >= info.Size() {
 		return nil, fmt.Errorf("offset %d at or past EOF (size=%d)", offset, info.Size())

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -548,7 +548,7 @@ func (r *cancelOnCloseReader) Close() error {
 // bounded header waits).
 func (a *S3Adapter) ReadRange(p string, offset, length int64) (io.ReadCloser, error) {
 	if offset < 0 || length < 0 {
-		return nil, fmt.Errorf("s3: invalid range offset=%d length=%d", offset, length)
+		return nil, fmt.Errorf("s3: invalid range offset=%d, length=%d", offset, length)
 	}
 	key, err := a.keyFor(p, false)
 	if err != nil {

--- a/internal/storage/sftp.go
+++ b/internal/storage/sftp.go
@@ -332,7 +332,7 @@ func (r *sftpReadCloser) Close() error {
 // so the pool connection is returned only when the caller closes the reader.
 func (s *SFTPAdapter) ReadRange(p string, offset, length int64) (io.ReadCloser, error) {
 	if offset < 0 || length < 0 {
-		return nil, fmt.Errorf("invalid range offset=%d length=%d", offset, length)
+		return nil, fmt.Errorf("invalid range offset=%d, length=%d", offset, length)
 	}
 	conn, err := s.pool.get()
 	if err != nil {

--- a/internal/storage/smb.go
+++ b/internal/storage/smb.go
@@ -165,7 +165,7 @@ func (r *smbReadCloser) Close() error {
 
 func (s *SMBAdapter) ReadRange(p string, offset, length int64) (io.ReadCloser, error) {
 	if offset < 0 || length < 0 {
-		return nil, fmt.Errorf("invalid range offset=%d length=%d", offset, length)
+		return nil, fmt.Errorf("invalid range offset=%d, length=%d", offset, length)
 	}
 	share, session, err := s.connect()
 	if err != nil {

--- a/internal/storage/webdav.go
+++ b/internal/storage/webdav.go
@@ -764,7 +764,7 @@ var errWebDAVRangeNotFound = errors.New("object not found")
 // callers verify whole-file checksums, matching plain-object Range semantics.
 func (w *WebDAVAdapter) ReadRange(p string, offset, length int64) (io.ReadCloser, error) {
 	if offset < 0 || length < 0 {
-		return nil, fmt.Errorf("webdav: invalid range offset=%d length=%d", offset, length)
+		return nil, fmt.Errorf("webdav: invalid range offset=%d, length=%d", offset, length)
 	}
 	full, err := w.fullPath(p, false)
 	if err != nil {

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -540,6 +540,25 @@ body {
 ::-webkit-scrollbar-thumb { background: var(--color-surface-3); border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--color-surface-4); }
 
+/* Console scrollbar — the default square track paints over the console's
+   rounded right corners, so the top-right/bottom-right border arcs
+   disappear behind it. Round the track's right corners to match rounded-xl
+   (12px) so the corner outlines stay visible like the rest of the console. */
+.console-scroll::-webkit-scrollbar { width: 8px; height: 8px; }
+.console-scroll::-webkit-scrollbar-track {
+  background: transparent;
+  border-radius: 0 12px 12px 0;
+}
+.console-scroll::-webkit-scrollbar-thumb {
+  background: var(--color-surface-3);
+  border-radius: 4px;
+}
+.console-scroll::-webkit-scrollbar-thumb:hover { background: var(--color-surface-4); }
+.console-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-surface-3) transparent;
+}
+
 /* Focus ring */
 *:focus-visible {
   outline: 2px solid var(--color-vault);

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -215,9 +215,16 @@ export const api = {
   },
 
   // Activity Log
-  getActivity: (limit = 100, category = '') =>
-    request('GET', `/activity?limit=${limit}${category ? '&category=' + encodeURIComponent(category) : ''}`),
+  getActivity: (limit = 100, category = '', beforeId = 0) =>
+    request('GET', `/activity?limit=${limit}${category ? '&category=' + encodeURIComponent(category) : ''}${beforeId ? '&before_id=' + beforeId : ''}`),
   purgeActivity: () => request('DELETE', '/activity'),
+
+  // Run Log (per-run streaming log, issue #328)
+  // tail=true fetches the run's NEWEST `limit` lines (oldest-first within
+  // that window) instead of the oldest, so the console always receives the
+  // end-of-run summary line even for runs longer than the limit.
+  getRunLogs: (runId, { after = 0, limit = 500, tail = false } = {}) =>
+    request('GET', `/runs/${runId}/logs?after=${after}&limit=${limit}${tail ? '&tail=true' : ''}`),
 
   // History
   purgeHistory: () => request('DELETE', '/history'),

--- a/web/src/lib/followmarker.js
+++ b/web/src/lib/followmarker.js
@@ -1,0 +1,42 @@
+// followmarker.js — pure logic for the Logs page "new entries" indicator.
+//
+// When the user scrolls away from the live tail (follow off), a marker
+// snapshots the buffer: the newest entry's timestamp and the id set of every
+// entry present at that moment. countNewEntries then reports only genuinely
+// new entries — any entry not older than the marker's timestamp whose id was
+// NOT in the snapshot. The id-set guard applies even to strictly-newer
+// timestamps: a WS run_log can replace an already-seen row (same id) with a
+// newer timestamp, and counting that by timestamp alone produced the phantom
+// "1 new entry" badge (#328).
+//
+// The old implementation tie-broke on a single id (`t === mt && e.id !==
+// marker.id`). Timestamps are often second-precision, so a same-second burst
+// at the buffer tail made pre-existing entries look "new" whenever the
+// marker's identity changed between scroll-ups (WS/dedupe tail replacements,
+// or a marker landing on a different same-second entry) — the #328 off-by-one
+// ("1 new entry" with nothing new). Snapshotting the id set fixes it.
+//
+// Plain object used as a set (key = id) to match the store's lint-friendly
+// convention for .svelte.js files.
+
+export function createFollowMarker(entries) {
+  if (entries.length === 0) return null
+  const ids = {}
+  for (const e of entries) ids[e.id] = true
+  return { ts: entries[entries.length - 1].ts, ids }
+}
+
+export function countNewEntries(entries, marker) {
+  if (!marker) return 0
+  const mt = Date.parse(marker.ts) || 0
+  let n = 0
+  for (const e of entries) {
+    const t = Date.parse(e.ts) || 0
+    // Count only ids not already snapshotted and not older than the marker.
+    // Guarding ids on BOTH branches (not just the same-second tie-break) is
+    // what stops an already-seen row whose ts advanced past the marker from
+    // reading as "new" (#328).
+    if (!marker.ids[e.id] && t >= mt) n++
+  }
+  return n
+}

--- a/web/src/lib/followmarker.test.js
+++ b/web/src/lib/followmarker.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { createFollowMarker, countNewEntries } from './followmarker.js'
+
+const at = (id, ts) => ({ id, ts })
+const T1 = '2026-08-18T21:00:00.000Z'
+const T2 = '2026-08-18T21:00:01.000Z'
+const T3 = '2026-08-18T21:00:02.000Z'
+
+describe('createFollowMarker', () => {
+  it('returns null for an empty buffer', () => {
+    expect(createFollowMarker([])).toBeNull()
+  })
+
+  it('snapshots the newest entry ts and every id in the buffer', () => {
+    const entries = [at(1, T1), at(2, T2), at(3, T3)]
+    const marker = createFollowMarker(entries)
+    expect(marker.ts).toBe(T3)
+    expect(marker.ids[1]).toBe(true)
+    expect(marker.ids[2]).toBe(true)
+    expect(marker.ids[3]).toBe(true)
+  })
+})
+
+describe('countNewEntries', () => {
+  it('counts zero when nothing arrived after the marker', () => {
+    const entries = [at(1, T1), at(2, T2), at(3, T3)]
+    const marker = createFollowMarker(entries)
+    expect(countNewEntries(entries, marker)).toBe(0)
+  })
+
+  it('counts entries with a strictly newer timestamp', () => {
+    const entries = [at(1, T1), at(2, T2), at(3, T3)]
+    const marker = createFollowMarker(entries)
+    expect(countNewEntries([...entries, at(4, '2026-08-18T21:00:03.000Z')], marker)).toBe(1)
+  })
+
+  it('does not count pre-existing entries that share the marker timestamp', () => {
+    // Two entries landed in the same second; the marker is the second one.
+    // The first is already visible — the old ts-tie-break counted it as
+    // "new" whenever the marker identity changed (the #328 off-by-one).
+    const entries = [at(1, T3), at(2, T3)]
+    const marker = createFollowMarker(entries)
+    expect(countNewEntries(entries, marker)).toBe(0)
+  })
+
+  it('counts a genuinely new entry arriving within the marker second', () => {
+    const entries = [at(1, T3), at(2, T3)]
+    const marker = createFollowMarker(entries)
+    expect(countNewEntries([...entries, at(3, T3)], marker)).toBe(1)
+  })
+
+  it('does not count an already-seen id even when its ts advances past the marker', () => {
+    // A WS run_log can replace an already-seen summary/activity row (same id)
+    // while carrying a strictly-newer timestamp. Its id is already in the
+    // marker, so it must not read as new — the #328 phantom "1 new entry".
+    const entries = [at(1, T1), at(2, T2)]
+    const marker = createFollowMarker(entries)
+    expect(countNewEntries([at(1, T1), at(2, T3)], marker)).toBe(0)
+  })
+
+  it('does not count older entries prepended by load-older', () => {
+    const entries = [at(3, T3)]
+    const marker = createFollowMarker(entries)
+    expect(countNewEntries([at(1, T1), at(2, T2), at(3, T3)], marker)).toBe(0)
+  })
+
+  it('returns 0 when there is no marker', () => {
+    expect(countNewEntries([at(1, T1)], null)).toBe(0)
+  })
+})

--- a/web/src/lib/logbatch.js
+++ b/web/src/lib/logbatch.js
@@ -1,0 +1,40 @@
+// planBatch decides how many RUN-LOG lines one load step may insert,
+// bounding the total to `budget` even when a single terminal activity
+// entry's run-log expansion alone exceeds it (#328 r4 #5).
+//
+// sizes: RUN-LOG line count contributed by each activity entry (0 for a
+//        plain activity row, or a terminal whose expansion produced no
+//        lines), newest-first — the API returns the page newest-first, and
+//        continuity with the loaded scrollback starts at the page's newest
+//        entry.
+// budget: max RUN-LOG lines per step. Plain activity rows are never
+//         budgeted: they cost one line each and always materialize, so an
+//         oversized terminal expansion can't defer the rest of the page
+//         out of the first paint (#328).
+//
+// Returns { fullCount, split }:
+//   - fullCount = number of leading activity entries to consume IN FULL.
+//   - split = number of RUN-LOG lines to consume from the NEXT entry (the
+//     one whose expansion would exceed the remaining budget), or 0 when no
+//     entry needs splitting.
+//
+// split only ever applies to terminal entries (sizes > 0); a plain activity
+// entry (size 0) never exceeds the budget and is always consumed. Unlike
+// the old selectBatchCount, this NEVER lets a single entry's expansion blow
+// past the budget — an oversized terminal entry is split so its run-log
+// lines are inserted across multiple bounded steps.
+export function planBatch(sizes, budget) {
+  let total = 0
+  let fullCount = 0
+  for (let i = 0; i < sizes.length; i++) {
+    const size = sizes[i]
+    if (total + size > budget) {
+      const remaining = budget - total
+      // remaining <= 0 means the budget is exactly filled: stop, no split.
+      return { fullCount, split: remaining > 0 ? remaining : 0 }
+    }
+    total += size
+    fullCount++
+  }
+  return { fullCount, split: 0 }
+}

--- a/web/src/lib/logbatch.test.js
+++ b/web/src/lib/logbatch.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { planBatch } from './logbatch.js'
+
+describe('planBatch', () => {
+  it('consumes the whole page in full when it fits the budget', () => {
+    expect(planBatch([1, 1, 1, 1], 150)).toEqual({ fullCount: 4, split: 0 })
+  })
+
+  it('splits a mid-page terminal entry that overflows the budget', () => {
+    // 40+40+40 = 120 consumed; the fourth 40-line entry overflows → split 30.
+    expect(planBatch([40, 40, 40, 40, 40], 150)).toEqual({ fullCount: 3, split: 30 })
+  })
+
+  it('splits an oversized leading entry instead of blowing the budget', () => {
+    expect(planBatch([200], 150)).toEqual({ fullCount: 0, split: 150 })
+  })
+
+  it('never defers plain activity rows (size 0) behind an oversized terminal', () => {
+    // 166 run-log lines blow the budget alone; the zero-size (plain) entries
+    // after it are always fully consumed — the caller materializes their rows
+    // and defers only the terminal's run-log lines.
+    expect(planBatch([166, 0, 0, 0], 150)).toEqual({ fullCount: 0, split: 150 })
+  })
+
+  it('splits the entry that overflows a partially-filled budget', () => {
+    expect(planBatch([40, 40, 100], 150)).toEqual({ fullCount: 2, split: 70 })
+  })
+
+  it('treats a batch exactly at the budget as fully consumed (no split)', () => {
+    expect(planBatch([75, 75, 1], 150)).toEqual({ fullCount: 2, split: 0 })
+  })
+
+  it('handles an empty page', () => {
+    expect(planBatch([], 150)).toEqual({ fullCount: 0, split: 0 })
+  })
+})

--- a/web/src/lib/logline.js
+++ b/web/src/lib/logline.js
@@ -1,0 +1,75 @@
+// logline.js — uniform `message | metadata` rendering for the Logs console.
+// Every log line — activity, summary, and run-log rows alike — renders as
+//
+//   <human-readable message> | <key=value metadata>
+//
+// The runner emits every line as `phrase, key=value, key=value…` (message
+// convention #328), so the metadata is the key=value tail of the message
+// itself: the split point is the first `, key=` boundary. Lines without a
+// kv tail render bare. For activity rows, structured details fields whose
+// key is not already in the message tail are appended (type, destination,
+// schedule), so nothing that used to be visible is lost and nothing
+// renders twice.
+
+import { lineTimestamp } from './tsformat.js'
+
+// Splits a log message at the first `, key=` boundary into its
+// human-readable part and its key=value metadata tail.
+export function splitMessageMeta(message) {
+  if (!message) return { message: '', meta: '' }
+  const m = /,\s*[A-Za-z_][A-Za-z0-9_]*=/.exec(message)
+  if (!m) return { message, meta: '' }
+  return {
+    message: message.slice(0, m.index),
+    meta: message.slice(m.index + 1).replace(/^\s+/, ''),
+  }
+}
+
+// Keys present in a rendered meta tail, so structured extras can be
+// deduped against what the message itself already carries.
+function metaKeys(meta) {
+  const keys = {}
+  for (const m of meta.matchAll(/(?:^|,\s*)([A-Za-z_][A-Za-z0-9_]*)=/g)) keys[m[1]] = true
+  return keys
+}
+
+function capitalize(s) {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : ''
+}
+
+// Structured details fields rendered as metadata for activity rows.
+// [source key in entry.meta, display key]; job falls back to entry.jobName.
+const DETAIL_FIELDS = [
+  ['job', 'job'],
+  ['backup_type', 'type'],
+  ['destination', 'destination'],
+  ['items', 'items'],
+  ['schedule', 'schedule'],
+]
+
+// Returns { message, meta } for a unified log entry: the split message and
+// its metadata tail, with activity-only structured extras appended.
+export function formatLine(entry) {
+  const { message, meta } = splitMessageMeta(entry.message)
+  if (entry.type !== 'activity' || !entry.meta) return { message, meta }
+  const present = metaKeys(meta)
+  const extras = []
+  for (const [srcKey, displayKey] of DETAIL_FIELDS) {
+    if (present[displayKey]) continue
+    const val = srcKey === 'job' ? (entry.meta.job || entry.jobName) : entry.meta[srcKey]
+    if (val == null || val === '') continue
+    if (displayKey === 'schedule') extras.push(`schedule="${val}"`)
+    else extras.push(`${displayKey}=${displayKey === 'type' ? capitalize(val) : val}`)
+  }
+  const combined = extras.length > 0 ? [meta, extras.join(', ')].filter(Boolean).join(', ') : meta
+  return { message, meta: combined }
+}
+
+// Single-line log text shared by copy, copy-all, and export:
+// `YYYY-MM-DD HH:MM:SS  level  category  message | metadata`.
+// Matches the console's visual layout; the raw JSON meta blob is dropped.
+export function logLine(entry) {
+  const { message, meta } = formatLine(entry)
+  const level = entry.level === 'warning' ? 'warn' : (entry.level || 'info')
+  return `${lineTimestamp(entry.ts)}  ${level}  ${entry.category}  ${message}${meta ? ` | ${meta}` : ''}`
+}

--- a/web/src/lib/logline.test.js
+++ b/web/src/lib/logline.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { splitMessageMeta, formatLine, logLine } from './logline.js'
+
+describe('splitMessageMeta', () => {
+  it.each([
+    // name, message, wantMessage, wantMeta
+    ['null message', null, '', ''],
+    ['empty message', '', '', ''],
+    ['no kv tail stays whole', 'Backup started', 'Backup started', ''],
+    ['comma not followed by key= stays whole', 'Error: something bad happened, retrying', 'Error: something bad happened, retrying', ''],
+    ['terminal summary splits at first kv', 'Backup finished, job="USB", status=completed, items=1/1, failed=0, size=3 GB, duration=2m15s', 'Backup finished', 'job="USB", status=completed, items=1/1, failed=0, size=3 GB, duration=2m15s'],
+    ['started line splits at job', 'Backup started, job="USB"', 'Backup started', 'job="USB"'],
+    ['per-item backed up line splits', 'Backed up src-a (folder), size=42 KB', 'Backed up src-a (folder)', 'size=42 KB'],
+    ['uploaded line splits at file', 'Uploaded Plex, file=volume_0.tar', 'Uploaded Plex', 'file=volume_0.tar'],
+    ['health check splits', 'Health check, container=Plex, status=ok', 'Health check', 'container=Plex, status=ok'],
+    ['message with comma inside the phrase still splits at kv', 'Backed up "src, old", size=1 KB', 'Backed up "src, old"', 'size=1 KB'],
+  ])('%s', (_name, message, wantMessage, wantMeta) => {
+    const got = splitMessageMeta(message)
+    expect(got.message).toBe(wantMessage)
+    expect(got.meta).toBe(wantMeta)
+  })
+})
+
+describe('formatLine', () => {
+  it.each([
+    // name, entry, wantMessage, wantMeta
+    [
+      'run-log row keeps its inline kv tail, no extras',
+      { type: 'runlog', message: 'Backup finished, job="USB", status=completed, items=1/1, failed=0, size=3 GB, duration=2m15s', meta: null },
+      'Backup finished',
+      'job="USB", status=completed, items=1/1, failed=0, size=3 GB, duration=2m15s',
+    ],
+    [
+      'activity row appends details extras not in the tail',
+      { type: 'activity', message: 'Backup started, job="USB"', meta: { job_name: 'USB', backup_type: 'full', schedule: 'daily' }, jobName: 'USB' },
+      'Backup started',
+      'job="USB", type=Full, schedule="daily"',
+    ],
+    [
+      'activity row with no kv tail renders extras as the whole meta',
+      { type: 'activity', message: 'Backup failed', meta: { job: 'USB' }, jobName: 'USB' },
+      'Backup failed',
+      'job=USB',
+    ],
+    [
+      'details fields already in the message tail are not duplicated',
+      { type: 'activity', message: 'Backup finished, job="USB", status=completed, items=1/1', meta: { job_name: 'USB', backup_type: 'incremental', items: '1/1' }, jobName: 'USB' },
+      'Backup finished',
+      'job="USB", status=completed, items=1/1, type=Incremental',
+    ],
+    [
+      'activity row without details renders the bare tail',
+      { type: 'activity', message: 'Backup finished, status=completed', meta: null, jobName: '' },
+      'Backup finished',
+      'status=completed',
+    ],
+  ])('%s', (_name, entry, wantMessage, wantMeta) => {
+    const got = formatLine(entry)
+    expect(got.message).toBe(wantMessage)
+    expect(got.meta).toBe(wantMeta)
+  })
+})
+
+describe('logLine', () => {
+  it('renders the console layout with message | metadata', () => {
+    const entry = {
+      ts: '2026-08-21T10:45:48',
+      level: 'info',
+      category: 'backup',
+      type: 'runlog',
+      message: 'Backup finished, job="USB", status=completed, items=1/1, failed=0, size=3 GB, duration=2m15s',
+    }
+    expect(logLine(entry)).toBe('2026-08-21 10:45:48  info  backup  Backup finished | job="USB", status=completed, items=1/1, failed=0, size=3 GB, duration=2m15s')
+  })
+
+  it('renders a bare message without a trailing pipe', () => {
+    const entry = { ts: '2026-08-21T10:45:48', level: 'info', category: 'backup', type: 'activity', message: 'Backup started' }
+    expect(logLine(entry)).toBe('2026-08-21 10:45:48  info  backup  Backup started')
+  })
+
+  it('normalizes warning level and unparseable ts', () => {
+    const entry = { ts: 'not-a-date', level: 'warning', category: 'system', type: 'activity', message: 'Disk low' }
+    expect(logLine(entry)).toBe('--:--:--  warn  system  Disk low')
+  })
+})

--- a/web/src/lib/logsearch.js
+++ b/web/src/lib/logsearch.js
@@ -1,0 +1,21 @@
+// logsearch.js — pure search filter for the unified log console (#328 r4 #9).
+// Case-insensitive substring match across the fields a user would expect to
+// search: message, level, category, job name, and the meta fields rendered
+// on the row (type=…, destination=…, items=…, schedule=…). An
+// empty/whitespace query matches everything.
+
+export function matchesSearch(entry, query) {
+  const q = (query || '').trim().toLowerCase()
+  if (!q) return true
+  // The meta (parsed details JSON) is part of what the console displays —
+  // e.g. `| type=Differential, destination=hdd, items=15` on activity rows —
+  // so a term visible on the line must match even when the message text
+  // itself does not mention it ("diff" must find "Backup started … |
+  // type=Differential") (#328).
+  const metaText = entry.meta ? JSON.stringify(entry.meta) : ''
+  const haystack = [entry.message, entry.level, entry.category, entry.jobName, metaText]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+  return haystack.includes(q)
+}

--- a/web/src/lib/logsearch.test.js
+++ b/web/src/lib/logsearch.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { matchesSearch } from './logsearch.js'
+
+const entry = {
+  message: 'Anomaly detected in backup',
+  level: 'warn',
+  category: 'health',
+  jobName: 'docker',
+}
+
+describe('matchesSearch', () => {
+  it('matches an empty or whitespace-only query', () => {
+    expect(matchesSearch(entry, '')).toBe(true)
+    expect(matchesSearch(entry, '   ')).toBe(true)
+  })
+
+  it('matches message text case-insensitively', () => {
+    expect(matchesSearch(entry, 'anomaly')).toBe(true)
+    expect(matchesSearch(entry, 'ANOMALY')).toBe(true)
+  })
+
+  it('matches the level field', () => {
+    expect(matchesSearch(entry, 'warn')).toBe(true)
+  })
+
+  it('matches the category field', () => {
+    expect(matchesSearch(entry, 'health')).toBe(true)
+  })
+
+  it('matches the job name field', () => {
+    expect(matchesSearch(entry, 'docker')).toBe(true)
+  })
+
+  it('does not match an absent term', () => {
+    expect(matchesSearch(entry, 'restore')).toBe(false)
+  })
+
+  it('matches the meta fields rendered on the row', () => {
+    const withMeta = { ...entry, meta: { backup_type: 'differential', destination: 'hdd', items: 15 } }
+    expect(matchesSearch(withMeta, 'diff')).toBe(true)
+    expect(matchesSearch(withMeta, 'differential')).toBe(true)
+    expect(matchesSearch(withMeta, 'hdd')).toBe(true)
+    expect(matchesSearch(withMeta, '15')).toBe(true)
+    expect(matchesSearch({ ...withMeta, meta: { backup_type: 'full' } }, 'diff')).toBe(false)
+  })
+
+  it('handles entries without meta', () => {
+    expect(matchesSearch(entry, 'anomaly')).toBe(true)
+    expect(matchesSearch(entry, 'diff')).toBe(false)
+  })
+
+  it('does not match a substring that is not present', () => {
+    expect(matchesSearch(entry, 'anomx')).toBe(false)
+  })
+})

--- a/web/src/lib/scrollanchor.js
+++ b/web/src/lib/scrollanchor.js
@@ -1,0 +1,12 @@
+// scrollanchor.js — pure arithmetic for scroll anchoring (#328 r3 #6, #8).
+//
+// When content is prepended (load-older) or reflowed (word-wrap toggle)
+// above the viewport, keeping the same element pinned at the same visual
+// position requires shifting scrollTop by the element's change in offset
+// from the container's top edge. The Logs page measures the offsets with
+// getBoundingClientRect and passes them here; this module holds only the
+// math so it is unit-testable without a DOM.
+
+export function anchoredScrollTop(prevScrollTop, elTopBefore, elTopAfter) {
+  return prevScrollTop + (elTopAfter - elTopBefore)
+}

--- a/web/src/lib/scrollanchor.test.js
+++ b/web/src/lib/scrollanchor.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { anchoredScrollTop } from './scrollanchor.js'
+
+describe('anchoredScrollTop', () => {
+  it('keeps scrollTop unchanged when the element does not move', () => {
+    expect(anchoredScrollTop(500, 0, 0)).toBe(500)
+  })
+
+  it('adds the element shift when content above grows (prepend)', () => {
+    // Element moves from 0 to 120px below the container top after a prepend:
+    // to keep it visually pinned, scrollTop must increase by 120.
+    expect(anchoredScrollTop(500, 0, 120)).toBe(620)
+  })
+
+  it('subtracts the element shift when content above shrinks', () => {
+    expect(anchoredScrollTop(300, 150, 40)).toBe(190)
+  })
+
+  it('handles a negative net shift', () => {
+    expect(anchoredScrollTop(80, 200, 0)).toBe(-120)
+  })
+})

--- a/web/src/lib/scrollflags.js
+++ b/web/src/lib/scrollflags.js
@@ -1,0 +1,18 @@
+// scrollflags.js — pure scroll-position predicates for the unified console
+// (#328 r5 #5). Extracting the predicates here keeps the boundary behavior
+// deterministic and unit-testable.
+
+const EDGE = 48        // px: "at top" / "near bottom" trigger band
+const LOAD_OLDER_EDGE = 200  // px: load-older triggers before the exact top
+
+export function atTop(scrollTop) {
+  return scrollTop < EDGE
+}
+
+export function nearTop(scrollTop) {
+  return scrollTop < LOAD_OLDER_EDGE
+}
+
+export function nearBottom(scrollTop, scrollHeight, clientHeight) {
+  return scrollHeight - scrollTop - clientHeight < EDGE
+}

--- a/web/src/lib/scrollflags.test.js
+++ b/web/src/lib/scrollflags.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { atTop, nearTop, nearBottom } from './scrollflags.js'
+
+describe('atTop', () => {
+  it('is at top within the edge band', () => {
+    expect(atTop(0)).toBe(true)
+    expect(atTop(47)).toBe(true)
+  })
+
+  it('is not at top past the edge band', () => {
+    expect(atTop(48)).toBe(false)
+    expect(atTop(200)).toBe(false)
+  })
+})
+
+describe('nearTop', () => {
+  it('is near top within the load-older band', () => {
+    expect(nearTop(0)).toBe(true)
+    expect(nearTop(199)).toBe(true)
+  })
+
+  it('is not near top past the load-older band', () => {
+    expect(nearTop(200)).toBe(false)
+    expect(nearTop(500)).toBe(false)
+  })
+})
+
+describe('nearBottom', () => {
+  it('is near bottom within the edge band', () => {
+    expect(nearBottom(400, 500, 100)).toBe(true) // 500-400-100 = 0
+    expect(nearBottom(360, 500, 100)).toBe(true) // 500-360-100 = 40 < 48
+  })
+
+  it('is not near bottom past the edge band', () => {
+    expect(nearBottom(0, 500, 100)).toBe(false)   // 400
+    expect(nearBottom(350, 500, 100)).toBe(false) // 50
+  })
+})

--- a/web/src/lib/tsformat.js
+++ b/web/src/lib/tsformat.js
@@ -1,0 +1,17 @@
+// tsformat.js — pure timestamp formatting for the unified log console
+// (#328 r4 #6). Produces a compact, fixed-width "YYYY-MM-DD HH:MM:SS" string
+// (24h) so every line carries a date, not just a time. Deterministic
+// (manual padding), so it is unit-testable without a locale/timezone
+// dependency.
+
+export function lineTimestamp(ts) {
+  const d = new Date(ts)
+  if (Number.isNaN(d.getTime())) return '--:--:--'
+  const yyyy = d.getFullYear()
+  const mo = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  const ss = String(d.getSeconds()).padStart(2, '0')
+  return `${yyyy}-${mo}-${dd} ${hh}:${mm}:${ss}`
+}

--- a/web/src/lib/tsformat.test.js
+++ b/web/src/lib/tsformat.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { lineTimestamp } from './tsformat.js'
+
+describe('lineTimestamp', () => {
+  it('formats a Date as "YYYY-MM-DD HH:MM:SS" in 24h', () => {
+    // Local constructor + local getters → timezone-independent.
+    const d = new Date(2026, 7, 19, 14, 23, 1) // Aug 19 2026 14:23:01 local
+    expect(lineTimestamp(d)).toBe('2026-08-19 14:23:01')
+  })
+
+  it('zero-pads single-digit month/day/hour/minute/second', () => {
+    const d = new Date(2026, 0, 5, 9, 3, 7) // Jan 5 2026 09:03:07 local
+    expect(lineTimestamp(d)).toBe('2026-01-05 09:03:07')
+  })
+
+  it('returns a placeholder for an invalid timestamp', () => {
+    expect(lineTimestamp('not-a-date')).toBe('--:--:--')
+  })
+})

--- a/web/src/lib/unifiedlog.svelte.js
+++ b/web/src/lib/unifiedlog.svelte.js
@@ -1,0 +1,720 @@
+// unifiedlog.svelte.js — merges activity-log entries with run-log lines into
+// one chronologically-sorted stream for the unified console on the Logs page.
+// Entries are sorted OLDEST-FIRST (newest at bottom, terminal-style).
+//
+// Loading strategy:
+//   • Initial load fetches the most recent batch of activity entries (default 30).
+//   • Terminal entries (run_log marker) are automatically expanded: their
+//     run-log lines are fetched and interleaved.
+//   • Older entries are loaded automatically via scroll-to-top detection
+//     (loadOlder called from the component's scroll handler).
+//   • Total entries in memory are capped at MAX_ENTRIES; oldest are pruned.
+//   • Duplicate activity+summary entries for the same run are deduped
+//     (backend logs both an activity entry and a run-log summary for
+//     backup/restore completions — only the run-log summary is kept).
+
+import { api } from './api.js'
+import { onWsMessage } from './ws.svelte.js'
+import { planBatch } from './logbatch.js'
+import { matchesSearch } from './logsearch.js'
+
+const BATCH_SIZE = 30       // activity entries per interactive page
+const FULL_LOAD_LIMIT = 1000 // activity entries per background full-history page (API clamps to 1000)
+const OLDER_BATCH_BUDGET = 150 // max unified entries added per loadOlder step
+// Hard cap on unified entries in memory. The console is designed to hold the
+// ENTIRE history (loadAll pins it, search loads it), so this is a safety
+// bound for pathological histories only — the DB itself caps activity_log at
+// MaxActivityLogRows (10k), and run-log lines are capped per run (#328).
+const MAX_ENTRIES = 50000
+const WS_DEDUP_CAP = 200    // seen-IDs cap for WS dedup
+const MIN_LOAD_OLDER_MS = 700 // floor for user-initiated loadOlder so the spinner reads as real work (#328 round 2)
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export function createUnifiedLogStore() {
+  let _entries = $state([])
+  let _loaded = $state(false)
+  let _loading = $state(false)
+  let _error = $state('')
+  let _hasMore = $state(false)
+  let _loadingOlder = $state(false)
+  let _oldestActivityId = $state(null) // cursor for "load older"
+  let _category = $state('')
+  let _levelFilter = $state('')
+  let _jobFilter = $state('')
+  let _search = $state('')
+  let _searching = $state(false) // background auto-load of older entries during search (#328)
+  let _pruned = $state(false)    // prune dropped oldest entries since the last fresh load (#328)
+  // Plain objects used as sets (key = id, value = true). Avoids svelte/prefer-svelte-reactivity
+  // lint rule on Set/Map constructors inside .svelte.js files.
+  let _expanded = {}   // activity IDs whose run-log has been fetched
+  let _seen = {}       // WS dedup ring
+  let _loadSeq = 0     // load() sequence token: stale async responses are discarded
+  let _contextSeq = 0  // bumped on every fresh load/reset: aborts an in-flight loadAll (#328)
+  let _pendingRunLogs = [] // leftover run-log lines from a split terminal expansion (#328 r4 #5)
+  let _fullHistoryLoaded = false // the buffer is (or is intended to become) the whole history (#328)
+
+  function reset() {
+    _entries = []
+    _loaded = false
+    _loading = false
+    _error = ''
+    _hasMore = false
+    _loadingOlder = false
+    _oldestActivityId = null
+    _expanded = {}
+    _seen = {}
+    _pendingRunLogs = []
+    _pruned = false
+    _fullHistoryLoaded = false
+    _contextSeq++
+  }
+
+  // Category is applied server-side via load(); the job and level filters are
+  // client-side and independent — switching category must NOT clear them, so
+  // filters compose (#328 round 2).
+  async function setCategory(v) {
+    _category = v
+    await load()
+    // If the active job filter no longer appears in the (category-filtered)
+    // buffer, fall back to All so the Job dropdown doesn't render blank when
+    // the category has no entries for that job (#328 r3 #1). (Level and
+    // category options are static, so only the dynamic Job list can go blank.)
+    if (_jobFilter && !jobs.includes(_jobFilter)) {
+      _jobFilter = ''
+    }
+    // Background: load the new category's entire history so the console
+    // stays uniformly scrollable to the true end (#328).
+    loadAll()
+  }
+  function setLevelFilter(v) { _levelFilter = v }
+  function setJobFilter(v) { _jobFilter = v }
+  function setSearchFilter(v) {
+    _search = v
+    if (!v) {
+      _searching = false
+      return
+    }
+    // Search is client-side over the loaded buffer, so a term that only
+    // matches an OLDER (not-yet-loaded) log would prematurely show "No
+    // logs". Load the ENTIRE history, then let the client-side filter
+    // narrow it: stopping at the first match hid deeper matches and left
+    // the tail of history unreachable while a query was active (#328 issue 2).
+    if (_searching) return                 // guard against concurrent loops
+    if (!_hasMore && !_pruned) return      // buffer already spans the whole history
+    _searching = true
+    ;(async () => {
+      try {
+        if (!_hasMore && _pruned) {
+          // The cursor is exhausted but the buffer was truncated (the scroll
+          // window dropped its oldest entries): a search over this window
+          // would miss the dropped older logs. Reload from the newest page
+          // so the search covers the whole history (#328).
+          await load()
+        }
+        while (_search && _hasMore) {
+          // Big pages + silent: a full-history search must not make ~333
+          // round-trips of BATCH_SIZE, and a transient error mid-search must
+          // not surface as the console-wide error box (the scroll path
+          // reports errors; the background search just retries) (#328).
+          await loadOlder({ limit: FULL_LOAD_LIMIT, silent: true })
+        }
+        // The loop ended because _hasMore is false: the buffer now IS the
+        // whole history. Pin it — pruning would drop the oldest entries
+        // while _hasMore stays false, so the "— End of logs —" marker would
+        // display over a truncated buffer and lie about the end (#328).
+        // (Guard on _search: a query cleared mid-loop aborts the load.)
+        if (_search) _fullHistoryLoaded = true
+      } finally {
+        _searching = false
+      }
+    })()
+  }
+
+  // ---- Unified entry shape ----
+  // { id, ts, level, message, type, category, jobName, jobId, runId, meta }
+
+  function makeUnifiedEntry(raw, overrides = {}) {
+    const meta = raw.details ? tryParse(raw.details) : null
+    return {
+      id: raw.id,
+      ts: raw.created_at || raw.ts,
+      level: raw.level,
+      message: raw.message,
+      type: overrides.type || 'activity',
+      category: raw.category || 'backup',
+      jobName: overrides.jobName || '',
+      jobId: overrides.jobId || null,
+      // Normalize run_id out of the details JSON so dedupe can correlate
+      // activity entries with their run-log summaries (details is stored as
+      // a JSON string like {"run_id":203,...} in the activity_log table).
+      runId: overrides.runId || meta?.run_id || null,
+      meta,
+      ...overrides,
+    }
+  }
+
+  function makeRunLogUnified(rle, activityMeta) {
+    return {
+      id: `rl-${rle.id}`,
+      ts: rle.ts,
+      level: rle.level || 'info',
+      message: rle.message,
+      type: 'runlog',
+      category: activityMeta?.category || 'backup',
+      jobName: activityMeta?.jobName || '',
+      jobId: activityMeta?.jobId || null,
+      runId: rle.run_id,
+      meta: rle.data ? tryParse(rle.data) : null,
+    }
+  }
+
+  // ---- Parsing helpers ----
+
+  function tryParse(str) {
+    if (!str) return null
+    if (typeof str === 'object') return str
+    try { return JSON.parse(str) } catch { return null }
+  }
+
+  // Extract job name/id from activity details
+  function jobFromDetails(parsed) {
+    if (!parsed) return {}
+    return {
+      jobName: parsed.job_name || '',
+      jobId: parsed.job_id || null,
+    }
+  }
+
+  // Parse an ISO timestamp string to epoch ms.
+  function tsMs(ts) {
+    const n = Date.parse(ts)
+    return Number.isNaN(n) ? 0 : n
+  }
+
+  // ---- Loading ----
+
+  // load() — full reset: fetch the newest page and REPLACE the buffer.
+  // Used on mount, category switch, and purge.
+  async function load() {
+    return _loadNewest(true)
+  }
+
+  // loadNewer() — incremental top-up: fetch the newest page and MERGE it into
+  // the scrollback (idempotent; dedup by id). This is the "newer" side of the
+  // cursor-keyed lazy-load (the "older" side is loadOlder, keyed on
+  // _oldestActivityId). Used by the poll timer and scroll-to-bottom refresh.
+  async function loadNewer() {
+    return _loadNewest(false)
+  }
+
+  // _loadNewest fetches the newest activity page and expands its terminal
+  // entries. With fresh=true the console is replaced; with fresh=false the
+  // batch is MERGED into the loaded scrollback so poll cycles don't discard
+  // "Load older" history.
+  async function _loadNewest(fresh) {
+    const seq = ++_loadSeq
+    _loading = true
+    _error = ''
+    try {
+      const activityEntries = (await api.getActivity(BATCH_SIZE, _category)) || []
+      if (seq !== _loadSeq) return
+
+      // Terminal entries (run_log flag) carry the run whose log expands.
+      // The fresh path fetches and materializes them all (bounded by
+      // planBatch); the merge path only handles first-seen ones.
+      const terminal = activityEntries.filter(e => {
+        const d = tryParse(e.details)
+        return d?.run_log === true
+      })
+
+      // Seed the WS dedup ring with fetched ids so a broadcast racing this
+      // fetch can't insert a duplicate of an entry we already have.
+      for (const ae of activityEntries) _seen[ae.id] = true
+
+      const oldestFetched = activityEntries.length > 0 ? activityEntries[activityEntries.length - 1].id : null
+
+      if (fresh) {
+        _expanded = {}
+        _pendingRunLogs = []
+        _pruned = false
+        _fullHistoryLoaded = false
+        _contextSeq++
+
+        // Expand terminal entries in parallel, then merge. Only the fresh
+        // path fetches: the merge path must NOT refetch every terminal on
+        // the page each poll (bounded, idempotent — see the else branch).
+        const runLogs = await fetchRunLogsForBatch(terminal)
+        if (seq !== _loadSeq) return
+
+        // Per-entry unified rows, newest-first. The fresh path runs these
+        // through planBatch so an oversized terminal run's expansion is
+        // bounded and split (overflow drains via _pendingRunLogs), instead
+        // of dumping every run-log line on the initial load (#328 r5 #8).
+        const perEntry = activityEntries.map(ae => buildUnified([ae], runLogs))
+        // The step budget bounds RUN-LOG lines only: plain activity rows
+        // (health checks, started rows) are one line each and must always
+        // materialize — an oversized terminal expansion must not defer the
+        // rest of the newest page out of the first paint (the console
+        // visibly flipped when those rows appeared on the next merge).
+        const { fullCount, split } = planBatch(
+          perEntry.map(list => list.filter(e => e.type === 'runlog').length),
+          OLDER_BATCH_BUDGET,
+        )
+        let newUnified = perEntry.slice(0, fullCount).flat()
+        let consumed = fullCount
+        if (split > 0) {
+          const splitEntry = perEntry[fullCount]
+          newUnified = [...newUnified, ...splitEntry.slice(0, split)]
+          // A terminal run's log ends in its "… finished" summary — the line an
+          // operator most needs. Keep that tail line in this batch and defer
+          // only the middle lines, so the terminal status renders immediately
+          // instead of surfacing on a later load-older step (#328 r9 #5).
+          const middle = splitEntry.slice(split, -1)
+          const tail = splitEntry.slice(-1)
+          if (tail.length > 0) newUnified = [...newUnified, ...tail]
+          if (middle.length > 0) _pendingRunLogs = [..._pendingRunLogs, ...middle]
+          consumed++
+        }
+        // Everything after the split point: materialize the activity rows now
+        // (they cost no budget) and defer only the run-log lines to the
+        // pending drain, so the newest page is fully present at first paint.
+        for (let i = consumed; i < perEntry.length; i++) {
+          const rows = perEntry[i].filter(e => e.type !== 'runlog')
+          if (rows.length > 0) newUnified = [...newUnified, ...rows]
+          const rl = perEntry[i].filter(e => e.type === 'runlog')
+          if (rl.length > 0) _pendingRunLogs = [..._pendingRunLogs, ...rl]
+        }
+        // Every terminal on the page is now accounted for: its lines are in
+        // the buffer or in _pendingRunLogs, so no later step re-expands it.
+        for (const ae of activityEntries) {
+          const d = tryParse(ae.details)
+          if (d?.run_log === true) _expanded[ae.id] = true
+        }
+        _entries = prune(dedupeSummaries(newUnified).sort((a, b) => tsMs(a.ts) - tsMs(b.ts)))
+        _oldestActivityId = activityEntries.length > 0 ? activityEntries[activityEntries.length - 1].id : null
+        _hasMore = (activityEntries.length === BATCH_SIZE) || (_pendingRunLogs.length > 0)
+      } else {
+        // Merge path (poll / scroll-to-bottom refresh). Bounded and
+        // idempotent: already-expanded terminals are NOT refetched or
+        // re-materialized (their lines are already in the buffer or in
+        // _pendingRunLogs), and first-seen expansions are split through
+        // planBatch exactly like the fresh path (#328).
+        //
+        // First, drain deferred lines from a previously split terminal at
+        // the same bounded rate loadOlder uses. This matters when the
+        // buffer is pinned to the full history (_hasMore false): nothing
+        // else would drive the drain (loadAll and the scroll path both
+        // require _hasMore), so a long run first seen mid-poll would
+        // otherwise stall mid-log. _hasMore is intentionally NOT touched
+        // here (see the note below).
+        if (_pendingRunLogs.length > 0) {
+          const take = _pendingRunLogs.slice(0, OLDER_BATCH_BUDGET)
+          _pendingRunLogs = _pendingRunLogs.slice(OLDER_BATCH_BUDGET)
+          const seenIds = {}
+          const merged = [...take, ..._entries].filter(e => {
+            if (seenIds[e.id]) return false
+            seenIds[e.id] = true
+            return true
+          })
+          _entries = prune(dedupeSummaries(merged).sort((a, b) => tsMs(a.ts) - tsMs(b.ts)))
+        }
+
+        // Only terminal entries NOT already expanded need their run log
+        // fetched. Exception — the catch-up that surfaces a missing
+        // terminal summary: an expanded terminal whose expansion produced
+        // no runlog lines (transient fetch failure, or a run that only
+        // started logging after the first fetch) is retried so its lines
+        // (or its summary) can still appear on a later poll.
+        const needExpansion = terminal.filter(ae => {
+          if (!_expanded[ae.id]) return true
+          const runId = tryParse(ae.details)?.run_id
+          return runId != null &&
+            !_entries.some(e => e.type === 'runlog' && e.runId === runId) &&
+            !_pendingRunLogs.some(e => e.type === 'runlog' && e.runId === runId)
+        })
+        const runLogs = await fetchRunLogsForBatch(needExpansion)
+        if (seq !== _loadSeq) return
+        for (const ae of needExpansion) _expanded[ae.id] = true
+
+        // Materialize only what contributes something new: plain activity
+        // rows plus terminals that were (re)expanded this step. Already
+        // expanded terminals contribute nothing — their lines are in the
+        // buffer and their summary rows were superseded by those lines.
+        const expansionIds = Object.fromEntries(needExpansion.map(ae => [ae.id, true]))
+        const needsMaterialization = activityEntries.filter(ae => {
+          const d = tryParse(ae.details)
+          if (d?.run_log === true) return expansionIds[ae.id] === true
+          return true
+        })
+        const perEntry = needsMaterialization.map(ae => buildUnified([ae], runLogs))
+        const { fullCount, split } = planBatch(
+          perEntry.map(list => list.filter(e => e.type === 'runlog').length),
+          OLDER_BATCH_BUDGET,
+        )
+        let newUnified = perEntry.slice(0, fullCount).flat()
+        let consumed = fullCount
+        if (split > 0) {
+          const splitEntry = perEntry[fullCount]
+          newUnified = [...newUnified, ...splitEntry.slice(0, split)]
+          // Same as the fresh path: never defer a run's terminal summary.
+          const middle = splitEntry.slice(split, -1)
+          const tail = splitEntry.slice(-1)
+          if (tail.length > 0) newUnified = [...newUnified, ...tail]
+          if (middle.length > 0) _pendingRunLogs = [..._pendingRunLogs, ...middle]
+          consumed++
+        }
+        // Same as the fresh path: activity rows always materialize; only
+        // run-log lines are budgeted and deferred to the pending drain.
+        for (let i = consumed; i < perEntry.length; i++) {
+          const rows = perEntry[i].filter(e => e.type !== 'runlog')
+          if (rows.length > 0) newUnified = [...newUnified, ...rows]
+          const rl = perEntry[i].filter(e => e.type === 'runlog')
+          if (rl.length > 0) _pendingRunLogs = [..._pendingRunLogs, ...rl]
+        }
+        const seenIds = {}
+        const merged = [...newUnified, ..._entries].filter(e => {
+          if (seenIds[e.id]) return false
+          seenIds[e.id] = true
+          return true
+        })
+        _entries = prune(dedupeSummaries(merged).sort((a, b) => tsMs(a.ts) - tsMs(b.ts)))
+        if (oldestFetched != null) {
+          _oldestActivityId = _oldestActivityId != null ? Math.min(_oldestActivityId, oldestFetched) : oldestFetched
+        }
+        // NOTE: do NOT touch _hasMore here. loadNewer fetches the NEWEST page,
+        // which tells us nothing about whether OLDER entries remain. Flipping
+        // _hasMore back to true on a full page made the "End of logs" marker
+        // vanish ~30s after the user reached the end (#328 r10 #1).
+      }
+
+      _loaded = true
+    } catch (e) {
+      if (seq === _loadSeq) _error = e.message || 'Failed to load logs'
+    } finally {
+      if (seq === _loadSeq) _loading = false
+    }
+  }
+
+  async function loadOlder({ smooth = false, limit = BATCH_SIZE, silent = false } = {}) {
+    if (_loadingOlder) return
+    if (!_hasMore && _pendingRunLogs.length === 0) return
+    _loadingOlder = true
+    const startedAt = Date.now()
+    let loaded = false
+    try {
+      // Drain leftover run-log lines from a previously split terminal
+      // expansion first, so a long run's log is inserted across bounded
+      // steps instead of one unbounded dump (#328 r4 #5). A drain step
+      // inserts at most OLDER_BATCH_BUDGET lines and then returns; the
+      // activity fetch resumes on a later step once pending is empty.
+      if (_pendingRunLogs.length > 0) {
+        const take = _pendingRunLogs.slice(0, OLDER_BATCH_BUDGET)
+        _pendingRunLogs = _pendingRunLogs.slice(OLDER_BATCH_BUDGET)
+        _entries = prune(dedupeSummaries([..._entries, ...take]).sort((a, b) => tsMs(a.ts) - tsMs(b.ts)))
+        loaded = true
+        return
+      }
+
+      if (!_hasMore || !_oldestActivityId) return
+      const older = (await api.getActivity(limit, _category, _oldestActivityId)) || []
+      if (older.length === 0) { _hasMore = false; return }
+      loaded = true
+
+      const terminal = older.filter(e => {
+        const d = tryParse(e.details)
+        return d?.run_log === true && !_expanded[e.id]
+      })
+      const runLogs = await fetchRunLogsForBatch(terminal)
+
+      const perEntry = older.map(ae => buildUnified([ae], runLogs))
+      // The step budget bounds RUN-LOG lines only; plain activity rows
+      // always materialize (same rationale as the fresh path).
+      const { fullCount, split } = planBatch(
+        perEntry.map(list => list.filter(e => e.type === 'runlog').length),
+        OLDER_BATCH_BUDGET,
+      )
+
+      // Consume fullCount entries in full, plus `split` lines of the next
+      // terminal entry (whose expansion exceeded the remaining budget).
+      let newUnified = perEntry.slice(0, fullCount).flat()
+      let consumed = fullCount
+      if (split > 0) {
+        const splitEntry = perEntry[fullCount]
+        newUnified = [...newUnified, ...splitEntry.slice(0, split)]
+        // Same as the fresh path: never defer a run's terminal summary.
+        const middle = splitEntry.slice(split, -1)
+        const tail = splitEntry.slice(-1)
+        if (tail.length > 0) newUnified = [...newUnified, ...tail]
+        if (middle.length > 0) {
+          _pendingRunLogs = [..._pendingRunLogs, ...middle]
+        }
+        consumed++
+      }
+      for (let i = consumed; i < perEntry.length; i++) {
+        const rows = perEntry[i].filter(e => e.type !== 'runlog')
+        if (rows.length > 0) newUnified = [...newUnified, ...rows]
+        const rl = perEntry[i].filter(e => e.type === 'runlog')
+        if (rl.length > 0) _pendingRunLogs = [..._pendingRunLogs, ...rl]
+      }
+
+      // Every terminal entry in this batch is accounted for: its run log is
+      // captured either in the buffer or in _pendingRunLogs, so a later
+      // fetch must not re-expand it.
+      for (const ae of older) {
+        const d = tryParse(ae.details)
+        if (d?.run_log === true) _expanded[ae.id] = true
+      }
+
+      _oldestActivityId = older.length > 0 ? older[older.length - 1].id : null
+      _hasMore = (older.length === limit) || (_pendingRunLogs.length > 0)
+
+      const combined = [..._entries, ...newUnified]
+      _entries = prune(dedupeSummaries(combined).sort((a, b) => tsMs(a.ts) - tsMs(b.ts)))
+    } catch (e) {
+      // Background full-history loads (loadAll) must not surface a transient
+      // fetch error as the console-wide error box — they just stop and leave
+      // the scroll path (which reports errors) to retry (#328).
+      if (!silent) _error = e.message || 'Failed to load older logs'
+    } finally {
+      // Artificial minimum latency (see MIN_LOAD_OLDER_MS). Only hold the
+      // floor when a batch actually loaded — an empty page means the user is
+      // already at the oldest log, and lingering would show the spinner with
+      // nothing to show (#328 r3 #4).
+      if (smooth && loaded) {
+        const remaining = MIN_LOAD_OLDER_MS - (Date.now() - startedAt)
+        if (remaining > 0) await sleep(remaining)
+      }
+      _loadingOlder = false
+    }
+  }
+
+  // loadAll() — background full-history load: keep pulling older pages until
+  // the cursor is exhausted, so the console spans the ENTIRE history and can
+  // be scrolled to the true end (where the "— End of logs —" marker shows).
+  // This is the uniform model: the search view already loads everything and
+  // filters client-side; the standard view now does the same (#328).
+  // Big pages (FULL_LOAD_LIMIT) keep the round-trip count low. Stale loops
+  // abort via _contextSeq (fresh load / category switch / reset).
+  async function loadAll() {
+    if (_fullHistoryLoaded && !_hasMore) return // already complete
+    _fullHistoryLoaded = true
+    const ctx = _contextSeq
+    try {
+      while (ctx === _contextSeq && _hasMore && !_error) {
+        await loadOlder({ limit: FULL_LOAD_LIMIT, silent: true })
+      }
+    } finally {
+      // If the loop was aborted by a context change, the fresh load already
+      // reset _fullHistoryLoaded; leave it otherwise so the pinned buffer
+      // keeps the marker honest.
+      if (ctx === _contextSeq) _fullHistoryLoaded = !_hasMore ? true : _fullHistoryLoaded
+    }
+  }
+
+  // Build unified entries from activity entries and their run-log expansions.
+  function buildUnified(activityEntries, runLogs) {
+    const unified = []
+    for (const ae of activityEntries) {
+      const d = tryParse(ae.details)
+      const job = jobFromDetails(d)
+      const runId = d?.run_id || null
+      if (d?.run_log === true && runId) {
+        const rlEntries = runLogs[runId] || []
+        for (const rle of rlEntries) {
+          unified.push(makeRunLogUnified(rle, { category: ae.category, ...job }))
+        }
+        // The run-log lines end with the run's own summary line
+        // ("Backup finished status=…"), which already represents the
+        // completion — keeping the terminal activity row here would show
+        // the same completion twice. Keep the activity-derived summary row
+        // only when the expansion produced no lines (run-log fetch failed
+        // or the run pre-dates run-logging).
+        if (rlEntries.length === 0) {
+          unified.push(makeUnifiedEntry(ae, { type: 'summary', runId, ...job }))
+        }
+      } else if (d?.job_id) {
+        unified.push(makeUnifiedEntry(ae, { runId, ...job }))
+      } else {
+        unified.push(makeUnifiedEntry(ae, { runId }))
+      }
+    }
+    return unified
+  }
+
+  // Dedupe: a run's streamed run-log lines end with the run's own summary
+  // line, which supersedes the terminal summary row for the same run_id.
+  // Plain activity entries (e.g. "Backup started") are kept — they are no
+  // longer duplicated in the run-log stream (the server-side run-log
+  // "started" line was removed, #328), so they must survive. Also collapse
+  // duplicate summaries (same run_id).
+  function dedupeSummaries(arr) {
+    const runsWithRunlogLines = {}   // runs with actual streamed run-log lines
+    for (const e of arr) {
+      if (e.type === 'runlog' && e.runId) {
+        runsWithRunlogLines[e.runId] = true
+      }
+    }
+    const seen = {}
+    return arr.filter(e => {
+      // Run-log lines (which end with the run's own summary line) supersede
+      // the terminal summary row for the same run.
+      if (e.type === 'summary' && e.runId && runsWithRunlogLines[e.runId]) return false
+      const key = e.type === 'summary' && e.runId ? `s-${e.runId}` : e.id
+      if (seen[key]) return false
+      seen[key] = true
+      return true
+    })
+  }
+
+  async function fetchRunLogsForBatch(terminalActivityEntries) {
+    const ids = terminalActivityEntries.map(ae => tryParse(ae.details)?.run_id).filter(Boolean)
+    const runIds = Object.fromEntries(ids.map(id => [id, true]))
+    if (Object.keys(runIds).length === 0) return {}
+    const results = {}
+    await Promise.all(Object.keys(runIds).map(async runId => {
+      try {
+        // Tail-first (limit 1000 = the repo's ceiling): the run's terminal
+        // summary is its NEWEST line, and a head-first fetch would never
+        // reach it for runs longer than the limit — the console would show
+        // the run as mid-flight forever. The tail window always ends with
+        // the summary line (status/size/duration) (#328).
+        const res = await api.getRunLogs(runId, { tail: true, limit: 1000 })
+        if (res?.entries?.length) results[runId] = res.entries
+      } catch { /* partial failure ok */ }
+    }))
+    return results
+  }
+
+  function prune(arr) {
+    if (arr.length <= MAX_ENTRIES) return arr
+    // During an active search the whole point of loadOlder is to surface
+    // matches that may live far back in history. Dropping the oldest entries
+    // (what slice(-MAX_ENTRIES) does) would immediately discard the
+    // just-loaded older batch, so "older logs" never render during a search.
+    if (_search) return arr
+    // A pinned full-history buffer (_fullHistoryLoaded, _hasMore false) used
+    // to skip pruning so the "— End of logs —" marker wouldn't lie over a
+    // truncated buffer — but that let a long-lived page grow without bound
+    // (WS arrivals + poll merges). Capping from the oldest side here keeps
+    // the marker honest instead: the UI gates the marker on _pruned, and a
+    // subsequent search sees _pruned and reloads from the newest page before
+    // searching (see setSearchFilter) (#328).
+    _pruned = true
+    return arr.slice(-MAX_ENTRIES)
+  }
+
+  // ---- Filters ----
+
+  function matchesLevel(entry) {
+    if (!_levelFilter) return true
+    if (_levelFilter === 'warn') return entry.level === 'warn' || entry.level === 'warning'
+    return entry.level === _levelFilter
+  }
+
+  function matchesJob(entry) {
+    if (!_jobFilter) return true
+    return entry.jobName === _jobFilter
+  }
+
+  let filtered = $derived(
+    _entries.filter(e => matchesLevel(e) && matchesJob(e) && matchesSearch(e, _search))
+  )
+
+  let jobs = $derived.by(() => {
+    const seen = {}
+    for (const e of _entries) {
+      const key = e.jobName || ''
+      if (key && !seen[key]) seen[key] = true
+    }
+    return Object.keys(seen).sort()
+  })
+
+  // ---- WS real-time ----
+
+  function setupWs() {
+    const unsub = onWsMessage((msg) => {
+      if (msg.type === 'activity' && msg.entry) {
+        if (_category && msg.entry.category !== _category) return
+        if (_seen[msg.entry.id]) return
+        _seen[msg.entry.id] = true
+        const keys = Object.keys(_seen)
+        if (keys.length > WS_DEDUP_CAP) delete _seen[keys[0]]
+
+        const ae = msg.entry
+        const d = tryParse(ae.details)
+        const job = jobFromDetails(d)
+        const runId = d?.run_id || null
+        const newEntries = []
+
+        if (d?.run_log === true && runId) {
+          _expanded[ae.id] = true
+          // Live run-log lines for this run have already streamed in — the
+          // run's own summary line ("Backup finished status=…") represents
+          // the completion, so the activity row would duplicate it. Keep the
+          // row only when nothing streamed (fetch failure / legacy data).
+          if (!_entries.some(e => e.type === 'runlog' && e.runId === runId)) {
+            newEntries.push(makeUnifiedEntry(ae, { type: 'summary', runId, ...job }))
+          }
+        } else {
+          // Plain activity row (e.g. "Backup started") — keep it. The
+          // run-log "started" line was removed server-side, so this is the
+          // only "started" emission and must not be dropped (#328).
+          newEntries.push(makeUnifiedEntry(ae, { runId, ...job }))
+        }
+
+        _entries = prune([..._entries, ...newEntries].sort((a, b) => tsMs(a.ts) - tsMs(b.ts)))
+      } else if (msg.type === 'run_log' && msg.entry) {
+        const rle = msg.entry
+        const ctx = _entries.find(e => e.runId === rle.run_id && e.type === 'summary') ||
+                     _entries.find(e => e.runId === rle.run_id)
+        // Category-filtered consoles must not leak lines from runs outside
+        // the active category. The activity branch filters on the entry's
+        // own category, but a run-log line's category is only known via its
+        // run's context in the buffer — so resolve it and drop the line
+        // when the run is unknown or belongs to another category. (A live
+        // run in the active category always has its activity row in the
+        // buffer by the time its lines stream, since the run must start
+        // before it logs; a missed line self-heals on the next poll.)
+        if (_category && ctx?.category !== _category) return
+        const newRl = makeRunLogUnified(rle, {
+          category: ctx?.category || 'backup',
+          jobName: ctx?.jobName || '',
+          jobId: ctx?.jobId || null,
+        })
+        // Streamed run-log lines no longer supersede the "Backup started"
+        // activity row (the run-log "started" line was removed server-side,
+        // #328), so plain activity entries stay. Terminal-summary dedup is
+        // handled in the activity branch above. The line is inserted in
+        // chronological position, NOT appended: a streamed line for a run
+        // that is mid-buffer (older than the newest entries) must not render
+        // at the bottom as if it were the newest log — the next sorted merge
+        // would yank it back and the visible set at the bottom would flip
+        // (the "set replaced by another set" flash on refresh during a run).
+        _entries = prune([..._entries, newRl].sort((a, b) => tsMs(a.ts) - tsMs(b.ts)))
+      }
+    })
+    return unsub
+  }
+
+  return {
+    get entries() { return _entries },
+    get filtered() { return filtered },
+    get loaded() { return _loaded },
+    get loading() { return _loading },
+    get loadingOlder() { return _loadingOlder },
+    get error() { return _error },
+    setError(v) { _error = v },
+    get hasMore() { return _hasMore },
+    get pruned() { return _pruned },
+    get jobs() { return jobs },
+    get category() { return _category },
+    get levelFilter() { return _levelFilter },
+    get jobFilter() { return _jobFilter },
+    get search() { return _search },
+    get searching() { return _searching },
+    reset, load, loadNewer, loadOlder, loadAll, setCategory, setLevelFilter, setJobFilter, setSearchFilter, setupWs,
+  }
+}

--- a/web/src/lib/unifiedlog.test.js
+++ b/web/src/lib/unifiedlog.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Regression tests for the unified log store (issue #328).
+// The store previously had zero coverage; the scenarios below pin the
+// invariants that the console depends on:
+//   1. The FIRST PAINT materializes every activity row of the newest page,
+//      even when the newest terminal's run-log expansion exceeds the step
+//      budget (the budget bounds RUN-LOG lines only). Previously the whole
+//      page beyond the split point was deferred, so a set of rows (health
+//      checks etc.) appeared only on the next merge — the visible "set
+//      replaced by another set" flash on every refresh.
+//   2. Streamed (WS) run-log lines for a live run are inserted in
+//      CHRONOLOGICAL position, never appended at the bottom.
+//   3. The newest set stays at the bottom of the buffer across the refresh
+//      sequence (load -> fillViewport -> loadAll -> poll merges).
+
+// Server model used by all tests:
+//   - terminal run 60: activity id 400 (NEWEST, 15:58:04) + 200 run-log
+//     lines (15:55:00..15:56:40) — the expansion exceeds the 150-line step
+//     budget, exercising the split path exactly like a real long run
+//   - 5 health checks (ids 300..304, 15:57:59..15:58:03)
+//   - active run 7: plain "started" row (id 210, 15:54:00); its lines
+//     arrive only over WS (ts 15:54:10..30, chronologically mid-buffer)
+
+vi.mock('./api.js', () => {
+  const entries = [
+    {
+      id: 400, level: 'info', category: 'backup',
+      message: 'Backup completed: vms',
+      details: JSON.stringify({ run_id: 60, run_log: true, job_id: 1, job_name: 'vms' }),
+      created_at: '2026-08-21T15:58:04Z',
+    },
+    {
+      id: 210, level: 'info', category: 'backup',
+      message: 'Backup started: docker',
+      details: JSON.stringify({ run_id: 7, job_id: 1, job_name: 'docker' }),
+      created_at: '2026-08-21T15:54:00Z',
+    },
+  ]
+  for (let i = 0; i < 5; i++) {
+    entries.push({
+      id: 300 + i, level: 'info', category: 'health',
+      message: `Health check, container=c${i}, status=ok`,
+      details: JSON.stringify({ container_name: `c${i}` }),
+      created_at: new Date(Date.UTC(2026, 7, 21, 15, 57, 59) + i * 1000).toISOString(),
+    })
+  }
+  entries.sort((a, b) => b.id - a.id) // newest-first page
+
+  const runLogs = { 60: [] }
+  for (let i = 1; i <= 200; i++) {
+    runLogs[60].push({
+      id: 60000 + i, run_id: 60, level: 'info',
+      message: `run 60 line ${i}`,
+      data: '', ts: new Date(Date.UTC(2026, 7, 21, 15, 55, 0) + i * 500).toISOString(),
+    })
+  }
+
+  const api = {
+    getActivity: vi.fn(async (limit = 30, category = '', beforeId = 0) => {
+      let rows = entries
+      if (beforeId) rows = rows.filter(r => r.id < beforeId)
+      return rows.slice(0, limit)
+    }),
+    getRunLogs: vi.fn(async (runId) => ({ entries: runLogs[runId] || [] })),
+  }
+  return { api }
+})
+
+let wsHandler = null
+vi.mock('./ws.svelte.js', () => ({
+  onWsMessage: (fn) => { wsHandler = fn; return () => { wsHandler = null } },
+}))
+
+import { createUnifiedLogStore } from './unifiedlog.svelte.js'
+
+function bottomIds(store, n) {
+  return store.entries.slice(-n).map(e => `${e.type}:${e.id}@${new Date(e.ts).toISOString().slice(11, 19)}`)
+}
+
+describe('unified log store', () => {
+  let store
+  beforeEach(() => { wsHandler = null; store = createUnifiedLogStore() })
+
+  it('first paint includes every activity row even when a terminal expansion exceeds the budget', async () => {
+    // The newest page is [terminal run 60 (200 lines), 5 health checks,
+    // started row]. The terminal's expansion blows the 150-line step budget,
+    // but the health checks and the started row MUST be present immediately
+    // after load() — no loadOlder/merge may be required to surface them.
+    await store.load()
+
+    const ids = store.entries.map(e => e.id)
+    expect(ids).toContain(210)   // "Backup started" row
+    for (let i = 0; i < 5; i++) expect(ids).toContain(300 + i) // health checks
+
+    // The newest rows at the bottom are the health checks, not run-log lines.
+    expect(bottomIds(store, 3)).toEqual([
+      'activity:302@15:58:01',
+      'activity:303@15:58:02',
+      'activity:304@15:58:03',
+    ])
+  })
+
+  it('inserts WS-streamed run-log lines in chronological position, not at the bottom', async () => {
+    await store.load()
+    store.setupWs()
+
+    // Baseline: the bottom of the buffer is the newest health-check set
+    const baseline = bottomIds(store, 3)
+    expect(baseline.every(s => s.includes('15:58:0'))).toBe(true)
+
+    // Stream 3 lines for the ACTIVE run 7 (ts 15:54:10..30 — mid-buffer)
+    wsHandler({ type: 'run_log', entry: { id: 70001, run_id: 7, level: 'info', message: 'docker: inspecting container', data: '', ts: '2026-08-21T15:54:10Z' } })
+    wsHandler({ type: 'run_log', entry: { id: 70002, run_id: 7, level: 'info', message: 'docker: stopping container', data: '', ts: '2026-08-21T15:54:20Z' } })
+    wsHandler({ type: 'run_log', entry: { id: 70003, run_id: 7, level: 'info', message: 'docker: backing up', data: '', ts: '2026-08-21T15:54:30Z' } })
+
+    // The bottom set must NOT change: a streamed line is not the newest log.
+    expect(bottomIds(store, 3)).toEqual(baseline)
+
+    // The streamed lines sit chronologically between the "started" row and
+    // the terminal run 60's lines.
+    const rl = store.entries.filter(e => e.type === 'runlog' && e.runId === 7)
+    expect(rl).toHaveLength(3)
+    const first = store.entries.indexOf(rl[0])
+    const last = store.entries.indexOf(rl[2])
+    expect(new Date(store.entries[first - 1].ts).getTime()).toBeLessThanOrEqual(new Date(rl[0].ts).getTime())
+    expect(new Date(store.entries[last + 1].ts).getTime()).toBeGreaterThanOrEqual(new Date(rl[2].ts).getTime())
+  })
+
+  it('keeps the newest set at the bottom across load -> fill -> loadAll -> poll', async () => {
+    await store.load()
+    const afterLoad = bottomIds(store, 3)
+
+    await store.loadOlder() // drains the split terminal's deferred middle lines
+    await store.loadOlder() // cursor exhausted -> hasMore false
+
+    let guard = 0
+    while (store.hasMore && guard++ < 10) await store.loadOlder({ limit: 1000, silent: true })
+
+    await store.loadNewer()
+    const stable = bottomIds(store, 3)
+    expect(stable).toEqual(afterLoad)
+  })
+})

--- a/web/src/pages/Logs.svelte
+++ b/web/src/pages/Logs.svelte
@@ -609,7 +609,7 @@
 
       <!-- Scroll container -->
       <div bind:this={box} onscroll={handleScroll} oncopy={handleCopy}
-        class="bg-surface-1 border border-border rounded-xl overflow-y-auto font-mono text-xs leading-tight h-[72vh]"
+        class="console-scroll bg-surface-1 border border-border rounded-xl overflow-y-auto font-mono text-xs leading-tight h-[72vh]"
         style="overflow-anchor: none;"
         role="log"
       >

--- a/web/src/pages/Logs.svelte
+++ b/web/src/pages/Logs.svelte
@@ -1,59 +1,35 @@
 <script>
-  import { onMount } from 'svelte'
-  import { SvelteSet } from 'svelte/reactivity'
+  import { onMount, tick } from 'svelte'
   import { api, isReplicaMode } from '../lib/api.js'
-  import { formatDate, relTime, formatBytes, prettyAnomalySummary } from '../lib/utils.js'
+  import { formatDate } from '../lib/utils.js'
   import { copyText } from '../lib/clipboard.js'
-  import { onWsMessage } from '../lib/ws.svelte.js'
+  import { createFollowMarker, countNewEntries } from '../lib/followmarker.js'
+  import { anchoredScrollTop } from '../lib/scrollanchor.js'
+  import { nearBottom, nearTop, atTop as isAtTop } from '../lib/scrollflags.js'
   import { getLiveMode } from '../lib/runtime-config.js'
+  import { lineTimestamp } from '../lib/tsformat.js'
+  import { formatLine, logLine } from '../lib/logline.js'
+  import { createUnifiedLogStore } from '../lib/unifiedlog.svelte.js'
   import Spinner from '../components/Spinner.svelte'
   import EmptyState from '../components/EmptyState.svelte'
   import ConfirmDialog from '../components/ConfirmDialog.svelte'
 
-  let loading = $state(true)
-  let error = $state('')
-  let entries = $state([])
-  let category = $state('')
-  let levelFilter = $state('')
-  let limit = $state(100)
-  let expandedIds = $state(new SvelteSet())
-  // IDs we've auto-expanded for errors. Prevents auto-expand from undoing a
-  // user collapse on the next refresh, and prevents user-expanded non-error
-  // rows from getting wiped when the 5s poll re-renders the list (#83).
-  let autoExpandedIds = $state(new SvelteSet())
-  let autoScroll = $state(true)
-  let logContainer = $state(null)
+  const store = createUnifiedLogStore()
+  let follow = $state(true)
+  let atTop = $state(false) // scrolled to the top edge — controls the jump-to-top button (#328)
+  let suppressFollowPin = false // auto-follow must not fight an in-flight smooth scroll (#328)
+  let box = $state(null)
   let copiedId = $state(null)
   let confirmPurge = $state(false)
   let purging = $state(false)
-  const liveMode = getLiveMode()
+  let newCount = $state(0)
+  let followOffMarker = null
+  let wrap = $state(false) // console-wide line wrapping for message text (#328 round 2)
+  let focusedId = $state(null) // row highlighted to mark the user's focus (#328 r3 #7)
+  let copiedAll = $state(false) // transient confirmation for copy-all (#328 r3 #14)
+  let suppressNextScroll = false // one-shot: swallow the anchor write's own scroll event (#328 r8 #4)
 
-  // Real-time: prepend new activity entries via WebSocket instead of full reload
-  onMount(() => {
-    const unsub = onWsMessage((msg) => {
-      if (msg.type === 'activity' && msg.entry) {
-        if (category && msg.entry.category !== category) return
-        if (!entries.some(e => e.id === msg.entry.id)) {
-          entries = [msg.entry, ...entries].slice(0, limit)
-          // Auto-expand errors once; user can collapse and it stays collapsed.
-          if (msg.entry.level === 'error' && msg.entry.details && !autoExpandedIds.has(msg.entry.id)) {
-            expandedIds.add(msg.entry.id)
-            autoExpandedIds.add(msg.entry.id)
-          }
-          if (autoScroll && logContainer) {
-            requestAnimationFrame(() => logContainer.scrollTop = 0)
-          }
-        }
-      } else if (msg.type === 'activity') {
-        loadLogs(true)
-      }
-    })
-    const pollTimer = liveMode === 'poll' ? setInterval(() => { loadLogs(true) }, 5000) : null
-    return () => {
-      unsub()
-      if (pollTimer) clearInterval(pollTimer)
-    }
-  })
+  const liveMode = getLiveMode()
 
   const categories = [
     { value: '', label: 'All' },
@@ -64,152 +40,392 @@
   ]
 
   const levels = [
-    { value: '', label: 'All Levels' },
+    { value: '', label: 'All' },
     { value: 'error', label: 'Error' },
-    { value: 'warning', label: 'Warning' },
+    { value: 'warn', label: 'Warn' },
     { value: 'info', label: 'Info' },
   ]
 
-  // background=true refreshes the list in place (5s poll, WS fallback)
-  // without swapping it out for the spinner – the swap caused a visible
-  // flicker every poll tick (#135). Only the initial load and explicit
-  // user actions (filter change, Refresh) show the spinner.
-  async function loadLogs(background = false) {
-    if (!background) loading = true
-    try {
-      entries = (await api.getActivity(limit, category)) || []
-      error = ''
-      // Preserve user expand/collapse choices across the 5s auto-refresh.
-      // Only auto-expand errors we haven't seen before, and drop tracking
-      // state for entries that have aged out of the list.
-      const presentIds = new Set(entries.map(e => e.id))
-      for (const id of [...expandedIds]) {
-        if (!presentIds.has(id)) expandedIds.delete(id)
-      }
-      for (const id of [...autoExpandedIds]) {
-        if (!presentIds.has(id)) autoExpandedIds.delete(id)
-      }
-      for (const e of entries) {
-        if (e.level === 'error' && e.details && !autoExpandedIds.has(e.id)) {
-          expandedIds.add(e.id)
-          autoExpandedIds.add(e.id)
-        }
-      }
-    } catch (e) {
-      // A failed background poll keeps the current list on screen instead of
-      // flashing an error panel; the next tick retries anyway.
-      if (!background) {
-        error = e.message || 'Failed to load activity log'
-        entries = []
-      }
-    } finally {
-      loading = false
-    }
-  }
-
-  $effect(() => {
-    category
-    loadLogs()
+  onMount(async () => {
+    await store.load()
+    await fillViewport()
+    // Background full-history load: the console spans ALL logs (uniform with
+    // the search view), so scrolling reaches the true end and the
+    // "— End of logs —" marker shows there (#328).
+    store.loadAll()
+    const unsub = store.setupWs()
+    // Poll safety net: in poll mode the timer is the primary path (10s); in
+    // live/WS mode it runs as a slower catch-up (30s) so a missed WS event
+    // (e.g. a terminal summary lost across a reconnect) is still surfaced
+    // instead of waiting for a reload (#328 r9 #5).
+    const pollTimer = setInterval(() => store.loadNewer(), liveMode === 'poll' ? 10000 : 30000)
+    return () => { unsub(); if (pollTimer) clearInterval(pollTimer) }
   })
 
-  let filteredEntries = $derived(
-    levelFilter ? entries.filter(e => e.level === levelFilter) : entries
-  )
+  // Track new entries arriving while follow is off. The marker snapshots the
+  // buffer (newest ts + full id set) the moment follow turns off; newCount
+  // counts only entries that arrived strictly AFTER that snapshot, so
+  // pruning/batch merges can't skew it and same-second entries already on
+  // screen are never recounted (#328 round 2).
+  $effect(() => {
+    if (follow) {
+      followOffMarker = null
+      newCount = 0
+    } else if (store.entries.length) {
+      if (!followOffMarker) followOffMarker = createFollowMarker(store.entries)
+      newCount = countNewEntries(store.entries, followOffMarker)
+    } else {
+      newCount = 0
+    }
+  })
 
-  function levelColor(level) {
+  // Auto-follow: pin to bottom when follow is on. Suppressed while a
+  // load-older prepend is in flight — the prepend + scroll-anchor dance
+  // adjusts scrollTop itself, and a mid-prepend pin-to-bottom here would
+  // fight it (scrollbar jumps down then back up) (#328 r4 #3).
+  $effect(() => {
+    store.entries
+    if (follow && box && !store.loadingOlder && !suppressFollowPin) {
+      box.scrollTop = box.scrollHeight
+    }
+  })
+
+  // Scroll detection: auto-load older, toggle follow, reset new count.
+  // While a load is in flight (store.loadingOlder), ignore scroll events
+  // entirely — loadOlderAnchored is about to adjust scrollTop by the prepend
+  // delta, and a scroll event fired mid-adjustment would otherwise re-trigger
+  // loadOlder or toggle follow, fighting the adjustment (scroll teleport).
+  function handleScroll() {
+    if (!box) return
+    // Swallow the programmatic anchor write's own scroll event so it can't
+    // re-trigger loadOlder or toggle follow (#328 r8 #4).
+    if (suppressNextScroll) {
+      suppressNextScroll = false
+      return
+    }
+    atTop = isAtTop(box.scrollTop)
+    if (store.loadingOlder) return
+    const isNearBottom = nearBottom(box.scrollTop, box.scrollHeight, box.clientHeight)
+
+    if (isNearBottom && !follow) {
+      follow = true
+      newCount = 0
+      followOffMarker = null
+    } else if (!isNearBottom && follow) {
+      follow = false
+    }
+
+    // Auto-load older entries as the user approaches the top (not only at the
+    // exact top), so the next batch is already streaming in by the time they
+    // reach it. Loading older during a search is allowed: the client-side
+    // filter re-applies to newly prepended entries, so deeper matches surface
+    // as older batches load (#328 r9 #4).
+    if (nearTop(box.scrollTop) && store.hasMore && !store.loadingOlder) {
+      loadOlderAnchored()
+    }
+  }
+
+  // Dozzle-style older-batch load: keep the viewport pinned to the same log
+  // line (content-identity anchoring) while a cursor-keyed page of older
+  // entries is prepended. Anchoring on a visible row's offset — not the total
+  // scrollHeight delta — is what prevents the teleport-to-top that the old
+  // delta approach caused (#328 r3 #6). The prepend shifts the anchored row
+  // down by the height of the newly loaded entries, so scrollTop grows and
+  // leaves headroom above to scroll up and trigger the NEXT batch — one batch
+  // per gesture, never a continuous drain (#328 r4 #1 / QA round 6 #2).
+  async function loadOlderAnchored() {
+    if (!box || store.loadingOlder || !store.hasMore || !nearTop(box.scrollTop)) return
+    // Was the "— End of logs —" marker already on screen? When the FINAL
+    // batch loads it appears above the anchor row, shifting every row down
+    // by its height. The anchor must not compensate for that shift: the
+    // marker is the destination the user scrolled to, not content that
+    // should stay hidden above the viewport. Compensating for it pinned the
+    // reading position and pushed the marker out of view, so it only
+    // surfaced after a manual scroll-away-and-back (#328 issue 1).
+    const hadEndMarker = !store.hasMore && !store.pruned
+    // Content-identity anchor: pin the first visible row by id+offset before
+    // the prepend and restore it after, so the user's reading position stays
+    // put and the newly loaded entries appear above it. Anchoring (rather than
+    // pinning to scrollTop 0) also leaves headroom to keep scrolling up, so
+    // the NEXT batch loads on a normal upward gesture instead of requiring a
+    // down-then-up re-arm (#328 r9 #1).
+    const anchorId = topmostEntryId()
+    const anchorTopBefore = anchorId ? entryTopOffset(anchorId) : null
+    // No `smooth` floor here: it prepends the batch then delays the anchor by
+    // MIN_LOAD_OLDER_MS, which paints the shifted viewport for that window
+    // (the "temporary jump" users saw). Loading without the floor lets the
+    // anchor apply in the same frame as the prepend, so the viewport never
+    // detaches (#328 r9).
+    await store.loadOlder()
+    await tick()
+    if (anchorId != null && anchorTopBefore != null) {
+      let anchorTopAfter = entryTopOffset(anchorId)
+      if (anchorTopAfter != null) {
+        // The marker only rendered during THIS load: exclude its height from
+        // the shift so it lands in view at the top instead of above it.
+        if (!hadEndMarker && !store.hasMore && !store.pruned) {
+          const marker = box?.querySelector('[data-end-marker]')
+          if (marker) anchorTopAfter -= marker.offsetHeight
+        }
+        // Anchor against the CURRENT scrollTop — the user keeps scrolling while
+        // the batch loads — not a value captured before the await.
+        const next = anchoredScrollTop(box.scrollTop, anchorTopBefore, anchorTopAfter)
+        if (next !== box.scrollTop) {
+          suppressNextScroll = true
+          box.scrollTop = next
+        }
+      }
+    }
+  }
+
+  function jumpToPresent() {
+    follow = true
+    newCount = 0
+    followOffMarker = null
+    if (!box) return
+    // The auto-follow effect pins scrollTop instantly on every entries
+    // change — it would snap the viewport to the bottom and cancel the
+    // smooth animation the moment `follow` flips true above. Suppress the
+    // pin until the scroll settles (scrollend), then re-arm it (#328).
+    suppressFollowPin = true
+    box.scrollTo({ top: box.scrollHeight, behavior: 'smooth' })
+    const rearm = () => { suppressFollowPin = false }
+    if ('onscrollend' in window) {
+      box.addEventListener('scrollend', rearm, { once: true })
+    } else {
+      setTimeout(rearm, 700)
+    }
+  }
+
+  // With the full history loaded, jump straight to the oldest log (the top
+  // edge, where the "— End of logs —" marker sits) (#328).
+  function jumpToOldest() {
+    if (box) box.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  // Filter switches reset the view to live-tail: follow back on, new-entry
+  // marker cleared, viewport pinned to the newest line.
+  async function snapToBottom() {
+    follow = true
+    newCount = 0
+    followOffMarker = null
+    await tick()
+    if (box) box.scrollTop = box.scrollHeight
+  }
+
+  // Return the data-entry-id of the topmost visible row, or null if none.
+  function topmostEntryId() {
+    if (!box) return null
+    const boxTop = box.getBoundingClientRect().top
+    for (const row of box.querySelectorAll('[data-entry-id]')) {
+      if (row.getBoundingClientRect().top >= boxTop - 1) return row.dataset.entryId
+    }
+    return null
+  }
+
+  // Offset (px) of a row's top from the scroll container's top edge.
+  function entryTopOffset(id) {
+    const el = box?.querySelector(`[data-entry-id="${id}"]`)
+    if (!el || !box) return null
+    return el.getBoundingClientRect().top - box.getBoundingClientRect().top
+  }
+
+  // Line-wrap toggle: reflows every message span, so re-anchor the viewport
+  // the same way loadOlderAnchored does — capture the scroll
+  // geometry before the reflow, restore it after the DOM settles.
+  async function toggleWrap() {
+    // Anchor on the HIGHLIGHTED row (the user's explicit focus) so wrapping
+    // keeps that exact log line at the same screen position; fall back to the
+    // topmost visible row when nothing is highlighted (#328 r4 #10). Wrapping
+    // reflows content above AND below the viewport, so anchoring on content
+    // identity avoids over-correcting on the total-height delta (#328 r3 #8).
+    const anchorId = (focusedId && entryTopOffset(focusedId) != null) ? focusedId : topmostEntryId()
+    const prevScrollTop = box ? box.scrollTop : 0
+    const elTopBefore = anchorId ? entryTopOffset(anchorId) : null
+    wrap = !wrap
+    if (!box) return
+    await tick()
+    if (anchorId && elTopBefore != null) {
+      const elTopAfter = entryTopOffset(anchorId)
+      if (elTopAfter != null) box.scrollTop = anchoredScrollTop(prevScrollTop, elTopBefore, elTopAfter)
+    }
+  }
+
+  async function fillViewport() {
+    await tick()
+    let guard = 0
+    while (box && box.scrollHeight <= box.clientHeight && store.hasMore && !store.loadingOlder && guard < 20) {
+      guard++
+      await store.loadOlder()
+      await tick()
+    }
+  }
+
+  async function handleCategory(v) {
+    await store.setCategory(v)
+    await snapToBottom()
+  }
+
+  function handleLevel(v) {
+    store.setLevelFilter(v)
+    snapToBottom()
+  }
+
+  function handleJob(v) {
+    store.setJobFilter(v)
+    snapToBottom()
+  }
+
+  // Reset every filter back to its "All" default. Category is server-side,
+  // so only reload when it was actually non-default (#328 r5 #7).
+  async function resetFilters() {
+    store.setLevelFilter('')
+    store.setJobFilter('')
+    store.setSearchFilter('')
+    if (store.category !== '') {
+      await store.setCategory('')
+    }
+    await snapToBottom()
+  }
+
+  // ---- formatting ----
+
+  function fullTs(ts) {
+    const d = new Date(ts)
+    return Number.isNaN(d.getTime()) ? '' : formatDate(ts)
+  }
+
+  // One color per row for the left side (timestamp, level, category,
+  // message): the default text color, or the level color when the level
+  // changes.
+  function rowColor(level) {
     switch (level) {
-      case 'error': return 'bg-danger/15 text-danger'
-      case 'warning': return 'bg-warning/15 text-warning'
-      case 'info': return 'bg-info/15 text-info'
-      default: return 'bg-surface-4 text-text-dim'
+      case 'error': return 'text-danger'
+      case 'warn': case 'warning': return 'text-warning'
+      case 'debug': return 'text-text-dim/50'
+      default: return 'text-text'
     }
   }
 
-  function levelIcon(level) {
+  // Metadata renders as the muted color — a lighter, subordinate tone than
+  // the message. "Muted" describes the metadata text; the default row text
+  // keeps the plain default color. Exception: when the level changes
+  // (error/warn/debug) the ENTIRE line syncs to one color and the metadata
+  // matches it, so a red row reads as a red row end to end.
+  function metaColor(level) {
     switch (level) {
-      case 'error': return 'M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
-      case 'warning': return 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z'
-      case 'info': return 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
-      default: return 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+      case 'error': return 'text-danger'
+      case 'warn': case 'warning': return 'text-warning'
+      case 'debug': return 'text-text-dim/50'
+      default: return 'text-text-muted'
     }
   }
 
-  function categoryBadge(cat) {
-    switch (cat) {
-      case 'backup': return 'bg-vault/15 text-vault'
-      case 'restore': return 'bg-blue-500/15 text-blue-400'
-      case 'health': return 'bg-green-500/15 text-green-400'
-      case 'system': return 'bg-purple-500/15 text-purple-400'
-      default: return 'bg-surface-4 text-text-dim'
+  function levelBg(level) {
+    switch (level) {
+      case 'error': return 'border-l-danger'
+      case 'warn': case 'warning': return 'border-l-warning'
+      case 'debug': return 'border-l-text-dim/30'
+      default: return 'border-l-text-dim/20'
     }
   }
 
-  function tryParseJSON(str) {
-    if (!str) return null
-    try { return JSON.parse(str) } catch { return null }
+  function levelDisplay(level) {
+    if (level === 'warning') return 'warn'
+    return level || 'info'
   }
 
-  function toggleExpand(id) {
-    if (expandedIds.has(id)) expandedIds.delete(id)
-    else expandedIds.add(id)
-  }
+  // ---- actions ----
 
-  function formatDuration(seconds) {
-    if (!Number.isFinite(seconds) || seconds < 0) return String(seconds)
-    if (seconds < 1) return `${(seconds * 1000).toFixed(0)} ms`
-    if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)} s`
-    const m = Math.floor(seconds / 60)
-    const s = Math.round(seconds - m * 60)
-    if (m < 60) return s === 0 ? `${m} min` : `${m} min ${s} s`
-    const h = Math.floor(m / 60)
-    const mm = m - h * 60
-    return mm === 0 ? `${h} h` : `${h} h ${mm} min`
-  }
-
-  function formatDetailValue(key, value) {
-    if (key === 'size_bytes') return formatBytes(value)
-    if (key === 'duration_seconds') return formatDuration(Number(value))
-    if (key === 'duration_ms') return formatDuration(Number(value) / 1000)
-    // Anomaly detail floats: new entries are rounded at the source (issue
-    // #134), but entries stored before that fix carry full float64 precision.
-    if (key === 'z_score' || key === 'growth_factor') return Number(value).toFixed(2)
-    if (key === 'eta_days') return `${Number(value).toFixed(1)} days`
-    if (key === 'pct_free') return `${Number(value).toFixed(1)}%`
-    if (key === 'free_bytes' || key === 'total_bytes') return formatBytes(value)
-    if (key === 'slope_bytes_per_day') {
-      const n = Number(value)
-      return `${n < 0 ? '-' : ''}${formatBytes(Math.abs(n))}/day`
-    }
-    if (key === 'backup_type') return String(value).charAt(0).toUpperCase() + String(value).slice(1)
-    if (key === 'containers_checked') return `${value} checked`
-    if (key === 'containers_healthy') return `${value} healthy`
-    if (key === 'containers_unhealthy') return `${value} unhealthy`
-    if (Array.isArray(value)) return value.length ? value.join(', ') : '–'
-    return String(value)
-  }
-
-  function detailLabel(key) {
-    return key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
-  }
+  // Single-line log text lives in the shared logline module (message and
+  // metadata split at the first `, key=` boundary and joined with ` | `),
+  // so the console rows, copy button, copy-all, and export all render
+  // every log line identically (#328).
 
   async function copyEntry(entry) {
-    const text = `[${entry.level?.toUpperCase()}] [${entry.category}] ${prettyAnomalySummary(entry.message)}${entry.details ? '\n' + entry.details : ''}`
-    if (await copyText(text)) {
+    if (await copyText(logLine(entry))) {
       copiedId = entry.id
       setTimeout(() => { copiedId = null }, 2000)
     }
   }
 
+  // Highlight the row immediately on pointer-down (not on click, which waits
+  // for mouse-up) so the focus marker appears without delay (#328 r5 #2).
+  function handleRowPointerDown(entry) {
+    focusedId = entry.id
+  }
+
+  // Triple-click selects the whole line. Single-click highlighting is handled
+  // by onpointerdown (above).
+  function handleRowClick(e) {
+    if (e.detail === 3) {
+      // Capture the row synchronously: `e.currentTarget` is nulled once the
+      // event finishes dispatching, so reading it inside the rAF callback was
+      // always null and triple-click never selected anything (#328 r4 #8).
+      const row = e.currentTarget
+      if (!row) return
+      // Defer the selection so it overrides the browser's native triple-click
+      // fragment selection after it settles.
+      requestAnimationFrame(() => selectRowText(row))
+    }
+  }
+
+  function selectRowText(el) {
+    const range = document.createRange()
+    range.selectNodeContents(el)
+    const sel = window.getSelection()
+    sel.removeAllRanges()
+    sel.addRange(range)
+  }
+
+  // A flex row of many <span>s serializes to clipboard with a newline between
+  // each span, so a manual selection copies multi-line. Intercept the copy
+  // event and write a single clean line instead (#328 #3). Only override when
+  // the whole selection lives inside one row; multi-row selections fall
+  // through to the browser's native copy.
+  function handleCopy(e) {
+    const sel = window.getSelection()
+    if (!sel || sel.isCollapsed || sel.rangeCount === 0) return
+    const row = closestRow(sel.anchorNode)
+    if (!row || row !== closestRow(sel.focusNode)) return
+    // dataset.entryId is always a string; activity ids are numbers and
+    // run-log ids are the "rl-<n>" strings — compare on the string form so
+    // the single-line copy interception works for both row kinds (#328).
+    const entry = store.filtered.find(en => String(en.id) === row.dataset.entryId)
+    if (!entry) return
+    e.preventDefault()
+    e.clipboardData.setData('text/plain', logLine(entry))
+  }
+
+  function closestRow(node) {
+    let el = node && node.nodeType === 3 ? node.parentElement : node
+    while (el) {
+      if (el.dataset && el.dataset.entryId) return el
+      el = el.parentElement
+    }
+    return null
+  }
+
+  // Shared line format for Export and Copy-all — keep the two in lockstep
+  // with the single-row copy (logLine from the shared logline module).
+  function formatLogLines() {
+    return store.filtered.map(e => logLine(e))
+  }
+
+  async function copyAllLogs() {
+    if (await copyText(formatLogLines().join('\n'))) {
+      copiedAll = true
+      setTimeout(() => { copiedAll = false }, 2000)
+    }
+  }
+
   function exportLogs() {
-    const lines = filteredEntries.map(e => {
-      const ts = formatDate(e.created_at)
-      return `[${ts}] [${e.level?.toUpperCase()}] [${e.category}] ${prettyAnomalySummary(e.message)}${e.details ? ' – ' + e.details : ''}`
-    })
+    const lines = formatLogLines()
     const blob = new Blob([lines.join('\n')], { type: 'text/plain' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = `vault-logs-${new Date().toISOString().slice(0, 10)}.txt`
+    a.download = `vault-logs-${new Date().toISOString().slice(0, 10)}.log`
     a.click()
     URL.revokeObjectURL(url)
   }
@@ -219,10 +435,10 @@
     try {
       await api.purgeActivity()
       confirmPurge = false
-      await loadLogs()
+      await store.load()
     } catch (e) {
       confirmPurge = false
-      error = e.message || 'Failed to purge logs'
+      store.setError(e.message || 'Failed to purge logs')
     } finally {
       purging = false
     }
@@ -230,178 +446,213 @@
 </script>
 
 <div>
-  <div class="flex items-center justify-between mb-6">
+  <!-- Header -->
+  <div class="flex items-center justify-between mb-5">
     <div>
-      <h1 class="text-2xl font-bold text-text">Activity Log</h1>
-      <p class="text-sm text-text-muted mt-1">System activity and backup operation history</p>
+      <h1 class="text-2xl font-bold text-text">Logs</h1>
+      <p class="text-sm text-text-muted mt-1">Unified activity and run-log output</p>
     </div>
     <div class="flex items-center gap-2">
-      <!-- Auto-scroll toggle -->
-      <button
-        role="switch"
-        aria-checked={autoScroll}
-        onclick={() => autoScroll = !autoScroll}
-        class="flex items-center gap-2 text-xs text-text-muted hover:text-text transition-colors"
-        title="Auto-scroll to new entries"
-      >
-        <span class="relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors {autoScroll ? 'bg-vault' : 'bg-surface-4'}">
-          <span class="inline-block h-3 w-3 rounded-full bg-white shadow transition-transform {autoScroll ? 'translate-x-3.5' : 'translate-x-0.5'}"></span>
-        </span>
-        Auto-scroll
+      <button onclick={toggleWrap} aria-pressed={wrap}
+        class="px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm transition-colors flex items-center gap-1.5 {wrap ? 'text-text border-vault/50' : 'text-text-muted hover:text-text'}" title="Toggle line wrapping">
+        <svg aria-hidden="true" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h10m-10 6h10M17 15l3-3-3-3"/></svg>
+        Wrap: {wrap ? 'on' : 'off'}
       </button>
-      <!-- Export button -->
-      <button onclick={exportLogs} disabled={filteredEntries.length === 0}
+      <button onclick={copyAllLogs} disabled={store.filtered.length === 0}
+        class="px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text-muted hover:text-text transition-colors flex items-center gap-1.5 disabled:opacity-40" title="Copy all filtered logs">
+        {#if copiedAll}
+          <svg aria-hidden="true" class="w-4 h-4 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+          Copied
+        {:else}
+          <svg aria-hidden="true" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+          Copy
+        {/if}
+      </button>
+      <button onclick={exportLogs} disabled={store.filtered.length === 0}
         class="px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text-muted hover:text-text transition-colors flex items-center gap-1.5 disabled:opacity-40" title="Export logs">
         <svg aria-hidden="true" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
         Export
       </button>
-      <!-- Purge button — clears ALL logs regardless of active filters, so gate on
-           whether any logs exist rather than the filtered subset. -->
       {#if !isReplicaMode()}
-        <button onclick={() => confirmPurge = true} disabled={entries.length === 0}
+        <button onclick={() => confirmPurge = true} disabled={store.entries.length === 0}
           class="px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text-muted hover:text-danger hover:bg-danger/10 transition-colors flex items-center gap-1.5 disabled:opacity-40" title="Purge all logs">
           <svg aria-hidden="true" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
-          Purge All
+          Purge
         </button>
       {/if}
-      <button onclick={() => loadLogs()} class="px-3 py-2 bg-surface-3 border border-border rounded-lg text-sm text-text-muted hover:text-text transition-colors flex items-center gap-1.5" aria-label="Refresh">
-        <svg aria-hidden="true" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
-        Refresh
-      </button>
     </div>
   </div>
 
   {#if isReplicaMode()}
     <div class="flex items-center gap-2.5 bg-surface-3 border border-border rounded-xl px-4 py-2.5 mb-4 text-sm text-text-muted">
       <svg aria-hidden="true" class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>
-      <span>Read-only replica — write actions are disabled on this instance.</span>
+      <span>Read-only replica — write actions are disabled.</span>
     </div>
   {/if}
 
-  <!-- Filters -->
-  <div class="flex flex-wrap items-center gap-2 mb-4">
-    <div role="group" aria-label="Filter by category" class="flex items-center gap-2 flex-wrap">
-      <span class="text-[11px] font-semibold uppercase tracking-wide text-text-muted">Category</span>
-      {#each categories as cat (cat.value)}
-        <button
-          type="button"
-          onclick={() => (category = cat.value)}
-          aria-pressed={category === cat.value}
-          class="px-3 py-1.5 text-xs font-medium rounded-lg transition-colors {category === cat.value
-            ? 'bg-vault text-white'
-            : 'bg-surface-3 text-text-muted hover:text-text hover:bg-surface-4'}"
-        >
-          {cat.label}
-        </button>
-      {/each}
-    </div>
-    <div class="w-px h-5 bg-border" aria-hidden="true"></div>
-    <div role="group" aria-label="Filter by level" class="flex items-center gap-2 flex-wrap">
-      <span class="text-[11px] font-semibold uppercase tracking-wide text-text-muted">Level</span>
-      {#each levels as lev (lev.value)}
-        <button
-          type="button"
-          onclick={() => (levelFilter = lev.value)}
-          aria-pressed={levelFilter === lev.value}
-          class="px-3 py-1.5 text-xs font-medium rounded-lg transition-colors {levelFilter === lev.value
-            ? (lev.value === 'error' ? 'bg-danger text-white' : lev.value === 'warning' ? 'bg-warning text-white' : 'bg-vault text-white')
-            : 'bg-surface-3 text-text-muted hover:text-text hover:bg-surface-4'}"
-        >
-          {lev.label}
-        </button>
-      {/each}
-    </div>
+  <!-- Filter bar -->
+  <div class="flex flex-wrap items-center gap-x-3 gap-y-2 mb-4">
+    <label class="flex items-center gap-1.5">
+      <span class="text-[11px] font-semibold uppercase tracking-wide text-text-dim">Level</span>
+      <select
+        value={store.levelFilter}
+        onchange={(e) => handleLevel(e.target.value)}
+        class="px-2 py-1 text-xs rounded-md bg-surface-3 border border-border text-text-muted focus:outline-none focus:ring-1 focus:ring-vault/50 {store.levelFilter ? 'border-vault text-text' : ''}"
+      >
+        {#each levels as lev (lev.value)}
+          <option value={lev.value}>{lev.label}</option>
+        {/each}
+      </select>
+    </label>
+    <div class="w-px h-4 bg-border" aria-hidden="true"></div>
+    <label class="flex items-center gap-1.5">
+      <span class="text-[11px] font-semibold uppercase tracking-wide text-text-dim">Category</span>
+      <select
+        value={store.category}
+        onchange={(e) => handleCategory(e.target.value)}
+        class="px-2 py-1 text-xs rounded-md bg-surface-3 border border-border text-text-muted focus:outline-none focus:ring-1 focus:ring-vault/50 {store.category ? 'border-vault text-text' : ''}"
+      >
+        {#each categories as cat (cat.value)}
+          <option value={cat.value}>{cat.label}</option>
+        {/each}
+      </select>
+    </label>
+    <div class="w-px h-4 bg-border" aria-hidden="true"></div>
+    <label class="flex items-center gap-1.5">
+      <span class="text-[11px] font-semibold uppercase tracking-wide text-text-dim">Job</span>
+      <select
+        value={store.jobFilter}
+        onchange={(e) => handleJob(e.target.value)}
+        class="px-2 py-1 text-xs rounded-md bg-surface-3 border border-border text-text-muted focus:outline-none focus:ring-1 focus:ring-vault/50 {store.jobFilter ? 'border-vault text-text' : ''}"
+      >
+        <option value="">All</option>
+        {#each store.jobs as jobName (jobName)}
+          <option value={jobName}>{jobName}</option>
+        {/each}
+      </select>
+    </label>
+    <div class="w-px h-4 bg-border" aria-hidden="true"></div>
+    <label class="flex items-center gap-1.5">
+      <span class="text-[11px] font-semibold uppercase tracking-wide text-text-dim">Search</span>
+      <div class="relative">
+        <input
+          type="text"
+          value={store.search}
+          oninput={(e) => { store.setSearchFilter(e.target.value); if (!e.target.value) snapToBottom() }}
+          placeholder="Filter logs…"
+          class="px-2 py-1 pr-6 text-xs rounded-md bg-surface-3 border border-border text-text-muted focus:outline-none focus:ring-1 focus:ring-vault/50 w-44 placeholder:text-text-dim/50 {store.search ? 'border-vault text-text' : ''}"
+        />
+        {#if store.search}
+          <button type="button" onclick={() => { store.setSearchFilter(''); snapToBottom() }}
+            class="absolute right-1.5 top-1/2 -translate-y-1/2 text-text-dim hover:text-text text-xs leading-none" title="Clear search" aria-label="Clear search">×</button>
+        {/if}
+      </div>
+    </label>
+    {#if store.category || store.levelFilter || store.jobFilter || store.search}
+      <div class="w-px h-4 bg-border" aria-hidden="true"></div>
+      <button type="button" onclick={resetFilters}
+        class="px-2 py-1 text-xs rounded-md bg-surface-3 border border-border text-text-muted hover:text-text transition-colors" title="Reset all filters">
+        Reset filters
+      </button>
+    {/if}
   </div>
 
-  {#if loading}
-    <Spinner text="Loading activity log..." />
-  {:else if error}
+  <!-- Console -->
+  {#if store.loading && !store.loaded}
+    <Spinner text="Loading logs..." />
+  {:else if store.error}
     <div class="bg-danger/10 border border-danger/30 text-danger rounded-xl p-4 flex items-center gap-3">
       <svg aria-hidden="true" class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
-      <span class="text-sm">{error}</span>
+      <span class="text-sm">{store.error}</span>
     </div>
-  {:else if filteredEntries.length === 0}
-    <EmptyState title="No activity yet" subtitle="Events are logged automatically" description="Activity from backup and restore operations will appear here.">
+  {:else if store.search && store.filtered.length === 0 && (store.searching || store.loadingOlder || store.loading)}
+    <div class="py-4 text-center text-sm text-text-dim flex items-center justify-center gap-2" aria-live="polite">
+      <span aria-hidden="true" class="inline-block w-4 h-4 border border-vault/30 border-t-vault rounded-full animate-spin"></span>
+      <span>searching older logs…</span>
+    </div>
+  {:else if store.filtered.length === 0}
+    <EmptyState title="No logs" subtitle="Events appear here as they happen" description="Backup and restore operations will stream their output into this console.">
       {#snippet iconSlot()}
-        <svg class="w-12 h-12 text-text-dim" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+        <svg class="w-12 h-12 text-text-dim" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
       {/snippet}
     </EmptyState>
   {:else}
-    <div class="bg-surface-2 border border-border rounded-xl overflow-y-auto max-h-[70vh]" bind:this={logContainer}>
-      <div class="divide-y divide-border">
-        {#each filteredEntries as entry (entry.id)}
-          <div class="px-5 py-3.5 hover:bg-surface-3/30 transition-colors {entry.level === 'error' ? 'border-l-2 border-l-danger' : ''} group">
-            <div class="flex items-start gap-3">
-              <div class="mt-0.5 shrink-0">
-                <svg aria-hidden="true" class="w-4 h-4 {entry.level === 'error' ? 'text-danger' : entry.level === 'warning' ? 'text-warning' : 'text-info'}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={levelIcon(entry.level)} />
-                </svg>
-              </div>
-              <div class="flex-1 min-w-0">
-                <div class="flex items-center gap-2 mb-0.5">
-                  <span class="text-xs px-1.5 py-0.5 rounded font-medium {levelColor(entry.level)}">{entry.level}</span>
-                  <span class="text-xs px-1.5 py-0.5 rounded font-medium {categoryBadge(entry.category)}">{entry.category}</span>
-                  <span class="text-xs text-text-dim ml-auto shrink-0" title={relTime(entry.created_at)}>{formatDate(entry.created_at)}</span>
-                  <!-- Copy button -->
-                  <button type="button" onclick={(e) => { e.stopPropagation(); copyEntry(entry) }}
-                    class="opacity-0 group-hover:opacity-100 p-1 text-text-dim hover:text-text rounded transition-all" title="Copy entry">
-                    {#if copiedId === entry.id}
-                      <svg aria-hidden="true" class="w-3.5 h-3.5 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
-                    {:else}
-                      <svg aria-hidden="true" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
-                    {/if}
-                  </button>
-                </div>
-                <p class="text-sm text-text {entry.level === 'error' ? 'font-medium' : ''}">{prettyAnomalySummary(entry.message)}</p>
-                {#if entry.details}
-                  {@const parsed = tryParseJSON(entry.details)}
-                  {#if parsed}
-                    <button
-                      type="button"
-                      class="text-xs text-text-dim mt-1 flex items-center gap-1 hover:text-text transition-colors"
-                      onclick={() => toggleExpand(entry.id)}
-                    >
-                      <svg aria-hidden="true" class="w-3 h-3 transition-transform {expandedIds.has(entry.id) ? 'rotate-90' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                      </svg>
-                      Details
-                    </button>
-                    {#if expandedIds.has(entry.id)}
-                      <div class="mt-2 flex flex-wrap gap-1.5">
-                        {#each Object.entries(parsed) as [key, value] (key)}
-                          {#if key === 'summary' && value && typeof value === 'object' && !Array.isArray(value)}
-                            {#each Object.entries(value) as [sk, sv] (sk)}
-                              <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-surface-4 text-text-dim">
-                                <span class="text-text-dim/70">{detailLabel(sk)}:</span> {formatDetailValue(sk, sv)}
-                              </span>
-                            {/each}
-                          {:else if key === 'results' && Array.isArray(value)}
-                            <!-- Skip results array in badge view – summary covers it -->
-                          {:else if value === null || value === undefined}
-                            <!-- Skip null values -->
-                          {:else if Array.isArray(value) && value.length > 0}
-                            <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-danger/10 text-danger font-medium">
-                              {detailLabel(key)}: {value.join(', ')}
-                            </span>
-                          {:else if !Array.isArray(value) && (typeof value !== 'object' || value === null)}
-                            <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-surface-4 text-text-dim">
-                              <span class="text-text-dim/70">{detailLabel(key)}:</span> {formatDetailValue(key, value)}
-                            </span>
-                          {/if}
-                        {/each}
-                      </div>
-                    {/if}
-                  {:else}
-                    <p class="text-xs text-text-dim mt-1 font-mono truncate">{entry.details}</p>
-                  {/if}
-                {/if}
-              </div>
-            </div>
+    <!-- Status bar -->
+    <div class="flex items-center justify-between mb-2">
+    </div>
+
+    <!-- Console wrapper: scroll container + fixed overlay buttons -->
+    <div class="relative" style="max-height: 72vh">
+      <!-- Jump to present / new-entries indicator (fixed, bottom-right whenever follow is off) -->
+      {#if !follow}
+        <button onclick={jumpToPresent}
+          class="absolute bottom-3 right-3 z-10 px-3 py-1.5 bg-vault/90 hover:bg-vault text-white text-xs font-medium rounded-lg shadow-lg transition-all flex items-center gap-1.5"
+          title="Jump to present">
+          <svg aria-hidden="true" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3"/></svg>
+          {#if newCount > 0}{newCount} new {newCount === 1 ? 'entry' : 'entries'}{:else}Jump to present{/if}
+        </button>
+      {/if}
+
+      {#if !atTop}
+        <button onclick={jumpToOldest}
+          class="absolute top-3 right-3 z-10 p-2 bg-surface-3 border border-border rounded-lg text-text-muted hover:text-text shadow-lg transition-colors"
+          title="Jump to oldest log" aria-label="Jump to top">
+          <svg aria-hidden="true" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 10l-7-7m0 0l-7 7m7-7v18"/></svg>
+        </button>
+      {/if}
+
+      <!-- Older-batch loading spinner removed: the console now loads the
+           ENTIRE history in the background (loadAll), so there is no
+           user-facing "reaching further back" phase to signal — the fill is
+           fast and silent, and scroll-triggered loads no longer happen once
+           the buffer spans the true end (#328). -->
+
+      <!-- Scroll container -->
+      <div bind:this={box} onscroll={handleScroll} oncopy={handleCopy}
+        class="bg-surface-1 border border-border rounded-xl overflow-y-auto font-mono text-xs leading-tight h-[72vh]"
+        style="overflow-anchor: none;"
+        role="log"
+      >
+        {#if !store.hasMore && !store.pruned}
+          <div data-end-marker class="h-8 flex items-center justify-center text-center text-[11px] text-text-dim select-none" aria-live="polite">
+            — End of logs —
+          </div>
+        {/if}
+        {#each store.filtered as entry (entry.id)}
+          {@const line = formatLine(entry)}
+          <div class="flex items-baseline gap-1 px-2 border-l-2 {levelBg(entry.level)} group {focusedId === entry.id ? 'bg-vault/15 hover:bg-vault/15' : 'hover:bg-surface-2/50'}" data-entry-id={entry.id} onclick={(e) => handleRowClick(e)} onpointerdown={() => handleRowPointerDown(entry)}>
+            <!-- Timestamp (date + 24h time) -->
+            <span class="{rowColor(entry.level)} shrink-0 w-[10rem] text-right tabular-nums" title={fullTs(entry.ts)}>{lineTimestamp(entry.ts)}</span>
+            <span class="text-text-dim/30 select-none px-1">│</span>
+            <!-- Level -->
+            <span class="shrink-0 w-[2.8rem] {rowColor(entry.level)}" title={entry.level}>{levelDisplay(entry.level)}</span>
+            <span class="text-text-dim/30 select-none px-1">│</span>
+            <!-- Category -->
+            <span class="shrink-0 w-[7ch] truncate {rowColor(entry.level)}" title={entry.category}>{entry.category}</span>
+            <span class="text-text-dim/30 select-none px-1">│</span>
+            <!-- Message. Priority order for truncation: the metadata (next
+                 span) is the only shrinking item, so it truncates first;
+                 the message is shrink-0 and max-w-full, so it only
+                 ellipsizes when the message alone overflows the row. -->
+            <span class="min-w-0 flex-1 flex items-baseline gap-1">
+              <span class="{wrap ? 'whitespace-pre-wrap break-words' : 'whitespace-nowrap overflow-hidden text-ellipsis'} shrink-0 max-w-full {rowColor(entry.level)} {entry.type === 'summary' ? 'font-medium' : ''}" title={line.message}>
+                {line.message}
+              </span>
+              {#if line.meta}<span class="{metaColor(entry.level)} px-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap" title={line.meta}> | {line.meta}</span>{/if}
+            </span>
+            <!-- Copy -->
+            <button type="button" onclick={() => copyEntry(entry)}
+              class="{copiedId === entry.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'} p-0.5 text-text-dim/40 hover:text-text shrink-0 transition-all self-center cursor-pointer" title="Copy">
+              {#if copiedId === entry.id}
+                <svg aria-hidden="true" class="w-3 h-3 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+              {:else}
+                <svg aria-hidden="true" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+              {/if}
+            </button>
           </div>
         {/each}
       </div>
     </div>
-    <p class="text-xs text-text-dim mt-3 text-center">{filteredEntries.length} log entr{filteredEntries.length !== 1 ? 'ies' : 'y'}</p>
   {/if}
 </div>
 

--- a/web/vitest.config.js
+++ b/web/vitest.config.js
@@ -1,8 +1,12 @@
 import { defineConfig } from 'vitest/config'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 // Pure-logic unit tests only (no DOM/component rendering), so the plain node
-// environment is enough and we deliberately don't load the Svelte plugin.
+// environment is enough. The Svelte plugin is loaded purely for the runes
+// transform: .svelte.js state modules (unifiedlog store) use $state/$derived
+// and must compile before vitest can import them.
 export default defineConfig({
+  plugins: [svelte()],
   test: {
     environment: 'node',
     include: ['src/**/*.test.js'],


### PR DESCRIPTION
## feat(engine): streamed run logs with unified activity + run-log console (#328)

### Problem

Vault recorded only a single status row per backup/restore run (`job_runs`) and a brief activity-log blurb on completion. There was no way to see *what happened* during a run — which items were processed, when phases started and finished, whether anything stalled, or why a run ended partial/failed. Operators had to SSH into the container and dig through syslog or the daemon's ephemeral stdout.

### Solution

Persistent, streaming per-run logs (`run_log_entries` table) **plus** a unified console that merges the run-log stream with the activity feed into one chronological view.

**Database layer** — `run_log_entries` (SQLite): `run_id → job_runs` FK with cascade delete, compound `(run_id, id)` index for efficient tail queries, and a `data` JSON column alongside the human-readable message. A per-run cap of 10,000 entries is enforced **on every append** (transactional prune, run-scoped), so a pathological run can't grow the table; normal retention is the cascade with the run row. Repo methods: `AppendRunLog`, `ListRunLogEntries`, `TailRunLogEntries`, `CapRunLogEntriesPerRun`.

**Runner layer** — `runLog()` persists each entry and broadcasts it over the reliable WebSocket channel so connected UIs append lines in real time; logging failures are non-fatal by design. Messages follow a strict comma-separated convention — `phrase, key=value, key=value` (per-item lines, phase milestones, health-check outcomes, and the terminal summary). `runSummaryMessage` is a shared, unit-tested pure function used verbatim by backup and restore. The terminal summary is dual-written: the run-log line for the stream, and the activity row (stamped `run_log:true`) as the durable audit record that survives run pruning.

**REST API** — `GET /api/v1/runs/{runId}/logs?after=<id>&limit=N&tail=true`. `after` supports cheap tailing/polling and WebSocket reconnect reconciliation; `tail=true` returns the run's NEWEST lines so the console always receives the end-of-run summary (status/size/duration) even for runs longer than one page. Unknown runs return 404 (distinct from empty); validation matches existing handler patterns (400 for bad `runId`, negative `after`, non-positive `limit`).

**MCP** — `get_run_logs` tool with the same tail/paginate semantics for agent-based consumers.

**Frontend — unified console** (replaces the earlier per-viewer run-log panels):
- One chronological stream merging activity entries with expanded run-log lines; duplicate terminal summaries for the same run are deduped (`rl-` id space keeps both kinds distinct)
- Cursor-keyed lazy loading on both sides (older pages via `before_id`, newer via poll/WS) with a background full-history load, so the console spans the entire history and the "— End of logs —" marker is honest
- Client-side search over the full history (category is applied server-side; level and job filters are client-side and compose)
- Bounded expansion: oversized run logs are split through `planBatch` (older-batch budget) with deferred lines draining across subsequent steps — and a run's terminal summary line is never deferred
- WebSocket live updates with a dedup ring; streamed `run_log` messages are category-filtered so a filtered console doesn't leak lines from other categories
- Uniform `message | metadata` rendering (pipe-separated, split at the first `, key=` boundary) across console rows, copy, copy-all, and export — one shared `logline` module
- Level-driven row colors: default text color for the message, muted metadata; error/warn/debug rows sync the entire line to one color
- Memory safety: a `MAX_ENTRIES` cap holds even when the buffer is pinned to the full history (the UI gates the end marker on the prune flag so it never lies)

### Preview

<img width="1115" height="778" alt="SCR-20260821-opkb" src="https://github.com/user-attachments/assets/62fd3c80-4217-49c6-a84d-a57e0bc2f46e" />

Closes #328.
