### PR TITLE
fix(ansible): copy CHANGELOG before lint; default api_key in MCP verify

### DIFF
--- a/ansible/roles/build/tasks/main.yml
+++ b/ansible/roles/build/tasks/main.yml
@@ -16,6 +16,16 @@
         chdir: "{{ playbook_dir }}/.."
       changed_when: false
 
+    # Must run before lint/tests: internal/release //go:embeds CHANGELOG.md,
+    # and Go forbids parent-directory embed paths, so the file has to sit next
+    # to the directive before any command that typechecks the module. Fresh
+    # checkouts fail at the linter without this.
+    - name: Copy CHANGELOG.md into embed location
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/../CHANGELOG.md"
+        dest: "{{ playbook_dir }}/../internal/release/CHANGELOG.md"
+        mode: '0644'
+
     - name: Run linter
       ansible.builtin.command:
         cmd: golangci-lint run --config .golangci.yml --max-issues-per-linter 0 --max-same-issues 0 ./...
@@ -39,12 +49,6 @@
         cmd: npm run build
         chdir: "{{ playbook_dir }}/../web"
       changed_when: true
-
-    - name: Copy CHANGELOG.md into embed location
-      ansible.builtin.copy:
-        src: "{{ playbook_dir }}/../CHANGELOG.md"
-        dest: "{{ playbook_dir }}/../internal/release/CHANGELOG.md"
-        mode: '0644'
 
     - name: Cross-compile Linux/amd64 binary
       ansible.builtin.command:

--- a/ansible/roles/verify/tasks/mcp.yml
+++ b/ansible/roles/verify/tasks/mcp.yml
@@ -7,7 +7,7 @@
     cmd: >
       go run {{ playbook_dir }}/../scripts/verify-mcp-streamable-http.go
       -endpoint http://127.0.0.1:{{ verify_local_port }}/api/v1/mcp
-      -api-key {{ api_key | quote }}
+      -api-key {{ api_key | default('') | quote }}
   register: mcp_result
   changed_when: false
 


### PR DESCRIPTION
**Summary**

Two robustness fixes for the ansible build pipeline, both hit while building a feature branch from a fresh checkout:

- **Copy CHANGELOG.md into embed location before lint/tests** (`c7a5196`)
  `internal/release` bundles the changelog via `//go:embed CHANGELOG.md`. Go forbids parent-directory embed paths, so the repo-root changelog must be copied to `internal/release/CHANGELOG.md` before *any* command that typechecks the module. The role did that copy as task 7 — after the linter (task 3) and unit tests (task 4) — so fresh checkouts (the copy is gitignored) failed immediately with `pattern CHANGELOG.md: no matching files found`. CI workflows and the Makefile already copy before compiling; the role was the outlier. The copy now runs right after `go mod tidy`, with a comment explaining the constraint.

- **Default the undefined `api_key` in the MCP verify task** (`4f61cd3`)
  `verify/tasks/mcp.yml` templates `{{ api_key | quote }}` with no default, but nothing in the playbook defines it — runs without `-e api_key=***` fail at argument finalization with `'api_key' is undefined`, after deploy already succeeded. The sibling verify tasks (`endpoints.yml`, `websocket.yml`) already use `default('')`; the MCP task now matches: empty key when auth is disabled, overridable via extra-vars when enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local build reliability by ensuring release notes are available during validation and testing.
  * Prevented inconsistent build behaviour between local and cross-platform builds.

* **Chores**
  * Streamlined the build process by removing a redundant release-notes handling step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->