### PR TITLE
feat(web): show plugin version + update indicator in sidebar footer

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -104,6 +104,10 @@
   // the convention in Settings.svelte.
   let version = $state('')
 
+  // Latest published GitHub release tag (normalized, no leading 'v'). Powers
+  // the update-available indicator next to the version in the sidebar footer.
+  let latestTag = $state('')
+
   // Watchdog threshold: how long any boot step may stall before we force the
   // shell to render anyway. Brave's blocked storage APIs and an unreachable
   // daemon (the LAN-IP workaround) could otherwise hang the SPA forever.
@@ -129,6 +133,12 @@
             replicaMode = true
           }
         } catch { /* ignore – default to daemon mode */ }
+
+        // Update-available indicator: best-effort latest-release lookup.
+        // Fire-and-forget on purpose — it must never delay or break boot.
+        api.getLatestRelease()
+          .then((r) => { if (r && r.tag) latestTag = String(r.tag).replace(/^v/i, '') })
+          .catch(() => { /* no indicator when the release lookup fails */ })
 
         // connectWs is synchronous; guard it so a throwing WebSocket constructor
         // can't reject this IIFE. The ws layer owns its own retry/backoff.
@@ -157,6 +167,19 @@
   let connectionLost = $derived.by(() => {
     const wsStatus = getWsStatus()
     return ready && (wsStatus === 'disconnected' || wsStatus === 'reconnecting')
+  })
+
+  // True when the daemon version predates the latest published release.
+  // Mirrors the comparison in Settings.svelte: strip a leading 'v', then plain
+  // string compare (YYYY.MM.PATCH is zero-padded, so it sorts
+  // chronologically). Equal or newer daemon versions show no indicator —
+  // same reasoning as the 'Pre-release' state in Settings — and dev builds
+  // or a failed release lookup never show one.
+  const updateAvailable = $derived.by(() => {
+    if (!version || !latestTag) return false
+    const cur = version.replace(/^v/i, '')
+    if (cur === 'dev') return false
+    return cur < latestTag
   })
 
   function isActive(path) {
@@ -260,7 +283,18 @@
       {/each}
     </nav>
     {#if version}
-      <footer class="px-3 py-3 border-t border-border text-xs text-text-muted">v{version}</footer>
+      <footer class="px-3 py-3 border-t border-border text-xs text-text-muted flex items-center justify-between gap-2">
+        <span>v{version}</span>
+        {#if updateAvailable}
+          <button onclick={() => go('/settings')}
+            title="Update available — latest release v{latestTag}"
+            aria-label="Update available, latest release v{latestTag}. Open settings."
+            class="inline-flex items-center gap-1.5 text-orange-400 hover:text-orange-300 transition-colors">
+            <span class="w-1.5 h-1.5 rounded-full bg-orange-400 animate-pulse" aria-hidden="true"></span>
+            Update available
+          </button>
+        {/if}
+      </footer>
     {/if}
   </aside>
 

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -99,6 +99,11 @@
   let ready = $state(false)
   let replicaMode = $state(false)
 
+  // Running plugin version shown in the sidebar footer. Sourced from the same
+  // /health response used for replica-mode detection; 'dev' fallback matches
+  // the convention in Settings.svelte.
+  let version = $state('')
+
   // Watchdog threshold: how long any boot step may stall before we force the
   // shell to render anyway. Brave's blocked storage APIs and an unreachable
   // daemon (the LAN-IP workaround) could otherwise hang the SPA forever.
@@ -118,6 +123,7 @@
         // Detect replica mode from health endpoint.
         try {
           const health = await api.health()
+          version = health.version || 'dev'
           if (health.mode === 'replica') {
             setReplicaMode(true)
             replicaMode = true
@@ -253,6 +259,9 @@
         {/each}
       {/each}
     </nav>
+    {#if version}
+      <footer class="px-3 py-3 border-t border-border text-xs text-text-muted">v{version}</footer>
+    {/if}
   </aside>
 
   <!-- Mobile header -->


### PR DESCRIPTION
## Summary

- Shows the running plugin version at the bottom of the desktop sidebar (e.g. `v2026.08.00`), so users can verify which version they're on without opening Settings
- Adds a small **update-available indicator** next to the version: a pulsing orange dot + label that appears when the daemon reports a version older than the latest published GitHub release
  - Comparison mirrors `Settings.svelte`: tags normalized (leading `v` stripped), plain string ordering on zero-padded `YYYY.MM.PATCH`; daemon equal/newer than latest (pre-release) shows no indicator
  - Latest-release lookup via the existing `GET /api/v1/release/latest`, fire-and-forget so it can never delay or break boot; failed lookups and dev builds show no indicator
  - Clicking the indicator opens Settings, where the About card shows the changelog and update details
- Version sourced from the `GET /api/v1/health` response `App.svelte` already fetches in `onMount` for replica-mode detection — no new boot request
- Falls back to `'dev'` when `health.version` is missing/empty, matching the existing `Settings.svelte` convention
- Footer renders only once a version is known, so no empty bar appears during boot
- Pinned to the sidebar bottom by the existing flex-column layout (`<aside>` flex-col + `flex-1` `<nav>`); no positioning changes

Closes #340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Displayed the installed plugin version in the desktop sidebar.
  * Added a background check for newer releases.
  * Added an update indicator linking to Settings when a newer version is available.
* **Bug Fixes**
  * Ensured release-check failures do not interrupt application startup.
  * Excluded development builds and cases where the installed version is current or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->