### PR TITLE
fix(engine,runner): pick up new and changed items in incremental/differential backups (#320)

### DIFF
--- a/internal/engine/container.go
+++ b/internal/engine/container.go
@@ -1164,6 +1164,43 @@ func anyVolumeChangedSince(ctx context.Context, mounts []container.MountPoint, e
 	return changes, anyChanged, nil
 }
 
+// chunkedPrevBySource derives the per-volume previous listing (mount source
+// host path -> volume-relative path set) from the parent manifest's volume
+// sub-manifests, mirroring the classic path's prev_volume_listing_paths. Used
+// by the chunked (dedup) stop decision so a NEW stale-mtime file flips an
+// otherwise-unchanged volume to changed (issue #320) — the same semantics the
+// classic Backup path's prev-aware stop check already has. A nil parent, a
+// missing/empty volume entry, or an unreadable sub-manifest simply omits that
+// volume, and a nil map degrades to mtime-only.
+func chunkedPrevBySource(parent *dedup.Manifest, mounts []container.MountPoint, repo *dedup.Repo) map[string]map[string]struct{} {
+	if parent == nil || repo == nil {
+		return nil
+	}
+	out := make(map[string]map[string]struct{})
+	for _, mnt := range mounts {
+		if !backupableMount(string(mnt.Type)) || mnt.Source == "" || mnt.Destination == "" {
+			continue
+		}
+		pe, ok := parent.Files[containerVolPrefix+mnt.Destination]
+		if !ok || len(pe.Chunks) == 0 {
+			continue
+		}
+		sub, err := repo.GetManifest(pe.Chunks[0])
+		if err != nil {
+			continue
+		}
+		set := make(map[string]struct{}, len(sub.Files))
+		for p := range sub.Files {
+			set[p] = struct{}{}
+		}
+		out[mnt.Source] = set
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // Restore restores a Docker container from a backup directory:
 //  1. Loads the image from image.tar.
 //  2. Reads the saved config (full docker inspect JSON).
@@ -1927,9 +1964,14 @@ func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, r
 		// Per-volume results are cached so the archiving loop reuses them.
 		var anyChanged bool
 		var err error
-		// The chunked (dedup) path carries forward via the parent manifest, not
-		// per-volume listings, so prevBySource stays nil (mtime-only).
-		volChanges, anyChanged, err = anyVolumeChangedSince(ctx, inspect.Mounts, exclusions, changedSince, nil)
+		// Derive the per-volume previous listing from the parent manifest's
+		// volume sub-manifests (the same resolution the archiving loop uses
+		// for carry-forward) so a NEW stale-mtime file flips the volume to
+		// changed (issue #320) — matching the classic Backup path's
+		// prev-aware stop check. Without it, a running container whose only
+		// change is such a file is not stopped and is backed up live.
+		prevBySource := chunkedPrevBySource(parent, inspect.Mounts, repo)
+		volChanges, anyChanged, err = anyVolumeChangedSince(ctx, inspect.Mounts, exclusions, changedSince, prevBySource)
 		if err != nil {
 			return dedup.ID{}, err
 		}

--- a/internal/engine/container.go
+++ b/internal/engine/container.go
@@ -722,6 +722,11 @@ func (h *ContainerHandler) Backup(ctx context.Context, item BackupItem, destDir 
 	noStop, _ := item.Settings["no_stop"].(bool)
 	changedSince, hasChangedSince := parseChangedSince(item.Settings)
 
+	// Previous backup's per-volume effective listings (mount source host path ->
+	// volume-relative path set), used to detect NEW files with stale mtimes in
+	// differential/incremental runs (issue #320).
+	prevBySource := prevVolumeListingSet(item.Settings)
+
 	// Extract path exclusions from item settings: free-text exclude_paths plus
 	// the checkbox-driven excluded_mounts from the job wizard, plus anything
 	// the container declares for itself via the vault.exclude label.
@@ -776,7 +781,7 @@ func (h *ContainerHandler) Backup(ctx context.Context, item BackupItem, destDir 
 		// via pathChangedSince.
 		var anyChanged bool
 		var err error
-		volChanges, anyChanged, err = anyVolumeChangedSince(ctx, inspect.Mounts, exclusions, changedSince)
+		volChanges, anyChanged, err = anyVolumeChangedSince(ctx, inspect.Mounts, exclusions, changedSince, prevBySource)
 		if err != nil {
 			return nil, err
 		}
@@ -935,7 +940,7 @@ func (h *ContainerHandler) Backup(ctx context.Context, item BackupItem, destDir 
 				changed, cached := volChanges[mount.Source]
 				if !cached {
 					var err error
-					changed, err = pathChangedSince(ctx, mount.Source, changedSince)
+					changed, err = pathChangedSinceWithPrev(ctx, mount.Source, changedSince, prevBySource[mount.Source])
 					if err != nil {
 						return fmt.Errorf("checking volume %s changes: %w", mount.Source, err)
 					}
@@ -965,7 +970,7 @@ func (h *ContainerHandler) Backup(ctx context.Context, item BackupItem, destDir 
 				volExclusions := mapExclusionsToVolume(exclusions, mount.Destination)
 
 				if hasChangedSince {
-					if err := tarDirectoryFiltered(ctx, mount.Source, volDest, changedSince, volExclusions, effectiveCompression); err != nil {
+					if err := tarDirectoryFilteredWithPrev(ctx, mount.Source, volDest, changedSince, volExclusions, effectiveCompression, prevBySource[mount.Source]); err != nil {
 						return fmt.Errorf("archiving volume %s: %w", mount.Source, err)
 					}
 				} else {
@@ -976,6 +981,16 @@ func (h *ContainerHandler) Backup(ctx context.Context, item BackupItem, destDir 
 
 				if len(volExclusions) > 0 {
 					entry.ExcludedPaths = volExclusions
+				}
+
+				// Authoritative point-in-time per-volume listing (full effective
+				// file set after exclusions) — lets the NEXT differential detect
+				// NEW files with stale mtimes (issue #320). Best-effort, mirroring
+				// folder.go's WriteEffectiveListing usage.
+				if err := WriteEffectiveListing(mount.Source, volDest, volExclusions); err != nil {
+					log.Printf("engine: warning: failed to write volume listing for %s: %v", mount.Source, err)
+				} else {
+					result.Files = append(result.Files, backupFileInfo(volDest+ListingSuffix))
 				}
 			} else {
 				// Auto-skip non-regular inodes (sockets, named pipes, devices,
@@ -1109,11 +1124,16 @@ func runWithRestart(shouldRestart bool, itemName string, progress ProgressFunc, 
 // pathChangedSince so an excluded host-root bind mount (/ → /rootfs —
 // Telegraf, Netdata, Glances) is never walked (issues #70, #251).
 //
+// prevBySource maps a mount source host path to the paths recorded in the
+// parent restore point's per-volume effective listing; a file absent from that
+// listing is treated as NEW (and therefore changed) even when its mtime
+// predates changedSince (issue #320). A nil map degrades to mtime-only.
+//
 // Callers use this to decide whether a differential run needs to stop the
 // container at all: when no volume changed, the in-loop per-volume
 // pathChangedSince checks skip every volume anyway, so the stop/restart
 // cycle would be pure downtime with no consistency benefit.
-func anyVolumeChangedSince(ctx context.Context, mounts []container.MountPoint, exclusions []string, changedSince time.Time) (map[string]bool, bool, error) {
+func anyVolumeChangedSince(ctx context.Context, mounts []container.MountPoint, exclusions []string, changedSince time.Time, prevBySource map[string]map[string]struct{}) (map[string]bool, bool, error) {
 	changes := make(map[string]bool)
 	anyChanged := false
 	for _, mnt := range mounts {
@@ -1132,7 +1152,7 @@ func anyVolumeChangedSince(ctx context.Context, mounts []container.MountPoint, e
 		if shouldExcludeMount(exclusions, mnt.Destination) {
 			continue
 		}
-		changed, err := pathChangedSince(ctx, mnt.Source, changedSince)
+		changed, err := pathChangedSinceWithPrev(ctx, mnt.Source, changedSince, prevBySource[mnt.Source])
 		if err != nil {
 			return nil, false, fmt.Errorf("checking volume %s changes: %w", mnt.Source, err)
 		}
@@ -1907,7 +1927,9 @@ func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, r
 		// Per-volume results are cached so the archiving loop reuses them.
 		var anyChanged bool
 		var err error
-		volChanges, anyChanged, err = anyVolumeChangedSince(ctx, inspect.Mounts, exclusions, changedSince)
+		// The chunked (dedup) path carries forward via the parent manifest, not
+		// per-volume listings, so prevBySource stays nil (mtime-only).
+		volChanges, anyChanged, err = anyVolumeChangedSince(ctx, inspect.Mounts, exclusions, changedSince, nil)
 		if err != nil {
 			return dedup.ID{}, err
 		}
@@ -2596,12 +2618,15 @@ func tarDirectory(ctx context.Context, srcDir, destPath string, exclusions []str
 	return err
 }
 
-// tarDirectoryFiltered creates a tar archive of srcDir at destPath, including
-// only files whose modification time is after changedSince. Directory entries
-// are always included to preserve structure. This is used for incremental and
-// differential backups. The compression argument selects the archive
-// compression layer ("none", "gzip", or "zstd").
-func tarDirectoryFiltered(ctx context.Context, srcDir, destPath string, changedSince time.Time, exclusions []string, compression string) (err error) {
+// tarDirectoryFilteredWithPrev creates a tar archive of srcDir at destPath
+// including only files whose modification time is after changedSince (directory
+// entries are always included to preserve structure), plus a prevPaths set of
+// item-relative paths recorded in the previous backup's effective listing. A
+// regular file whose mtime predates changedSince is normally skipped as
+// unchanged; when prevPaths is non-nil, a file ABSENT from the set (a NEW file
+// copied in with a stale timestamp) is archived instead of dropped (issue #320).
+// A nil prevPaths preserves the mtime-only behaviour.
+func tarDirectoryFilteredWithPrev(ctx context.Context, srcDir, destPath string, changedSince time.Time, exclusions []string, compression string, prevPaths map[string]struct{}) (err error) {
 	root, err := os.OpenRoot(srcDir)
 	if err != nil {
 		return fmt.Errorf("opening source root: %w", err)
@@ -2685,9 +2710,18 @@ func tarDirectoryFiltered(ctx context.Context, srcDir, destPath string, changedS
 			return nil
 		}
 
-		// Always include directories; filter regular files by mod time.
+		// Always include directories; filter regular files by mod time. A file
+		// whose mtime predates changedSince is unchanged — unless it is absent
+		// from the previous backup's listing, in which case it is a NEW file
+		// with a stale timestamp and must be archived (issue #320).
 		if !info.IsDir() && !info.ModTime().After(changedSince) {
-			return nil
+			if prevPaths == nil {
+				return nil
+			}
+			if _, exists := prevPaths[rel]; exists {
+				return nil
+			}
+			// Fall through and archive the new file.
 		}
 
 		header, err := tar.FileInfoHeader(info, "")

--- a/internal/engine/container.go
+++ b/internal/engine/container.go
@@ -1169,9 +1169,14 @@ func anyVolumeChangedSince(ctx context.Context, mounts []container.MountPoint, e
 // sub-manifests, mirroring the classic path's prev_volume_listing_paths. Used
 // by the chunked (dedup) stop decision so a NEW stale-mtime file flips an
 // otherwise-unchanged volume to changed (issue #320) — the same semantics the
-// classic Backup path's prev-aware stop check already has. A nil parent, a
-// missing/empty volume entry, or an unreadable sub-manifest simply omits that
-// volume, and a nil map degrades to mtime-only.
+// classic Backup path's prev-aware stop check already has. A nil parent or a
+// nil repo omits every volume. A volume whose parent entry is missing, holds
+// the skip sentinel, or whose sub-manifest is unreadable gets an EMPTY set:
+// every pre-existing file then reports as absent-from-parent (changed), which
+// forces the stop decision to keep needsStop set. Omitting the volume instead
+// would let the pre-check report the volume unchanged (mtime-only) and skip
+// the stop, while the archiving loop below later takes the full-chunk
+// fallback on a still-running container — an inconsistent live backup.
 func chunkedPrevBySource(parent *dedup.Manifest, mounts []container.MountPoint, repo *dedup.Repo) map[string]map[string]struct{} {
 	if parent == nil || repo == nil {
 		return nil
@@ -1183,10 +1188,12 @@ func chunkedPrevBySource(parent *dedup.Manifest, mounts []container.MountPoint, 
 		}
 		pe, ok := parent.Files[containerVolPrefix+mnt.Destination]
 		if !ok || len(pe.Chunks) == 0 {
+			out[mnt.Source] = map[string]struct{}{}
 			continue
 		}
 		sub, err := repo.GetManifest(pe.Chunks[0])
 		if err != nil {
+			out[mnt.Source] = map[string]struct{}{}
 			continue
 		}
 		set := make(map[string]struct{}, len(sub.Files))

--- a/internal/engine/container.go
+++ b/internal/engine/container.go
@@ -1771,7 +1771,7 @@ const (
 //
 // Like FolderHandler.BackupChunked, repo.Flush is NOT called here — the
 // runner flushes once per backup run after all items complete.
-func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, repo *dedup.Repo, progress ProgressFunc) (dedup.ID, error) {
+func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, repo *dedup.Repo, parent *dedup.Manifest, progress ProgressFunc) (dedup.ID, error) {
 	if repo == nil {
 		return dedup.ID{}, fmt.Errorf("container: dedup repo is nil")
 	}
@@ -1964,7 +1964,28 @@ func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, r
 			}
 			// For differential backups, skip volumes whose entire tree is
 			// unchanged since the reference time. Mirrors the classic Backup
-			// path. Reuses cached pre-check results when available.
+			// path. Reuses cached pre-check results when available. With a
+			// parent manifest, the unchanged volume's sub-manifest reference is
+			// carried forward so the resulting manifest stays complete for
+			// single-point restore (issue #320).
+			// Resolve the parent's matching sub-manifest up front so the
+			// unchanged-volume short-circuit below can route through it
+			// (per-file carry-forward with the stale-mtime fall-through)
+			// instead of copying the parent entry verbatim — the latter
+			// silently drops a NEW file whose mtime predates changed_since
+			// (e.g. cp -a), the literal issue #320 data-loss class. The
+			// len(pe.Chunks) > 0 guard also rejects a pre-PR parent entry
+			// that recorded the volume as the -1 skip sentinel, which must
+			// be re-chunked rather than carried forward.
+			var volParent *dedup.Manifest
+			if hasChangedSince && parent != nil {
+				if pe, ok := parent.Files[key]; ok && len(pe.Chunks) > 0 {
+					if sub, gErr := repo.GetManifest(pe.Chunks[0]); gErr == nil {
+						volParent = &sub
+					}
+				}
+			}
+
 			if hasChangedSince {
 				changed, cached := volChanges[mnt.Source]
 				if !cached {
@@ -1974,11 +1995,39 @@ func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, r
 						return fmt.Errorf("checking volume %s changes: %w", mnt.Source, err)
 					}
 				}
-				if !changed {
-					log.Printf("engine: chunked: skipping volume %s for %s: unchanged since reference", mnt.Source, item.Name)
-					m.Files[key] = dedup.ManifestEntry{Size: volumeSkippedSize}
+				if !changed && volParent == nil {
+					// The volume looks unchanged AND there is no parent
+					// sub-manifest to carry forward from (a full backup with a
+					// changed_since set, a parent whose manifest is missing
+					// this volume, or a pre-PR parent that recorded it as the
+					// -1 skip sentinel). Chunk FULLY so the manifest stays
+					// complete. changed_since is deliberately NOT propagated
+					// here — with no parent entry there is nothing to carry
+					// forward from, and the per-file filter would otherwise
+					// drop every file (issue #320).
+					log.Printf("engine: chunked: volume %s for %s unchanged since reference — no parent entry to carry forward, chunking fully", mnt.Source, item.Name)
+					volItem := BackupItem{
+						Name: mnt.Destination,
+						Type: "folder",
+						Settings: map[string]any{
+							"path":          mnt.Source,
+							"exclude_paths": mapExclusionsToVolume(exclusions, mnt.Destination),
+						},
+					}
+					volManifestID, vErr := fh.BackupChunked(ctx, volItem, repo, nil, progress)
+					if vErr != nil {
+						return fmt.Errorf("backup unchanged volume %s: %w", mnt.Destination, vErr)
+					}
+					m.Files[key] = dedup.ManifestEntry{
+						Size:   0,
+						Chunks: []dedup.ID{volManifestID},
+					}
 					continue
 				}
+				// A volume that is unchanged by mtime but still has a parent
+				// sub-manifest falls through: it is re-chunked with volParent
+				// below, which carries forward unchanged files AND chunks any
+				// new stale-mtime file (issue #320).
 			}
 			volItem := BackupItem{
 				Name: mnt.Destination,
@@ -1988,12 +2037,10 @@ func (h *ContainerHandler) BackupChunked(ctx context.Context, item BackupItem, r
 					"exclude_paths": mapExclusionsToVolume(exclusions, mnt.Destination),
 				},
 			}
-			// Propagate changed_since for per-file filtering inside
-			// FolderHandler.BackupChunked.
-			if hasChangedSince {
+			if volParent != nil {
 				volItem.Settings["changed_since"] = item.Settings["changed_since"]
 			}
-			volManifestID, vErr := fh.BackupChunked(ctx, volItem, repo, progress)
+			volManifestID, vErr := fh.BackupChunked(ctx, volItem, repo, volParent, progress)
 			if vErr != nil {
 				return fmt.Errorf("backup volume %s: %w", mnt.Destination, vErr)
 			}

--- a/internal/engine/container_chunked_restore_test.go
+++ b/internal/engine/container_chunked_restore_test.go
@@ -21,7 +21,7 @@ func backupTestVolume(t *testing.T, repo *dedup.Repo, src string) dedup.ID {
 		Name:     "vol",
 		Type:     "folder",
 		Settings: map[string]any{"path": src},
-	}, repo, nil)
+	}, repo, nil, nil)
 	if err != nil {
 		t.Fatalf("BackupChunked() error = %v", err)
 	}

--- a/internal/engine/container_chunked_test.go
+++ b/internal/engine/container_chunked_test.go
@@ -935,7 +935,7 @@ func TestChunkedPrevBySource(t *testing.T) {
 
 	subID, err := r.PutManifest("sub", dedup.Manifest{
 		Files: map[string]dedup.ManifestEntry{
-			"old.txt":       {},
+			"old.txt":        {},
 			"sub/nested.txt": {},
 		},
 	})

--- a/internal/engine/container_chunked_test.go
+++ b/internal/engine/container_chunked_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -791,5 +792,204 @@ func TestBackupChunked_AllMountsExcluded(t *testing.T) {
 	if mock.stopCalled {
 		t.Error("container was stopped for a run that cannot produce a backup — " +
 			"the guard must run before the stop")
+	}
+}
+
+// TestBackupChunkedStopDecisionPrevAware is the regression test for the dedup
+// stop-decision half of issue #320. A running container whose only change
+// since the parent restore point is a NEW file with a stale mtime must still
+// be stopped for a consistent backup. The chunked stop pre-check derives the
+// per-volume previous listing from the parent manifest's sub-manifest
+// (chunkedPrevBySource), so an otherwise-unchanged volume that gained a
+// stale-mtime file flips to changed — mirroring the classic Backup path.
+func TestBackupChunkedStopDecisionPrevAware(t *testing.T) {
+	changedSince := time.Now().Add(-1 * time.Hour).Truncate(time.Second)
+	old := changedSince.Add(-time.Hour)
+
+	writePinned := func(t *testing.T, path, content string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tests := []struct {
+		name       string
+		mutateDiff func(t *testing.T, diffVol string)
+		wantStop   bool
+	}{
+		{
+			name: "stale-mtime new file stops a running container",
+			mutateDiff: func(t *testing.T, diffVol string) {
+				writePinned(t, filepath.Join(diffVol, "new.txt"), "new")
+			},
+			wantStop: true,
+		},
+		{
+			name:       "unchanged volume does not stop a running container",
+			mutateDiff: func(t *testing.T, diffVol string) {},
+			wantStop:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, _, cleanup := dedup.NewTestRepoForEngine(t)
+			defer cleanup()
+
+			// Parent (full) backup: not running, single /data volume holding
+			// only old.txt.
+			fullVol := t.TempDir()
+			writePinned(t, filepath.Join(fullVol, "old.txt"), "old")
+			fullMock := &mockDockerClient{
+				inspectResp: client.ContainerInspectResult{
+					Container: containertypes.InspectResponse{
+						ID:     "abc123",
+						Name:   "/test",
+						Config: &containertypes.Config{Image: "nginx:latest"},
+						State:  &containertypes.State{Running: false},
+						Mounts: []containertypes.MountPoint{
+							{Type: mounttypes.TypeBind, Source: fullVol, Destination: "/data"},
+						},
+					},
+				},
+				imageResp: client.ImageInspectResult{
+					InspectResponse: imagetypes.InspectResponse{
+						RepoDigests: []string{"nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+					},
+				},
+			}
+			fullID, err := (&ContainerHandler{cli: fullMock}).BackupChunked(context.Background(), BackupItem{
+				Name:     "test",
+				Type:     "container",
+				Settings: map[string]any{"id": "abc123"},
+			}, r, nil, noopProgress)
+			if err != nil {
+				t.Fatalf("full BackupChunked() error = %v", err)
+			}
+			if err := r.Flush(); err != nil {
+				t.Fatalf("Flush() error = %v", err)
+			}
+			parent, err := r.GetManifest(fullID)
+			if err != nil {
+				t.Fatalf("GetManifest(parent) error = %v", err)
+			}
+
+			// Differential backup: running container, same volume plus the
+			// scenario's mutation. The dir mtime is pinned back to `old` so the
+			// prev-aware check (not a bumped dir mtime) is the only change
+			// signal.
+			diffVol := t.TempDir()
+			writePinned(t, filepath.Join(diffVol, "old.txt"), "old")
+			tt.mutateDiff(t, diffVol)
+			if err := os.Chtimes(diffVol, old, old); err != nil {
+				t.Fatal(err)
+			}
+			diffMock := &mockDockerClient{
+				inspectResp: client.ContainerInspectResult{
+					Container: containertypes.InspectResponse{
+						ID:     "abc123",
+						Name:   "/test",
+						Config: &containertypes.Config{Image: "nginx:latest"},
+						State:  &containertypes.State{Running: true},
+						Mounts: []containertypes.MountPoint{
+							{Type: mounttypes.TypeBind, Source: diffVol, Destination: "/data"},
+						},
+					},
+				},
+				imageResp: client.ImageInspectResult{
+					InspectResponse: imagetypes.InspectResponse{
+						RepoDigests: []string{"nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+					},
+				},
+			}
+			if _, err := (&ContainerHandler{cli: diffMock}).BackupChunked(context.Background(), BackupItem{
+				Name: "test",
+				Type: "container",
+				Settings: map[string]any{
+					"id":            "abc123",
+					"changed_since": changedSince.UTC().Format(time.RFC3339),
+				},
+			}, r, &parent, noopProgress); err != nil {
+				t.Fatalf("differential BackupChunked() error = %v", err)
+			}
+
+			if diffMock.stopCalled != tt.wantStop {
+				t.Errorf("stopCalled = %v, want %v", diffMock.stopCalled, tt.wantStop)
+			}
+		})
+	}
+}
+
+// TestChunkedPrevBySource verifies the per-volume previous-listing derivation
+// used by the chunked stop decision: it resolves each mount's parent
+// sub-manifest (via the containerVolPrefix+destination key) into a
+// volume-relative path set keyed by mount source, and degrades gracefully (nil
+// or omitted volume) when the parent has nothing to carry forward from.
+func TestChunkedPrevBySource(t *testing.T) {
+	r, _, cleanup := dedup.NewTestRepoForEngine(t)
+	defer cleanup()
+
+	subID, err := r.PutManifest("sub", dedup.Manifest{
+		Files: map[string]dedup.ManifestEntry{
+			"old.txt":       {},
+			"sub/nested.txt": {},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PutManifest(sub) error = %v", err)
+	}
+	if err := r.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	dataMount := containertypes.MountPoint{Type: mounttypes.TypeBind, Source: "/s", Destination: "/data"}
+
+	tests := []struct {
+		name   string
+		parent *dedup.Manifest
+		mounts []containertypes.MountPoint
+		want   map[string]map[string]struct{}
+	}{
+		{
+			name:   "nil parent returns nil",
+			parent: nil,
+			mounts: []containertypes.MountPoint{dataMount},
+			want:   nil,
+		},
+		{
+			name: "sub-manifest resolves to per-volume paths keyed by source",
+			parent: &dedup.Manifest{Files: map[string]dedup.ManifestEntry{
+				containerVolPrefix + "/data": {Chunks: []dedup.ID{subID}},
+			}},
+			mounts: []containertypes.MountPoint{dataMount},
+			want:   map[string]map[string]struct{}{"/s": {"old.txt": {}, "sub/nested.txt": {}}},
+		},
+		{
+			name:   "mount destination absent from parent is omitted",
+			parent: &dedup.Manifest{Files: map[string]dedup.ManifestEntry{}},
+			mounts: []containertypes.MountPoint{dataMount},
+			want:   nil,
+		},
+		{
+			name: "skipped volume (empty chunks sentinel) is omitted",
+			parent: &dedup.Manifest{Files: map[string]dedup.ManifestEntry{
+				containerVolPrefix + "/data": {Size: volumeSkippedSize},
+			}},
+			mounts: []containertypes.MountPoint{dataMount},
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := chunkedPrevBySource(tt.parent, tt.mounts, r)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("chunkedPrevBySource() = %#v, want %#v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/engine/container_chunked_test.go
+++ b/internal/engine/container_chunked_test.go
@@ -57,6 +57,433 @@ func newRunningMock(t *testing.T, running bool) *mockDockerClient {
 // when shouldRestart is true).
 func noopProgress(_ string, _ int, _ string) {}
 
+// TestBackupChunked_DifferentialProducesCompleteManifest is the regression
+// test for issue #320 (dedup path). A differential/incremental chunked
+// container backup must produce a COMPLETE volume sub-manifest — unchanged
+// files must be retained — because the dedup restore path restores the
+// selected manifest alone and assumes it is complete. Before the fix,
+// FolderHandler.BackupChunked honoured changed_since and dropped old.txt,
+// so a differential restore lost the base files.
+func TestBackupChunked_DifferentialProducesCompleteManifest(t *testing.T) {
+	t.Parallel()
+
+	changedSince := time.Now().Add(-1 * time.Hour).Truncate(time.Second)
+
+	writeOld := func(dir string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, "old.txt"), []byte("old"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(filepath.Join(dir, "old.txt"), changedSince.Add(-time.Hour), changedSince.Add(-time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Full backup: a single volume containing only old.txt.
+	fullVol := t.TempDir()
+	writeOld(fullVol)
+	fullMock := &mockDockerClient{
+		inspectResp: client.ContainerInspectResult{
+			Container: containertypes.InspectResponse{
+				ID:     "abc123",
+				Name:   "/test",
+				Config: &containertypes.Config{Image: "nginx:latest"},
+				State:  &containertypes.State{Running: false},
+				Mounts: []containertypes.MountPoint{
+					{Type: mounttypes.TypeBind, Source: fullVol, Destination: "/data"},
+				},
+			},
+		},
+		imageResp: client.ImageInspectResult{
+			InspectResponse: imagetypes.InspectResponse{
+				RepoDigests: []string{"nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+			},
+		},
+	}
+
+	r, _, cleanup := dedup.NewTestRepoForEngine(t)
+	defer cleanup()
+
+	fh := &ContainerHandler{cli: fullMock}
+	fullID, err := fh.BackupChunked(context.Background(), BackupItem{
+		Name:     "test",
+		Type:     "container",
+		Settings: map[string]any{"id": "abc123"},
+	}, r, nil, noopProgress)
+	if err != nil {
+		t.Fatalf("full BackupChunked() error = %v", err)
+	}
+	if err := r.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	parent, err := r.GetManifest(fullID)
+	if err != nil {
+		t.Fatalf("GetManifest(parent) error = %v", err)
+	}
+
+	// Differential backup: the same volume now holds old.txt (unchanged) plus
+	// a freshly-written new.txt.
+	diffVol := t.TempDir()
+	writeOld(diffVol)
+	if err := os.WriteFile(filepath.Join(diffVol, "new.txt"), []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	diffMock := &mockDockerClient{
+		inspectResp: client.ContainerInspectResult{
+			Container: containertypes.InspectResponse{
+				ID:     "abc123",
+				Name:   "/test",
+				Config: &containertypes.Config{Image: "nginx:latest"},
+				State:  &containertypes.State{Running: false},
+				Mounts: []containertypes.MountPoint{
+					{Type: mounttypes.TypeBind, Source: diffVol, Destination: "/data"},
+				},
+			},
+		},
+		imageResp: client.ImageInspectResult{
+			InspectResponse: imagetypes.InspectResponse{
+				RepoDigests: []string{"nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+			},
+		},
+	}
+
+	dh := &ContainerHandler{cli: diffMock}
+	manifestID, err := dh.BackupChunked(context.Background(), BackupItem{
+		Name: "test",
+		Type: "container",
+		Settings: map[string]any{
+			"id":            "abc123",
+			"changed_since": changedSince.UTC().Format(time.RFC3339),
+		},
+	}, r, &parent, noopProgress)
+	if err != nil {
+		t.Fatalf("differential BackupChunked() error = %v", err)
+	}
+	if err := r.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	m, err := r.GetManifest(manifestID)
+	if err != nil {
+		t.Fatalf("GetManifest() error = %v", err)
+	}
+
+	volEntry, ok := m.Files[containerVolPrefix+"/data"]
+	if !ok {
+		t.Fatalf("manifest missing %s/data entry", containerVolPrefix)
+	}
+	if volEntry.Size == volumeSkippedSize {
+		t.Fatalf("volume was skipped (Size == volumeSkippedSize); expected a complete sub-manifest")
+	}
+	if len(volEntry.Chunks) != 1 {
+		t.Fatalf("volume sub-manifest chunks = %d, want 1", len(volEntry.Chunks))
+	}
+
+	sub, err := r.GetManifest(volEntry.Chunks[0])
+	if err != nil {
+		t.Fatalf("GetManifest(sub) error = %v", err)
+	}
+	if _, ok := sub.Files["old.txt"]; !ok {
+		t.Errorf("sub-manifest missing old.txt — unchanged files must be retained for single-point restore")
+	}
+	if _, ok := sub.Files["new.txt"]; !ok {
+		t.Errorf("sub-manifest missing new.txt")
+	}
+}
+
+// TestBackupChunked_NewVolumeChunkedFully is the regression test for the
+// "new items missing" data-loss class in issue #320. A differential backup of
+// a container with a newly-added volume (no matching entry in the parent
+// manifest) must chunk that volume FULLY — even when the volume's files and
+// directory predate changed_since — rather than recording an empty
+// sub-manifest. Before the fix, changed_since was applied with a nil parent
+// and every old-mtime file was silently dropped.
+func TestBackupChunked_NewVolumeChunkedFully(t *testing.T) {
+	t.Parallel()
+
+	changedSince := time.Now().Add(-1 * time.Hour).Truncate(time.Second)
+	writeOldFile := func(dir string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, "old.txt"), []byte("old"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(filepath.Join(dir, "old.txt"), changedSince.Add(-time.Hour), changedSince.Add(-time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Full backup: a container with a single volume "/data" holding old.txt.
+	fullVol := t.TempDir()
+	writeOldFile(fullVol)
+	fullMock := &mockDockerClient{
+		inspectResp: client.ContainerInspectResult{
+			Container: containertypes.InspectResponse{
+				ID:     "abc123",
+				Name:   "/test",
+				Config: &containertypes.Config{Image: "nginx:latest"},
+				State:  &containertypes.State{Running: false},
+				Mounts: []containertypes.MountPoint{
+					{Type: mounttypes.TypeBind, Source: fullVol, Destination: "/data"},
+				},
+			},
+		},
+		imageResp: client.ImageInspectResult{
+			InspectResponse: imagetypes.InspectResponse{
+				RepoDigests: []string{"nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+			},
+		},
+	}
+
+	r, _, cleanup := dedup.NewTestRepoForEngine(t)
+	defer cleanup()
+
+	fullID, err := (&ContainerHandler{cli: fullMock}).BackupChunked(context.Background(), BackupItem{
+		Name:     "test",
+		Type:     "container",
+		Settings: map[string]any{"id": "abc123"},
+	}, r, nil, noopProgress)
+	if err != nil {
+		t.Fatalf("full BackupChunked() error = %v", err)
+	}
+	if err := r.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	parent, err := r.GetManifest(fullID)
+	if err != nil {
+		t.Fatalf("GetManifest(parent) error = %v", err)
+	}
+
+	// Differential backup: the container now exposes a DIFFERENT, newly-added
+	// volume "/newdata". Its only file (and the volume dir) predate
+	// changed_since, so it looks "unchanged" — but there is no parent entry to
+	// carry forward from, so it must be chunked fully.
+	newVol := t.TempDir()
+	file := filepath.Join(newVol, "fresh_old.txt")
+	if err := os.WriteFile(file, []byte("kept"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{file, newVol} {
+		if err := os.Chtimes(p, changedSince.Add(-time.Hour), changedSince.Add(-time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	diffMock := &mockDockerClient{
+		inspectResp: client.ContainerInspectResult{
+			Container: containertypes.InspectResponse{
+				ID:     "abc123",
+				Name:   "/test",
+				Config: &containertypes.Config{Image: "nginx:latest"},
+				State:  &containertypes.State{Running: false},
+				Mounts: []containertypes.MountPoint{
+					{Type: mounttypes.TypeBind, Source: newVol, Destination: "/newdata"},
+				},
+			},
+		},
+		imageResp: client.ImageInspectResult{
+			InspectResponse: imagetypes.InspectResponse{
+				RepoDigests: []string{"nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+			},
+		},
+	}
+
+	manifestID, err := (&ContainerHandler{cli: diffMock}).BackupChunked(context.Background(), BackupItem{
+		Name: "test",
+		Type: "container",
+		Settings: map[string]any{
+			"id":            "abc123",
+			"changed_since": changedSince.UTC().Format(time.RFC3339),
+		},
+	}, r, &parent, noopProgress)
+	if err != nil {
+		t.Fatalf("differential BackupChunked() error = %v", err)
+	}
+	if err := r.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	m, err := r.GetManifest(manifestID)
+	if err != nil {
+		t.Fatalf("GetManifest() error = %v", err)
+	}
+
+	volEntry, ok := m.Files[containerVolPrefix+"/newdata"]
+	if !ok {
+		t.Fatalf("manifest missing %s/newdata entry", containerVolPrefix)
+	}
+	if volEntry.Size == volumeSkippedSize {
+		t.Fatalf("new volume was skipped (Size == volumeSkippedSize); expected a complete sub-manifest")
+	}
+	if len(volEntry.Chunks) != 1 {
+		t.Fatalf("volume sub-manifest chunks = %d, want 1", len(volEntry.Chunks))
+	}
+
+	sub, err := r.GetManifest(volEntry.Chunks[0])
+	if err != nil {
+		t.Fatalf("GetManifest(sub) error = %v", err)
+	}
+	if _, ok := sub.Files["fresh_old.txt"]; !ok {
+		t.Errorf("new volume sub-manifest missing fresh_old.txt — a new volume with old-mtime files must be chunked fully")
+	}
+}
+
+// chunkedMockWithVolume builds a stopped mockDockerClient exposing a single
+// /data bind mount backed by volSrc, with a valid image inspect response.
+func chunkedMockWithVolume(t *testing.T, volSrc string) *mockDockerClient {
+	t.Helper()
+	return &mockDockerClient{
+		inspectResp: client.ContainerInspectResult{
+			Container: containertypes.InspectResponse{
+				ID:     "abc123",
+				Name:   "/test",
+				Config: &containertypes.Config{Image: "nginx:latest"},
+				State:  &containertypes.State{Running: false},
+				Mounts: []containertypes.MountPoint{
+					{Type: mounttypes.TypeBind, Source: volSrc, Destination: "/data"},
+				},
+			},
+		},
+		imageResp: client.ImageInspectResult{
+			InspectResponse: imagetypes.InspectResponse{
+				RepoDigests: []string{"nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+			},
+		},
+	}
+}
+
+// TestBackupChunked_UnchangedVolumeCarryForward is the regression test for two
+// silent data-loss gaps in the dedup container flow (issue #320):
+//   - a NEW file with a stale mtime (cp -a / rsync -a) in an otherwise
+//     mtime-unchanged volume must still be chunked, not dropped by the
+//     volume-level mtime gate;
+//   - a pre-PR parent entry that recorded an unchanged volume as the -1 skip
+//     sentinel must be re-chunked fully, not carried forward and skipped on
+//     restore.
+func TestBackupChunked_UnchangedVolumeCarryForward(t *testing.T) {
+	t.Parallel()
+
+	reference := time.Now().Add(-1 * time.Hour).Truncate(time.Second)
+	stale := reference.Add(-time.Hour)
+
+	writeFile := func(t *testing.T, dir, name string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// pinOld stamps the files AND the volume root dir with a stale mtime so
+	// pathChangedSince reports the volume unchanged — the root dir's mtime is
+	// itself a change signal (pathChangedSinceWithPrev checks it), and writing
+	// the files bumps it.
+	pinOld := func(t *testing.T, dir string, names []string) {
+		t.Helper()
+		for _, name := range names {
+			if err := os.Chtimes(filepath.Join(dir, name), stale, stale); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := os.Chtimes(dir, stale, stale); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cases := []struct {
+		name      string
+		parent    string   // "submanifest" (a real full-backup parent) or "sentinel" (a pre-PR -1 entry)
+		diffFiles []string // files written into the differential volume, all with stale mtimes
+		wantFiles []string // files that must appear in the resulting sub-manifest
+	}{
+		{
+			name:      "stale-mtime new file in an unchanged volume is chunked",
+			parent:    "submanifest",
+			diffFiles: []string{"old.txt", "new_stale.txt"},
+			wantFiles: []string{"old.txt", "new_stale.txt"},
+		},
+		{
+			name:      "pre-PR sentinel parent entry is re-chunked fully",
+			parent:    "sentinel",
+			diffFiles: []string{"old.txt"},
+			wantFiles: []string{"old.txt"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, _, cleanup := dedup.NewTestRepoForEngine(t)
+			defer cleanup()
+
+			var parent dedup.Manifest
+			switch tc.parent {
+			case "submanifest":
+				fullVol := t.TempDir()
+				writeFile(t, fullVol, "old.txt")
+				pinOld(t, fullVol, []string{"old.txt"})
+				fullID, err := (&ContainerHandler{cli: chunkedMockWithVolume(t, fullVol)}).BackupChunked(context.Background(), BackupItem{
+					Name: "test", Type: "container", Settings: map[string]any{"id": "abc123"},
+				}, r, nil, noopProgress)
+				if err != nil {
+					t.Fatalf("full BackupChunked() error = %v", err)
+				}
+				if err := r.Flush(); err != nil {
+					t.Fatalf("Flush() error = %v", err)
+				}
+				parent, err = r.GetManifest(fullID)
+				if err != nil {
+					t.Fatalf("GetManifest(parent) error = %v", err)
+				}
+			case "sentinel":
+				parent = dedup.Manifest{
+					Item:  "test",
+					Files: map[string]dedup.ManifestEntry{containerVolPrefix + "/data": {Size: volumeSkippedSize}},
+				}
+			}
+
+			diffVol := t.TempDir()
+			for _, name := range tc.diffFiles {
+				writeFile(t, diffVol, name)
+			}
+			pinOld(t, diffVol, tc.diffFiles)
+
+			manifestID, err := (&ContainerHandler{cli: chunkedMockWithVolume(t, diffVol)}).BackupChunked(context.Background(), BackupItem{
+				Name: "test", Type: "container",
+				Settings: map[string]any{
+					"id":            "abc123",
+					"changed_since": reference.UTC().Format(time.RFC3339),
+				},
+			}, r, &parent, noopProgress)
+			if err != nil {
+				t.Fatalf("differential BackupChunked() error = %v", err)
+			}
+			if err := r.Flush(); err != nil {
+				t.Fatalf("Flush() error = %v", err)
+			}
+
+			m, err := r.GetManifest(manifestID)
+			if err != nil {
+				t.Fatalf("GetManifest() error = %v", err)
+			}
+			entry, ok := m.Files[containerVolPrefix+"/data"]
+			if !ok {
+				t.Fatalf("manifest missing %s/data entry", containerVolPrefix)
+			}
+			if entry.Size == volumeSkippedSize {
+				t.Fatalf("volume was skipped (Size == volumeSkippedSize); expected a complete sub-manifest")
+			}
+			if len(entry.Chunks) != 1 {
+				t.Fatalf("volume sub-manifest chunks = %d, want 1", len(entry.Chunks))
+			}
+			sub, err := r.GetManifest(entry.Chunks[0])
+			if err != nil {
+				t.Fatalf("GetManifest(sub) error = %v", err)
+			}
+			for _, want := range tc.wantFiles {
+				if _, ok := sub.Files[want]; !ok {
+					t.Errorf("sub-manifest missing %s", want)
+				}
+			}
+		})
+	}
+}
+
 // TestBackupChunked_StopRestartBehaviour consolidates the stop/restart
 // lifecycle tests for BackupChunked into a single table-driven test.
 // Each case varies the container running state, no_stop setting, and
@@ -126,7 +553,7 @@ func TestBackupChunked_StopRestartBehaviour(t *testing.T) {
 				progress = nil
 			}
 
-			_, err := h.BackupChunked(context.Background(), item, r, progress)
+			_, err := h.BackupChunked(context.Background(), item, r, nil, progress)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -197,7 +624,7 @@ func TestBackupChunked_RestartsOnBackupError(t *testing.T) {
 
 	// BackupChunked should fail because the mount source doesn't exist,
 	// but the container must still be restarted.
-	_, err := h.BackupChunked(context.Background(), item, r, noopProgress)
+	_, err := h.BackupChunked(context.Background(), item, r, nil, noopProgress)
 	if err == nil {
 		t.Fatal("expected BackupChunked to fail for nonexistent mount source")
 	}
@@ -250,24 +677,25 @@ func newChunkedMockForChangedSince(t *testing.T, volMtime time.Time) *mockDocker
 // pre-check tests for BackupChunked into a single table-driven test.
 // Each case varies whether the volume's files are older or newer than the
 // changed_since reference, then asserts whether ContainerStop and
-// ContainerStart were called. The unchanged case additionally verifies
-// the manifest records the volume as skipped.
+// ContainerStart were called. The unchanged case additionally verifies the
+// manifest records a complete sub-manifest for the unchanged volume (rather
+// than a volumeSkippedSize sentinel).
 func TestBackupChunked_DifferentialStopBehaviour(t *testing.T) {
 	reference := time.Now().Add(-1 * time.Hour)
 
 	cases := []struct {
-		name           string
-		volMtime       time.Time // mtime applied to the volume's file and dir
-		wantStopCall   bool
-		wantStartCall  bool
-		checkSkipEntry bool // when true, verify manifest has volumeSkippedSize entry
+		name                     string
+		volMtime                 time.Time // mtime applied to the volume's file and dir
+		wantStopCall             bool
+		wantStartCall            bool
+		checkCompleteSubManifest bool // when true, verify the volume was NOT skipped (a complete sub-manifest was recorded)
 	}{
 		{
-			name:           "no_changes_skips_stop",
-			volMtime:       time.Now().Add(-2 * time.Hour),
-			wantStopCall:   false,
-			wantStartCall:  false,
-			checkSkipEntry: true,
+			name:                     "no_changes_skips_stop",
+			volMtime:                 time.Now().Add(-2 * time.Hour),
+			wantStopCall:             false,
+			wantStartCall:            false,
+			checkCompleteSubManifest: true,
 		},
 		{
 			name:          "volume_changed_stops_and_restarts",
@@ -294,7 +722,7 @@ func TestBackupChunked_DifferentialStopBehaviour(t *testing.T) {
 				},
 			}
 
-			manifestID, err := h.BackupChunked(context.Background(), item, r, noopProgress)
+			manifestID, err := h.BackupChunked(context.Background(), item, r, nil, noopProgress)
 			if err != nil {
 				t.Fatalf("BackupChunked() error = %v", err)
 			}
@@ -305,7 +733,7 @@ func TestBackupChunked_DifferentialStopBehaviour(t *testing.T) {
 				t.Errorf("startCalled = %v, want %v", mock.startCalled, tc.wantStartCall)
 			}
 
-			if tc.checkSkipEntry {
+			if tc.checkCompleteSubManifest {
 				if err := r.Flush(); err != nil {
 					t.Fatalf("Flush() error = %v", err)
 				}
@@ -317,8 +745,11 @@ func TestBackupChunked_DifferentialStopBehaviour(t *testing.T) {
 				if !ok {
 					t.Fatalf("manifest missing %s/data entry", containerVolPrefix)
 				}
-				if entry.Size != volumeSkippedSize {
-					t.Errorf("volume entry Size = %d, want volumeSkippedSize (%d)", entry.Size, volumeSkippedSize)
+				if entry.Size == volumeSkippedSize {
+					t.Errorf("volume entry was skipped (Size == volumeSkippedSize); expected a complete sub-manifest")
+				}
+				if len(entry.Chunks) != 1 {
+					t.Errorf("volume sub-manifest chunks = %d, want 1", len(entry.Chunks))
 				}
 			}
 		})
@@ -349,7 +780,7 @@ func TestBackupChunked_AllMountsExcluded(t *testing.T) {
 		},
 	}
 
-	_, err := h.BackupChunked(context.Background(), item, r, noopProgress)
+	_, err := h.BackupChunked(context.Background(), item, r, nil, noopProgress)
 	if err == nil {
 		t.Fatal("BackupChunked succeeded with every eligible mount excluded — " +
 			"that commits a restore point holding no volume data")

--- a/internal/engine/container_chunked_test.go
+++ b/internal/engine/container_chunked_test.go
@@ -819,6 +819,7 @@ func TestBackupChunkedStopDecisionPrevAware(t *testing.T) {
 	tests := []struct {
 		name       string
 		mutateDiff func(t *testing.T, diffVol string)
+		mutatePar  func(t *testing.T, parent *dedup.Manifest)
 		wantStop   bool
 	}{
 		{
@@ -832,6 +833,21 @@ func TestBackupChunkedStopDecisionPrevAware(t *testing.T) {
 			name:       "unchanged volume does not stop a running container",
 			mutateDiff: func(t *testing.T, diffVol string) {},
 			wantStop:   false,
+		},
+		{
+			// Regression (issue #320 review follow-up): a parent manifest
+			// without an entry for the current volume must still stop the
+			// container. chunkedPrevBySource maps such a volume to an EMPTY
+			// set, so old.txt reports as absent-from-parent (changed) and
+			// needsStop stays set — the archiving loop will take the
+			// full-chunk fallback, which must not run against a live
+			// container.
+			name:       "parent manifest missing the volume entry stops a running container",
+			mutateDiff: func(t *testing.T, diffVol string) {},
+			mutatePar: func(t *testing.T, parent *dedup.Manifest) {
+				delete(parent.Files, containerVolPrefix+"/data")
+			},
+			wantStop: true,
 		},
 	}
 
@@ -876,6 +892,9 @@ func TestBackupChunkedStopDecisionPrevAware(t *testing.T) {
 			parent, err := r.GetManifest(fullID)
 			if err != nil {
 				t.Fatalf("GetManifest(parent) error = %v", err)
+			}
+			if tt.mutatePar != nil {
+				tt.mutatePar(t, &parent)
 			}
 
 			// Differential backup: running container, same volume plus the
@@ -927,8 +946,11 @@ func TestBackupChunkedStopDecisionPrevAware(t *testing.T) {
 // TestChunkedPrevBySource verifies the per-volume previous-listing derivation
 // used by the chunked stop decision: it resolves each mount's parent
 // sub-manifest (via the containerVolPrefix+destination key) into a
-// volume-relative path set keyed by mount source, and degrades gracefully (nil
-// or omitted volume) when the parent has nothing to carry forward from.
+// volume-relative path set keyed by mount source. A volume with no usable
+// parent entry (absent key, skip sentinel, or unreadable sub-manifest) gets an
+// EMPTY set rather than being omitted — every pre-existing file then reports
+// as changed, which keeps needsStop set for the archiving loop's full-chunk
+// fallback (issue #320 review follow-up). Only a nil parent/repo returns nil.
 func TestChunkedPrevBySource(t *testing.T) {
 	r, _, cleanup := dedup.NewTestRepoForEngine(t)
 	defer cleanup()
@@ -944,6 +966,11 @@ func TestChunkedPrevBySource(t *testing.T) {
 	}
 	if err := r.Flush(); err != nil {
 		t.Fatalf("Flush() error = %v", err)
+	}
+	// An ID that was never written: GetManifest must fail on it.
+	var missingID dedup.ID
+	for i := range missingID {
+		missingID[i] = 0xFF
 	}
 
 	dataMount := containertypes.MountPoint{Type: mounttypes.TypeBind, Source: "/s", Destination: "/data"}
@@ -969,18 +996,26 @@ func TestChunkedPrevBySource(t *testing.T) {
 			want:   map[string]map[string]struct{}{"/s": {"old.txt": {}, "sub/nested.txt": {}}},
 		},
 		{
-			name:   "mount destination absent from parent is omitted",
+			name:   "mount destination absent from parent yields an empty set",
 			parent: &dedup.Manifest{Files: map[string]dedup.ManifestEntry{}},
 			mounts: []containertypes.MountPoint{dataMount},
-			want:   nil,
+			want:   map[string]map[string]struct{}{"/s": {}},
 		},
 		{
-			name: "skipped volume (empty chunks sentinel) is omitted",
+			name: "skipped volume (empty chunks sentinel) yields an empty set",
 			parent: &dedup.Manifest{Files: map[string]dedup.ManifestEntry{
 				containerVolPrefix + "/data": {Size: volumeSkippedSize},
 			}},
 			mounts: []containertypes.MountPoint{dataMount},
-			want:   nil,
+			want:   map[string]map[string]struct{}{"/s": {}},
+		},
+		{
+			name: "unreadable sub-manifest yields an empty set",
+			parent: &dedup.Manifest{Files: map[string]dedup.ManifestEntry{
+				containerVolPrefix + "/data": {Chunks: []dedup.ID{missingID}},
+			}},
+			mounts: []containertypes.MountPoint{dataMount},
+			want:   map[string]map[string]struct{}{"/s": {}},
 		},
 	}
 

--- a/internal/engine/container_coverage_test.go
+++ b/internal/engine/container_coverage_test.go
@@ -196,7 +196,7 @@ func TestUntarDirectoryFiltered_TypeReg_DeepParent(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	archive := filepath.Join(t.TempDir(), "deep.tar")
-	if err := tarDirectoryFiltered(context.Background(), src, archive, time.Time{}, nil, CompressionNone); err != nil {
+	if err := tarDirectoryFilteredWithPrev(context.Background(), src, archive, time.Time{}, nil, CompressionNone, nil); err != nil {
 		t.Fatalf("tarDirectoryFiltered: %v", err)
 	}
 

--- a/internal/engine/container_helpers_test.go
+++ b/internal/engine/container_helpers_test.go
@@ -102,7 +102,7 @@ func TestTarDirectoryFilteredIncludesAllWhenChangedSinceZero(t *testing.T) {
 	}
 
 	dst := filepath.Join(t.TempDir(), "out.tar")
-	err := tarDirectoryFiltered(context.Background(), src, dst, time.Time{}, nil, CompressionNone)
+	err := tarDirectoryFilteredWithPrev(context.Background(), src, dst, time.Time{}, nil, CompressionNone, nil)
 	if err != nil {
 		t.Fatalf("tarDirectoryFiltered: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestTarDirectoryFilteredSkipsOlderFiles(t *testing.T) {
 
 	dst := filepath.Join(t.TempDir(), "out.tar")
 	// changedSince = 1h ago — old file should be skipped, new file kept.
-	err := tarDirectoryFiltered(context.Background(), src, dst, time.Now().Add(-1*time.Hour), nil, CompressionNone)
+	err := tarDirectoryFilteredWithPrev(context.Background(), src, dst, time.Now().Add(-1*time.Hour), nil, CompressionNone, nil)
 	if err != nil {
 		t.Fatalf("tarDirectoryFiltered: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestTarDirectoryFilteredHonoursExclusions(t *testing.T) {
 	}
 
 	dst := filepath.Join(t.TempDir(), "out.tar")
-	err := tarDirectoryFiltered(context.Background(), src, dst, time.Time{}, []string{"*.log", "logs"}, CompressionNone)
+	err := tarDirectoryFilteredWithPrev(context.Background(), src, dst, time.Time{}, []string{"*.log", "logs"}, CompressionNone, nil)
 	if err != nil {
 		t.Fatalf("tarDirectoryFiltered: %v", err)
 	}
@@ -200,7 +200,7 @@ func TestTarDirectoryFilteredCancelledContext(t *testing.T) {
 	cancel()
 
 	dst := filepath.Join(t.TempDir(), "out.tar")
-	err := tarDirectoryFiltered(ctx, src, dst, time.Time{}, nil, CompressionNone)
+	err := tarDirectoryFilteredWithPrev(ctx, src, dst, time.Time{}, nil, CompressionNone, nil)
 	if err == nil {
 		t.Fatal("expected ctx.Err() to surface when context is cancelled")
 	}
@@ -210,7 +210,7 @@ func TestTarDirectoryFilteredMissingSrc(t *testing.T) {
 	t.Parallel()
 
 	dst := filepath.Join(t.TempDir(), "out.tar")
-	err := tarDirectoryFiltered(context.Background(), filepath.Join(t.TempDir(), "does-not-exist"), dst, time.Time{}, nil, CompressionNone)
+	err := tarDirectoryFilteredWithPrev(context.Background(), filepath.Join(t.TempDir(), "does-not-exist"), dst, time.Time{}, nil, CompressionNone, nil)
 	if err == nil {
 		t.Fatal("expected error opening missing source root")
 	}
@@ -353,7 +353,7 @@ func TestTarDirectoryFilteredPreservesSymlinks(t *testing.T) {
 	}
 
 	dst := filepath.Join(t.TempDir(), "out.tar")
-	if err := tarDirectoryFiltered(context.Background(), src, dst, time.Time{}, nil, CompressionNone); err != nil {
+	if err := tarDirectoryFilteredWithPrev(context.Background(), src, dst, time.Time{}, nil, CompressionNone, nil); err != nil {
 		t.Fatalf("tarDirectoryFiltered: %v", err)
 	}
 
@@ -473,7 +473,7 @@ func TestUntarDirectoryFilteredCancelledContext(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	archive := filepath.Join(t.TempDir(), "ctx.tar")
-	if err := tarDirectoryFiltered(context.Background(), src, archive, time.Time{}, nil, CompressionNone); err != nil {
+	if err := tarDirectoryFilteredWithPrev(context.Background(), src, archive, time.Time{}, nil, CompressionNone, nil); err != nil {
 		t.Fatalf("tarDirectoryFiltered: %v", err)
 	}
 
@@ -498,7 +498,7 @@ func TestUntarDirectoryFilteredAppliesIncludeFilter(t *testing.T) {
 	}
 
 	archive := filepath.Join(t.TempDir(), "with-filter.tar")
-	if err := tarDirectoryFiltered(context.Background(), src, archive, time.Time{}, nil, CompressionNone); err != nil {
+	if err := tarDirectoryFilteredWithPrev(context.Background(), src, archive, time.Time{}, nil, CompressionNone, nil); err != nil {
 		t.Fatalf("tarDirectoryFiltered: %v", err)
 	}
 
@@ -547,4 +547,76 @@ func containsName(names []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// TestTarDirectoryFilteredWithPrevNewFiles covers the classic-path half of
+// issue #320: a NEW file whose mtime predates changed_since (absent from the
+// previous backup's listing) must be archived, while unchanged files present in
+// the listing are still skipped. A nil prev set preserves the mtime-only
+// behaviour.
+func TestTarDirectoryFilteredWithPrevNewFiles(t *testing.T) {
+	t.Parallel()
+
+	changedSince := time.Now().Add(-1 * time.Hour)
+	stale := time.Now().Add(-3 * time.Hour)
+
+	tests := []struct {
+		name      string
+		prevPaths map[string]struct{}
+		wantSkip  []string
+		wantKeep  []string
+	}{
+		{
+			name:      "new file with stale mtime is archived when absent from prev set",
+			prevPaths: map[string]struct{}{"old.txt": {}},
+			wantSkip:  []string{"old.txt"},
+			wantKeep:  []string{"added.txt", "fresh.txt"},
+		},
+		{
+			name:      "nil prev set preserves mtime-only behaviour",
+			prevPaths: nil,
+			wantSkip:  []string{"old.txt", "added.txt"},
+			wantKeep:  []string{"fresh.txt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			src := t.TempDir()
+			writeStale := func(name, content string) {
+				p := filepath.Join(src, name)
+				if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chtimes(p, stale, stale); err != nil {
+					t.Fatal(err)
+				}
+			}
+			writeStale("old.txt", "old")
+			writeStale("added.txt", "added")
+			fresh := filepath.Join(src, "fresh.txt")
+			if err := os.WriteFile(fresh, []byte("fresh"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			dst := filepath.Join(t.TempDir(), "out.tar")
+			if err := tarDirectoryFilteredWithPrev(context.Background(), src, dst, changedSince, nil, CompressionNone, tt.prevPaths); err != nil {
+				t.Fatalf("tarDirectoryFilteredWithPrev: %v", err)
+			}
+
+			names := listTarEntries(t, dst)
+			for _, skip := range tt.wantSkip {
+				if containsName(names, skip) {
+					t.Errorf("expected %q to be skipped, got %v", skip, names)
+				}
+			}
+			for _, keep := range tt.wantKeep {
+				if !containsName(names, keep) {
+					t.Errorf("expected %q to be kept, got %v", keep, names)
+				}
+			}
+		})
+	}
 }

--- a/internal/engine/container_merge.go
+++ b/internal/engine/container_merge.go
@@ -1,0 +1,136 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// MergeContainerChainStaging merges per-chain-step staging directories for a
+// classic container restore into a single directory that
+// ContainerHandler.Restore can consume. Sidecar files (config.json,
+// template.xml, volumes.json) are taken from the newest step that has them;
+// image.tar (whose compression suffix varies) is located via findArchive.
+// Each volume_*.tar is the overlay of every step's archive, oldest first, so
+// unchanged files from the base full backup survive a later partial
+// differential/incremental archive (issue #320). stepDirs MUST be ordered
+// oldest first.
+func MergeContainerChainStaging(ctx context.Context, stepDirs []string, outDir string) error {
+	if err := os.MkdirAll(outDir, 0o750); err != nil {
+		return fmt.Errorf("creating merge dir: %w", err)
+	}
+
+	// Plain sidecars: newest step wins.
+	for _, name := range []string{"config.json", "template.xml", "volumes.json"} {
+		for i := len(stepDirs) - 1; i >= 0; i-- {
+			src := filepath.Join(stepDirs[i], name)
+			if _, err := os.Stat(src); err == nil {
+				if err := mergeCopyFile(src, filepath.Join(outDir, name)); err != nil {
+					return fmt.Errorf("merge sidecar %s: %w", name, err)
+				}
+				break
+			}
+		}
+	}
+
+	// image.tar: locate across steps (compression suffix varies).
+	for i := len(stepDirs) - 1; i >= 0; i-- {
+		if src, err := findArchive(stepDirs[i], "image.tar"); err == nil {
+			if err := mergeCopyFile(src, filepath.Join(outDir, filepath.Base(src))); err != nil {
+				return fmt.Errorf("merge image archive: %w", err)
+			}
+			break
+		}
+	}
+
+	// Collect distinct volume archive base names (e.g. "volume_0.tar") across
+	// every step, normalising the compression suffix.
+	bases := map[string]struct{}{}
+	for _, dir := range stepDirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if !strings.HasPrefix(name, "volume_") {
+				continue
+			}
+			base := name
+			if i := strings.Index(base, ".tar"); i >= 0 {
+				base = base[:i] + ".tar"
+			}
+			bases[base] = struct{}{}
+		}
+	}
+
+	sorted := make([]string, 0, len(bases))
+	for b := range bases {
+		sorted = append(sorted, b)
+	}
+	sort.Strings(sorted)
+
+	for _, base := range sorted {
+		work := filepath.Join(outDir, base+".merge")
+		if err := os.MkdirAll(work, 0o750); err != nil {
+			return fmt.Errorf("creating work dir for %s: %w", base, err)
+		}
+		// Overlay each step's archive, oldest first. A step that did not
+		// archive this volume (unchanged) simply has no matching archive.
+		for _, dir := range stepDirs {
+			archive, err := findArchive(dir, base)
+			if err != nil {
+				continue
+			}
+			if err := untarDirectory(ctx, archive, work); err != nil {
+				return fmt.Errorf("extracting %s from %s: %w", base, dir, err)
+			}
+		}
+		// Re-tar the merged tree as a plain archive; findArchive checks the
+		// plain name first and untarDirectory auto-detects compression.
+		if err := tarDirectory(ctx, work, filepath.Join(outDir, base), nil, CompressionNone); err != nil {
+			return fmt.Errorf("creating merged %s: %w", base, err)
+		}
+		if err := os.RemoveAll(work); err != nil {
+			return fmt.Errorf("removing work dir for %s: %w", base, err)
+		}
+	}
+	return nil
+}
+
+func mergeCopyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// TarDirectory is an exported wrapper for tarDirectory, used by the runner
+// package's tests to stage volume archives without reaching into unexported
+// engine helpers.
+func TarDirectory(ctx context.Context, srcDir, destPath string, exclusions []string, compression string) error {
+	return tarDirectory(ctx, srcDir, destPath, exclusions, compression)
+}
+
+// UntarDirectory is an exported wrapper for untarDirectory, used by the
+// runner package's tests to inspect merged archives.
+func UntarDirectory(ctx context.Context, srcPath, destDir string) error {
+	return untarDirectory(ctx, srcPath, destDir)
+}

--- a/internal/engine/container_merge.go
+++ b/internal/engine/container_merge.go
@@ -111,26 +111,21 @@ func mergeCopyFile(src, dst string) error {
 		return err
 	}
 	defer in.Close()
-	out, err := os.Create(dst)
+
+	// Preserve the source's permission bits (e.g. config.json at 0600) instead
+	// of os.Create's 0666&umask default.
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 	if err != nil {
 		return err
 	}
 	if _, err := io.Copy(out, in); err != nil {
 		_ = out.Close()
+		_ = os.Remove(dst)
 		return err
 	}
 	return out.Close()
-}
-
-// TarDirectory is an exported wrapper for tarDirectory, used by the runner
-// package's tests to stage volume archives without reaching into unexported
-// engine helpers.
-func TarDirectory(ctx context.Context, srcDir, destPath string, exclusions []string, compression string) error {
-	return tarDirectory(ctx, srcDir, destPath, exclusions, compression)
-}
-
-// UntarDirectory is an exported wrapper for untarDirectory, used by the
-// runner package's tests to inspect merged archives.
-func UntarDirectory(ctx context.Context, srcPath, destDir string) error {
-	return untarDirectory(ctx, srcPath, destDir)
 }

--- a/internal/engine/container_merge_test.go
+++ b/internal/engine/container_merge_test.go
@@ -1,0 +1,75 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMergeContainerChainStagingOverlaysVolumes is the regression test for the
+// classic-path half of issue #320. The full step's volume_0.tar holds old.txt;
+// the differential step's volume_0.tar holds only new.txt. Merging must produce
+// a single volume_0.tar containing BOTH, so the engine's ContainerHandler.Restore
+// (which untars the merged archive once) restores the complete volume.
+func TestMergeContainerChainStagingOverlaysVolumes(t *testing.T) {
+	t.Parallel()
+
+	fullDir := t.TempDir()
+	diffDir := t.TempDir()
+
+	// Full step: old.txt only.
+	fullVol := filepath.Join(fullDir, "volroot")
+	if err := os.MkdirAll(fullVol, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fullVol, "old.txt"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := tarDirectory(context.Background(), fullVol, filepath.Join(fullDir, "volume_0.tar"), nil, CompressionNone); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fullDir, "config.json"), []byte(`{"full":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Differential step: new.txt only.
+	diffVol := filepath.Join(diffDir, "volroot")
+	if err := os.MkdirAll(diffVol, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(diffVol, "new.txt"), []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := tarDirectory(context.Background(), diffVol, filepath.Join(diffDir, "volume_0.tar"), nil, CompressionNone); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(diffDir, "config.json"), []byte(`{"diff":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	outDir := t.TempDir()
+	if err := MergeContainerChainStaging(context.Background(), []string{fullDir, diffDir}, outDir); err != nil {
+		t.Fatalf("MergeContainerChainStaging() error = %v", err)
+	}
+
+	// config.json comes from the newest step.
+	cfg, err := os.ReadFile(filepath.Join(outDir, "config.json"))
+	if err != nil {
+		t.Fatalf("read merged config.json: %v", err)
+	}
+	if string(cfg) != `{"diff":true}` {
+		t.Fatalf("merged config.json = %s, want the newest step's", string(cfg))
+	}
+
+	// Extract the merged volume archive and assert both files are present.
+	extract := t.TempDir()
+	if err := untarDirectory(context.Background(), filepath.Join(outDir, "volume_0.tar"), extract); err != nil {
+		t.Fatalf("untar merged volume: %v", err)
+	}
+	for _, name := range []string{"old.txt", "new.txt"} {
+		if _, err := os.Stat(filepath.Join(extract, name)); err != nil {
+			t.Errorf("merged volume missing %s: %v", name, err)
+		}
+	}
+}

--- a/internal/engine/container_merge_test.go
+++ b/internal/engine/container_merge_test.go
@@ -16,62 +16,61 @@ import (
 func TestMergeContainerChainStagingOverlaysVolumes(t *testing.T) {
 	t.Parallel()
 
-	fullDir := t.TempDir()
-	diffDir := t.TempDir()
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T) (stepDirs []string, wantConfig string)
+		wantVolume []string
+	}{
+		{
+			name: "differential step's partial volume overlays the full step's",
+			setup: func(t *testing.T) ([]string, string) {
+				// Full step: old.txt only.
+				fullDir := t.TempDir()
+				fullVol := filepath.Join(fullDir, "volroot")
+				if err := os.MkdirAll(fullVol, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(fullVol, "old.txt"), []byte("old"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := tarDirectory(context.Background(), fullVol, filepath.Join(fullDir, "volume_0.tar"), nil, CompressionNone); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(fullDir, "config.json"), []byte(`{"full":true}`), 0o600); err != nil {
+					t.Fatal(err)
+				}
 
-	// Full step: old.txt only.
-	fullVol := filepath.Join(fullDir, "volroot")
-	if err := os.MkdirAll(fullVol, 0o755); err != nil {
-		t.Fatal(err)
+				// Differential step: new.txt only.
+				diffDir := t.TempDir()
+				diffVol := filepath.Join(diffDir, "volroot")
+				if err := os.MkdirAll(diffVol, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(diffVol, "new.txt"), []byte("new"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := tarDirectory(context.Background(), diffVol, filepath.Join(diffDir, "volume_0.tar"), nil, CompressionNone); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(diffDir, "config.json"), []byte(`{"diff":true}`), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return []string{fullDir, diffDir}, `{"diff":true}`
+			},
+			wantVolume: []string{"old.txt", "new.txt"},
+		},
 	}
-	if err := os.WriteFile(filepath.Join(fullVol, "old.txt"), []byte("old"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := tarDirectory(context.Background(), fullVol, filepath.Join(fullDir, "volume_0.tar"), nil, CompressionNone); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(fullDir, "config.json"), []byte(`{"full":true}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	// Differential step: new.txt only.
-	diffVol := filepath.Join(diffDir, "volroot")
-	if err := os.MkdirAll(diffVol, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(diffVol, "new.txt"), []byte("new"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := tarDirectory(context.Background(), diffVol, filepath.Join(diffDir, "volume_0.tar"), nil, CompressionNone); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(diffDir, "config.json"), []byte(`{"diff":true}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	outDir := t.TempDir()
-	if err := MergeContainerChainStaging(context.Background(), []string{fullDir, diffDir}, outDir); err != nil {
-		t.Fatalf("MergeContainerChainStaging() error = %v", err)
-	}
-
-	// config.json comes from the newest step.
-	cfg, err := os.ReadFile(filepath.Join(outDir, "config.json"))
-	if err != nil {
-		t.Fatalf("read merged config.json: %v", err)
-	}
-	if string(cfg) != `{"diff":true}` {
-		t.Fatalf("merged config.json = %s, want the newest step's", string(cfg))
-	}
-
-	// Extract the merged volume archive and assert both files are present.
-	extract := t.TempDir()
-	if err := untarDirectory(context.Background(), filepath.Join(outDir, "volume_0.tar"), extract); err != nil {
-		t.Fatalf("untar merged volume: %v", err)
-	}
-	for _, name := range []string{"old.txt", "new.txt"} {
-		if _, err := os.Stat(filepath.Join(extract, name)); err != nil {
-			t.Errorf("merged volume missing %s: %v", name, err)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stepDirs, wantConfig := tt.setup(t)
+			outDir := t.TempDir()
+			if err := MergeContainerChainStaging(context.Background(), stepDirs, outDir); err != nil {
+				t.Fatalf("MergeContainerChainStaging() error = %v", err)
+			}
+			// config.json comes from the newest step.
+			assertMergedFile(t, outDir, "config.json", wantConfig)
+			assertMergedVolumeHas(t, outDir, tt.wantVolume...)
+		})
 	}
 }
 
@@ -80,30 +79,45 @@ func TestMergeContainerChainStagingOverlaysVolumes(t *testing.T) {
 func TestMergeCopyFilePreservesMode(t *testing.T) {
 	t.Parallel()
 
-	src := filepath.Join(t.TempDir(), "config.json")
-	if err := os.WriteFile(src, []byte(`{"a":1}`), 0o600); err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name    string
+		mode    os.FileMode
+		content string
+	}{
+		{
+			name:    "0600 source mode and content are copied",
+			mode:    0o600,
+			content: `{"a":1}`,
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := filepath.Join(t.TempDir(), "config.json")
+			if err := os.WriteFile(src, []byte(tt.content), tt.mode); err != nil {
+				t.Fatal(err)
+			}
 
-	dst := filepath.Join(t.TempDir(), "config.json")
-	if err := mergeCopyFile(src, dst); err != nil {
-		t.Fatalf("mergeCopyFile: %v", err)
-	}
+			dst := filepath.Join(t.TempDir(), "config.json")
+			if err := mergeCopyFile(src, dst); err != nil {
+				t.Fatalf("mergeCopyFile: %v", err)
+			}
 
-	info, err := os.Stat(dst)
-	if err != nil {
-		t.Fatalf("stat dst: %v", err)
-	}
-	if info.Mode().Perm() != 0o600 {
-		t.Errorf("dst mode = %o, want 600", info.Mode().Perm())
-	}
+			info, err := os.Stat(dst)
+			if err != nil {
+				t.Fatalf("stat dst: %v", err)
+			}
+			if info.Mode().Perm() != tt.mode {
+				t.Errorf("dst mode = %o, want %o", info.Mode().Perm(), tt.mode)
+			}
 
-	data, err := os.ReadFile(dst)
-	if err != nil {
-		t.Fatalf("read dst: %v", err)
-	}
-	if string(data) != `{"a":1}` {
-		t.Errorf("dst content = %q, want %q", string(data), `{"a":1}`)
+			data, err := os.ReadFile(dst)
+			if err != nil {
+				t.Fatalf("read dst: %v", err)
+			}
+			if string(data) != tt.content {
+				t.Errorf("dst content = %q, want %q", string(data), tt.content)
+			}
+		})
 	}
 }
 
@@ -305,15 +319,26 @@ func TestMergeContainerChainStagingErrors(t *testing.T) {
 // directory that cannot be read is skipped (continue) rather than aborting the
 // merge, while still merging the readable steps.
 func TestMergeContainerChainStagingUnreadableStepDir(t *testing.T) {
-	full := t.TempDir()
-	writeTestVolume(t, full, "volume_0.tar", CompressionNone, map[string]string{"old.txt": "old"})
-
-	outDir := t.TempDir()
-	err := MergeContainerChainStaging(context.Background(), []string{full, filepath.Join(t.TempDir(), "does-not-exist")}, outDir)
-	if err != nil {
-		t.Fatalf("MergeContainerChainStaging() error = %v", err)
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "unreadable step dir is skipped and readable steps still merge",
+		},
 	}
-	assertMergedVolumeHas(t, outDir, "old.txt")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			full := t.TempDir()
+			writeTestVolume(t, full, "volume_0.tar", CompressionNone, map[string]string{"old.txt": "old"})
+
+			outDir := t.TempDir()
+			err := MergeContainerChainStaging(context.Background(), []string{full, filepath.Join(t.TempDir(), "does-not-exist")}, outDir)
+			if err != nil {
+				t.Fatalf("MergeContainerChainStaging() error = %v", err)
+			}
+			assertMergedVolumeHas(t, outDir, "old.txt")
+		})
+	}
 }
 
 // TestMergeCopyFileErrors exercises the error branches of mergeCopyFile:

--- a/internal/engine/container_merge_test.go
+++ b/internal/engine/container_merge_test.go
@@ -333,7 +333,7 @@ func TestMergeCopyFileErrors(t *testing.T) {
 			wantErr: "no such file",
 		},
 		{
-			name: "unwritable destination",
+			name: "missing parent directory",
 			setup: func(t *testing.T) (string, string) {
 				src := filepath.Join(t.TempDir(), "src")
 				if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {

--- a/internal/engine/container_merge_test.go
+++ b/internal/engine/container_merge_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -68,6 +69,338 @@ func TestMergeContainerChainStagingOverlaysVolumes(t *testing.T) {
 		t.Fatalf("untar merged volume: %v", err)
 	}
 	for _, name := range []string{"old.txt", "new.txt"} {
+		if _, err := os.Stat(filepath.Join(extract, name)); err != nil {
+			t.Errorf("merged volume missing %s: %v", name, err)
+		}
+	}
+}
+
+// TestMergeCopyFilePreservesMode verifies mergeCopyFile copies the source's
+// permission bits rather than defaulting to 0644 (issue #320 review feedback).
+func TestMergeCopyFilePreservesMode(t *testing.T) {
+	t.Parallel()
+
+	src := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(src, []byte(`{"a":1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "config.json")
+	if err := mergeCopyFile(src, dst); err != nil {
+		t.Fatalf("mergeCopyFile: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("dst mode = %o, want 600", info.Mode().Perm())
+	}
+
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(data) != `{"a":1}` {
+		t.Errorf("dst content = %q, want %q", string(data), `{"a":1}`)
+	}
+}
+
+// TestMergeContainerChainStagingSidecarsAndImage exercises the non-volume parts
+// of MergeContainerChainStaging that the overlay regression test does not
+// reach: plain sidecar files (config.json / template.xml / volumes.json)
+// newest-step-wins, and image.tar located across steps regardless of its
+// compression suffix (issue #320).
+func TestMergeContainerChainStagingSidecarsAndImage(t *testing.T) {
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T) (stepDirs []string, outDir string)
+		verify func(t *testing.T, outDir string)
+	}{
+		{
+			name: "all sidecars plus plain image copied, newest config wins",
+			setup: func(t *testing.T) ([]string, string) {
+				full := t.TempDir()
+				diff := t.TempDir()
+				for _, f := range []struct{ name, content string }{
+					{"config.json", `{"full":true}`},
+					{"template.xml", "<template/>"},
+					{"volumes.json", `{"volumes":[]}`},
+					{"image.tar", "image-bytes"},
+				} {
+					if err := os.WriteFile(filepath.Join(full, f.name), []byte(f.content), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := os.WriteFile(filepath.Join(diff, "config.json"), []byte(`{"diff":true}`), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return []string{full, diff}, t.TempDir()
+			},
+			verify: func(t *testing.T, outDir string) {
+				assertMergedFile(t, outDir, "config.json", `{"diff":true}`)
+				assertMergedFile(t, outDir, "template.xml", "<template/>")
+				assertMergedFile(t, outDir, "volumes.json", `{"volumes":[]}`)
+				assertMergedFile(t, outDir, "image.tar", "image-bytes")
+			},
+		},
+		{
+			name: "gzip-suffixed image archive located via findArchive",
+			setup: func(t *testing.T) ([]string, string) {
+				full := t.TempDir()
+				if err := os.WriteFile(filepath.Join(full, "image.tar.gz"), []byte("gz-image-bytes"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return []string{full}, t.TempDir()
+			},
+			verify: func(t *testing.T, outDir string) {
+				assertMergedFile(t, outDir, "image.tar.gz", "gz-image-bytes")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stepDirs, outDir := tt.setup(t)
+			if err := MergeContainerChainStaging(context.Background(), stepDirs, outDir); err != nil {
+				t.Fatalf("MergeContainerChainStaging() error = %v", err)
+			}
+			tt.verify(t, outDir)
+		})
+	}
+}
+
+// TestMergeContainerChainStagingVolumeOverlay exercises the volume-archive
+// overlay across chain steps: compression-suffixed volumes (volume_0.tar.gz)
+// are normalised to their plain base name before merging, and a step that
+// omits a volume archive (unchanged) is skipped rather than failing the merge
+// (issue #320).
+func TestMergeContainerChainStagingVolumeOverlay(t *testing.T) {
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T) (stepDirs []string, outDir string)
+		verify func(t *testing.T, outDir string)
+	}{
+		{
+			name: "gzip-suffixed volumes overlay oldest-first",
+			setup: func(t *testing.T) ([]string, string) {
+				full := t.TempDir()
+				diff := t.TempDir()
+				writeTestVolume(t, full, "volume_0.tar.gz", CompressionGzip, map[string]string{"old.txt": "old"})
+				writeTestVolume(t, diff, "volume_0.tar.gz", CompressionGzip, map[string]string{"new.txt": "new"})
+				return []string{full, diff}, t.TempDir()
+			},
+			verify: func(t *testing.T, outDir string) {
+				assertMergedVolumeHas(t, outDir, "old.txt", "new.txt")
+			},
+		},
+		{
+			name: "middle step omitting the volume is skipped",
+			setup: func(t *testing.T) ([]string, string) {
+				full := t.TempDir()
+				mid := t.TempDir()
+				diff := t.TempDir()
+				writeTestVolume(t, full, "volume_0.tar", CompressionNone, map[string]string{"old.txt": "old"})
+				writeTestVolume(t, diff, "volume_0.tar", CompressionNone, map[string]string{"new.txt": "new"})
+				return []string{full, mid, diff}, t.TempDir()
+			},
+			verify: func(t *testing.T, outDir string) {
+				assertMergedVolumeHas(t, outDir, "old.txt", "new.txt")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stepDirs, outDir := tt.setup(t)
+			if err := MergeContainerChainStaging(context.Background(), stepDirs, outDir); err != nil {
+				t.Fatalf("MergeContainerChainStaging() error = %v", err)
+			}
+			tt.verify(t, outDir)
+		})
+	}
+}
+
+// TestMergeContainerChainStagingErrors exercises the error paths of
+// MergeContainerChainStaging: merge-dir creation failure, a sidecar that
+// cannot be copied, a corrupt volume archive, and an unreadable step dir.
+func TestMergeContainerChainStagingErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T) (stepDirs []string, outDir string)
+		wantErr string
+	}{
+		{
+			name: "out dir creation fails",
+			setup: func(t *testing.T) ([]string, string) {
+				blocker := filepath.Join(t.TempDir(), "file")
+				if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return []string{t.TempDir()}, filepath.Join(blocker, "sub", "dir")
+			},
+			wantErr: "creating merge dir",
+		},
+		{
+			name: "sidecar copy fails",
+			setup: func(t *testing.T) ([]string, string) {
+				step := t.TempDir()
+				if err := os.MkdirAll(filepath.Join(step, "config.json"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				return []string{step}, t.TempDir()
+			},
+			wantErr: "merge sidecar config.json",
+		},
+		{
+			name: "corrupt volume archive fails extraction",
+			setup: func(t *testing.T) ([]string, string) {
+				step := t.TempDir()
+				if err := os.WriteFile(filepath.Join(step, "volume_0.tar"), []byte("this is not a tar archive"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return []string{step}, t.TempDir()
+			},
+			wantErr: "extracting volume_0.tar",
+		},
+		{
+			name: "image archive copy fails",
+			setup: func(t *testing.T) ([]string, string) {
+				step := t.TempDir()
+				if err := os.MkdirAll(filepath.Join(step, "image.tar"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				return []string{step}, t.TempDir()
+			},
+			wantErr: "merge image archive",
+		},
+		{
+			name: "work dir creation fails",
+			setup: func(t *testing.T) ([]string, string) {
+				step := t.TempDir()
+				writeTestVolume(t, step, "volume_0.tar", CompressionNone, map[string]string{"old.txt": "old"})
+				out := t.TempDir()
+				if err := os.WriteFile(filepath.Join(out, "volume_0.tar.merge"), []byte("blocker"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return []string{step}, out
+			},
+			wantErr: "creating work dir",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stepDirs, outDir := tt.setup(t)
+			err := MergeContainerChainStaging(context.Background(), stepDirs, outDir)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestMergeContainerChainStagingUnreadableStepDir verifies that a step
+// directory that cannot be read is skipped (continue) rather than aborting the
+// merge, while still merging the readable steps.
+func TestMergeContainerChainStagingUnreadableStepDir(t *testing.T) {
+	full := t.TempDir()
+	writeTestVolume(t, full, "volume_0.tar", CompressionNone, map[string]string{"old.txt": "old"})
+
+	outDir := t.TempDir()
+	err := MergeContainerChainStaging(context.Background(), []string{full, filepath.Join(t.TempDir(), "does-not-exist")}, outDir)
+	if err != nil {
+		t.Fatalf("MergeContainerChainStaging() error = %v", err)
+	}
+	assertMergedVolumeHas(t, outDir, "old.txt")
+}
+
+// TestMergeCopyFileErrors exercises the error branches of mergeCopyFile:
+// a missing source, an unwritable destination, and a directory source (which
+// fails during the copy and must clean up the partial destination).
+func TestMergeCopyFileErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T) (src, dst string)
+		wantErr string
+	}{
+		{
+			name: "missing source",
+			setup: func(t *testing.T) (string, string) {
+				return filepath.Join(t.TempDir(), "nope"), filepath.Join(t.TempDir(), "out")
+			},
+			wantErr: "no such file",
+		},
+		{
+			name: "unwritable destination",
+			setup: func(t *testing.T) (string, string) {
+				src := filepath.Join(t.TempDir(), "src")
+				if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return src, filepath.Join(t.TempDir(), "missing-parent", "out")
+			},
+			wantErr: "no such file",
+		},
+		{
+			name: "source is a directory",
+			setup: func(t *testing.T) (string, string) {
+				return t.TempDir(), filepath.Join(t.TempDir(), "out")
+			},
+			wantErr: "is a directory",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src, dst := tt.setup(t)
+			err := mergeCopyFile(src, dst)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// writeTestVolume writes a volume archive (plain or gzip-compressed) into dir,
+// containing the given name→content files, by tarring a fresh source dir.
+func writeTestVolume(t *testing.T, dir, name, compression string, files map[string]string) {
+	t.Helper()
+	root := t.TempDir()
+	for n, c := range files {
+		if err := os.WriteFile(filepath.Join(root, n), []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tarDirectory(context.Background(), root, filepath.Join(dir, name), nil, compression); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// assertMergedFile asserts that outDir/name exists with the exact content want.
+func assertMergedFile(t *testing.T, outDir, name, want string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(outDir, name))
+	if err != nil {
+		t.Fatalf("read merged %s: %v", name, err)
+	}
+	if string(data) != want {
+		t.Fatalf("merged %s = %q, want %q", name, string(data), want)
+	}
+}
+
+// assertMergedVolumeHas extracts outDir/volume_0.tar and asserts every wanted
+// file name is present in the merged archive.
+func assertMergedVolumeHas(t *testing.T, outDir string, want ...string) {
+	t.Helper()
+	extract := t.TempDir()
+	if err := untarDirectory(context.Background(), filepath.Join(outDir, "volume_0.tar"), extract); err != nil {
+		t.Fatalf("untar merged volume: %v", err)
+	}
+	for _, name := range want {
 		if _, err := os.Stat(filepath.Join(extract, name)); err != nil {
 			t.Errorf("merged volume missing %s: %v", name, err)
 		}

--- a/internal/engine/container_milestones_test.go
+++ b/internal/engine/container_milestones_test.go
@@ -37,7 +37,7 @@ func TestContainerBackup_ProgressMilestones(t *testing.T) {
 				r, _, cleanup := dedup.NewTestRepoForEngine(t)
 				defer cleanup()
 				item := BackupItem{Name: "test", Type: "container", Settings: map[string]any{"id": "abc123"}}
-				if _, err := h.BackupChunked(context.Background(), item, r, progress); err != nil {
+				if _, err := h.BackupChunked(context.Background(), item, r, nil, progress); err != nil {
 					return err
 				}
 				return r.Flush()

--- a/internal/engine/container_test.go
+++ b/internal/engine/container_test.go
@@ -1041,14 +1041,17 @@ func TestAnyVolumeChangedSince(t *testing.T) {
 		return containertypes.MountPoint{Type: mounttypes.TypeBind, Source: src, Destination: dest}
 	}
 
-	cases := []struct {
-		name        string
-		mounts      []containertypes.MountPoint
-		exclusions  []string
-		ctx         context.Context // defaults to context.Background() when nil
-		wantChanged bool
-		wantErr     bool
-	}{
+	type volCase struct {
+		name         string
+		mounts       []containertypes.MountPoint
+		exclusions   []string
+		prevBySource map[string]map[string]struct{}
+		ctx          context.Context // defaults to context.Background() when nil
+		wantChanged  bool
+		wantErr      bool
+	}
+
+	cases := []volCase{
 		{
 			name:        "no mounts returns false",
 			mounts:      nil,
@@ -1106,13 +1109,35 @@ func TestAnyVolumeChangedSince(t *testing.T) {
 		},
 	}
 
+	// A NEW file with a stale mtime that is absent from the parent listing
+	// (parent listed only data.txt) must flip an otherwise-unchanged volume
+	// to changed. prevBySource must be keyed by the volume's actual Source,
+	// so the fixture is built here rather than inside the table literal.
+	staleSrc := mkVolume(t, old)
+	if err := os.WriteFile(filepath.Join(staleSrc, "new.txt"), []byte("y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(filepath.Join(staleSrc, "new.txt"), old, old); err != nil {
+		t.Fatal(err)
+	}
+	cases = append(cases, volCase{
+		name: "new file with stale mtime flips unchanged volume to changed",
+		mounts: []containertypes.MountPoint{
+			bind(staleSrc, "/data"),
+		},
+		prevBySource: map[string]map[string]struct{}{
+			staleSrc: {"data.txt": {}},
+		},
+		wantChanged: true,
+	})
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := tc.ctx
 			if ctx == nil {
 				ctx = context.Background()
 			}
-			volChanges, anyChanged, err := anyVolumeChangedSince(ctx, tc.mounts, tc.exclusions, reference)
+			volChanges, anyChanged, err := anyVolumeChangedSince(ctx, tc.mounts, tc.exclusions, reference, tc.prevBySource)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -1231,6 +1256,115 @@ func TestBackupDifferentialStopBehaviour(t *testing.T) {
 			}
 			if mock.startCalled != tc.wantStartCall {
 				t.Errorf("startCalled = %v, want %v", mock.startCalled, tc.wantStartCall)
+			}
+		})
+	}
+}
+
+// TestContainerBackupDifferentialIncludesNewFileWithStaleMtime is the classic
+// container regression test for issue #320. After a full backup, a NEW file
+// added with a stale mtime must be present in the differential archive. It
+// exercises BOTH stacked bugs: the volume gate (running=true pre-scan would
+// otherwise skip the whole volume) and the file filter (tarDirectoryFiltered
+// would otherwise drop the file). running=false also covers the no-stop path
+// where the loop gate runs directly.
+func TestContainerBackupDifferentialIncludesNewFileWithStaleMtime(t *testing.T) {
+	t.Parallel()
+
+	changedSince := time.Now().Add(-1 * time.Hour)
+	stale := time.Now().Add(-3 * time.Hour)
+
+	cases := []struct {
+		name          string
+		running       bool
+		wantStopCall  bool
+		wantStartCall bool
+	}{
+		{name: "not running (loop gate + filter)", running: false, wantStopCall: false, wantStartCall: false},
+		{name: "running (pre-scan gate + filter)", running: true, wantStopCall: true, wantStartCall: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			volSrc := t.TempDir()
+			writeStale := func(rel string) {
+				p := filepath.Join(volSrc, rel)
+				if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(p, []byte(rel), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chtimes(p, stale, stale); err != nil {
+					t.Fatal(err)
+				}
+			}
+			writeStale("old.txt")
+
+			// Full backup: only old.txt present (no changed_since).
+			fullMock := newClassicMock(t, false, volSrc, time.Now().Add(-48*time.Hour).UTC().Format(time.RFC3339Nano))
+			fullItem := BackupItem{
+				Name: "test", Type: "container",
+				Settings:    map[string]any{"id": "abc123"},
+				Compression: CompressionNone,
+			}
+			fullDest := t.TempDir()
+			if _, err := (&ContainerHandler{cli: fullMock}).Backup(context.Background(), fullItem, fullDest, noopProgress); err != nil {
+				t.Fatalf("full Backup: %v", err)
+			}
+			if _, err := os.Stat(filepath.Join(fullDest, "volume_0.tar")); err != nil {
+				t.Fatalf("full backup missing volume archive: %v", err)
+			}
+			if _, err := os.Stat(filepath.Join(fullDest, "volume_0.tar.listing.json")); err != nil {
+				t.Fatalf("full backup missing volume listing sidecar: %v", err)
+			}
+
+			// Add a NEW file with a stale mtime after the full backup.
+			writeStale("added.txt")
+
+			// Differential backup: changed_since + per-volume parent listing.
+			mock := newClassicMock(t, tc.running, volSrc, time.Now().Add(-48*time.Hour).UTC().Format(time.RFC3339Nano))
+			diffItem := BackupItem{
+				Name: "test", Type: "container",
+				Settings: map[string]any{
+					"id":            "abc123",
+					"changed_since": changedSince.UTC().Format(time.RFC3339),
+					"prev_volume_listing_paths": map[string][]string{
+						volSrc: {"old.txt"},
+					},
+				},
+				Compression: CompressionNone,
+			}
+			diffDest := t.TempDir()
+			result, err := (&ContainerHandler{cli: mock}).Backup(context.Background(), diffItem, diffDest, noopProgress)
+			if err != nil {
+				t.Fatalf("differential Backup: %v", err)
+			}
+			if !result.Success {
+				t.Error("expected result.Success")
+			}
+			if mock.stopCalled != tc.wantStopCall {
+				t.Errorf("stopCalled = %v, want %v", mock.stopCalled, tc.wantStopCall)
+			}
+			if mock.startCalled != tc.wantStartCall {
+				t.Errorf("startCalled = %v, want %v", mock.startCalled, tc.wantStartCall)
+			}
+
+			// The volume must NOT have been skipped: archive + listing exist.
+			archive := filepath.Join(diffDest, "volume_0.tar")
+			if _, err := os.Stat(archive); err != nil {
+				t.Fatalf("differential volume was skipped (archive missing): %v", err)
+			}
+			if _, err := os.Stat(archive + ListingSuffix); err != nil {
+				t.Fatalf("differential listing sidecar missing: %v", err)
+			}
+
+			names := listTarEntries(t, archive)
+			if !containsName(names, "added.txt") {
+				t.Errorf("differential archive missing added.txt (new file with stale mtime): %v", names)
+			}
+			if containsName(names, "old.txt") {
+				t.Errorf("differential archive should skip unchanged old.txt: %v", names)
 			}
 		})
 	}

--- a/internal/engine/container_test.go
+++ b/internal/engine/container_test.go
@@ -1120,6 +1120,13 @@ func TestAnyVolumeChangedSince(t *testing.T) {
 	if err := os.Chtimes(filepath.Join(staleSrc, "new.txt"), old, old); err != nil {
 		t.Fatal(err)
 	}
+	// Writing new.txt bumped the volume dir's mtime to now; re-pin it so the
+	// dir-mtime check in pathChangedSinceWithPrev does not fire and the
+	// prev-listing check is the ONLY change signal (mirrors
+	// TestBackupChunkedStopDecisionPrevAware).
+	if err := os.Chtimes(staleSrc, old, old); err != nil {
+		t.Fatal(err)
+	}
 	cases = append(cases, volCase{
 		name: "new file with stale mtime flips unchanged volume to changed",
 		mounts: []containertypes.MountPoint{

--- a/internal/engine/container_test.go
+++ b/internal/engine/container_test.go
@@ -693,7 +693,7 @@ func TestContainerChunkedBackupCapturesVolumesAndMeta(t *testing.T) {
 		Settings: map[string]any{"id": "deadbeef"},
 	}
 
-	manifestID, err := h.BackupChunked(context.Background(), item, r, nil)
+	manifestID, err := h.BackupChunked(context.Background(), item, r, nil, nil)
 	if err != nil {
 		t.Fatalf("BackupChunked() error = %v", err)
 	}
@@ -796,7 +796,7 @@ func TestContainerChunkedBackupIncludesVolumesSkipsTmpfs(t *testing.T) {
 	defer cleanup()
 	h := &ContainerHandler{cli: mock}
 	item := BackupItem{Name: "svc", Type: "container", Settings: map[string]any{"id": "deadbeef"}}
-	mID, err := h.BackupChunked(context.Background(), item, r, nil)
+	mID, err := h.BackupChunked(context.Background(), item, r, nil, nil)
 	if err != nil {
 		t.Fatalf("BackupChunked() error = %v", err)
 	}
@@ -872,7 +872,7 @@ func TestContainerChunkedHonoursExclusions(t *testing.T) {
 		},
 	}
 
-	mID, err := h.BackupChunked(context.Background(), item, r, nil)
+	mID, err := h.BackupChunked(context.Background(), item, r, nil, nil)
 	if err != nil {
 		t.Fatalf("BackupChunked() error = %v", err)
 	}
@@ -961,7 +961,7 @@ func TestContainerChunkedGCKeepsNestedVolumeData(t *testing.T) {
 	defer cleanup()
 	h := &ContainerHandler{cli: mock}
 	item := BackupItem{Name: "svc", Type: "container", Settings: map[string]any{"id": "deadbeef"}}
-	topID, err := h.BackupChunked(context.Background(), item, r, nil)
+	topID, err := h.BackupChunked(context.Background(), item, r, nil, nil)
 	if err != nil {
 		t.Fatalf("BackupChunked() error = %v", err)
 	}

--- a/internal/engine/folder.go
+++ b/internal/engine/folder.go
@@ -227,8 +227,8 @@ func (h *FolderHandler) Restore(ctx context.Context, item BackupItem, sourceDir 
 // log line; the run continues. Directories are recorded with their permission
 // bits so Restore can recreate them with the same mode. Empty files produce
 // a manifest entry with zero chunks (not an error).
-func (h *FolderHandler) BackupChunked(ctx context.Context, item BackupItem, repo *dedup.Repo, progress ProgressFunc) (dedup.ID, error) {
-	m, totalBytes, skipped, err := h.buildChunkedManifest(ctx, item, repo, progress)
+func (h *FolderHandler) BackupChunked(ctx context.Context, item BackupItem, repo *dedup.Repo, parent *dedup.Manifest, progress ProgressFunc) (dedup.ID, error) {
+	m, totalBytes, skipped, err := h.buildChunkedManifest(ctx, item, repo, parent, progress)
 	if err != nil {
 		return dedup.ID{}, err
 	}
@@ -251,7 +251,7 @@ func (h *FolderHandler) BackupChunked(ctx context.Context, item BackupItem, repo
 // out-of-tree data (e.g. PluginHandler's .plg installer) to the manifest
 // before the single PutManifest. Returns the manifest, total bytes chunked,
 // and the number of inaccessible paths that were skipped.
-func (h *FolderHandler) buildChunkedManifest(ctx context.Context, item BackupItem, repo *dedup.Repo, progress ProgressFunc) (dedup.Manifest, int64, int, error) {
+func (h *FolderHandler) buildChunkedManifest(ctx context.Context, item BackupItem, repo *dedup.Repo, parent *dedup.Manifest, progress ProgressFunc) (dedup.Manifest, int64, int, error) {
 	srcPath, _ := item.Settings["path"].(string)
 	if srcPath == "" {
 		return dedup.Manifest{}, 0, 0, fmt.Errorf("folder: missing path setting")
@@ -334,11 +334,29 @@ func (h *FolderHandler) buildChunkedManifest(ctx context.Context, item BackupIte
 			log.Printf("engine: skipping non-regular file %s (mode %v)", rel, info.Mode())
 			return nil
 		}
-		// Skip files whose mtime is not after the changed_since reference.
-		// Consistent with pathChangedSince and tarDirectoryFiltered.
-		// Directory entries are still recorded above for restore structure.
-		if hasChangedSince && !info.ModTime().After(changedSince) {
-			return nil
+		// changed_since filtering is ONLY applied when a parent manifest is
+		// supplied (differential/incremental) so an unchanged file can be
+		// carried forward from the parent instead of being omitted — keeping
+		// the resulting manifest COMPLETE for single-point restore. Deleted
+		// files are never walked, so they are not carried forward and
+		// deletions still take effect (issue #320).
+		//
+		// Without a parent (a full backup, a newly-added item, or a missing
+		// parent manifest), there is nothing to carry forward from, so
+		// changed_since is ignored and the tree is chunked FULLY. Applying the
+		// filter with a nil parent would silently drop every file whose mtime
+		// predates the reference — the literal "new items missing" data loss
+		// class from issue #320.
+		if parent != nil && hasChangedSince && !info.ModTime().After(changedSince) {
+			if pe, ok := parent.Files[rel]; ok {
+				m.Files[rel] = pe
+				return nil
+			}
+			// Not in the parent manifest: a NEW file whose mtime predates the
+			// reference (e.g. copied in with timestamps preserved). Fall
+			// through and chunk it so it is not silently dropped — carrying
+			// forward is only valid when the parent already has the entry
+			// (issue #320).
 		}
 		warnIfSparse(rel, info)
 		f, err := root.Open(rel)

--- a/internal/engine/folder.go
+++ b/internal/engine/folder.go
@@ -109,9 +109,13 @@ func (h *FolderHandler) Backup(ctx context.Context, item BackupItem, destDir str
 	// folder), matching the dedup BackupChunked path (issue #204).
 	exclusions := extractExcludePaths(item.Settings)
 
+	// Previous backup's effective listing (item-relative paths), used to detect
+	// NEW files with stale mtimes in differential/incremental runs (issue #320).
+	prevPaths := prevListingSet(item.Settings)
+
 	if !changedSince.IsZero() {
 		// Incremental/differential: only archive files modified since the reference time.
-		if err := tarDirectoryFiltered(ctx, srcPath, archivePath, changedSince, exclusions, effectiveCompression); err != nil {
+		if err := tarDirectoryFilteredWithPrev(ctx, srcPath, archivePath, changedSince, exclusions, effectiveCompression, prevPaths); err != nil {
 			return nil, fmt.Errorf("archiving changed files in %s: %w", srcPath, err)
 		}
 	} else {

--- a/internal/engine/folder_chunked_changed_since_test.go
+++ b/internal/engine/folder_chunked_changed_since_test.go
@@ -16,6 +16,14 @@ import (
 // Boundary convention: a file whose mtime equals changed_since is
 // treated as "not changed" (skipped). This matches pathChangedSince
 // and tarDirectoryFiltered in the classic tar path.
+//
+// changed_since filtering only applies when a parent manifest is supplied.
+// Without a parent (a full backup, a newly-added item, or a missing parent
+// manifest), changed_since is ignored and the tree is chunked FULLY, so a
+// brand-new item with old file mtimes is never silently recorded empty
+// (issue #320). With a parent manifest, unchanged files are carried forward
+// from the parent so the resulting manifest stays complete for single-point
+// restore.
 func TestFolderBackupChunked_ChangedSince(t *testing.T) {
 	t.Parallel()
 
@@ -31,7 +39,7 @@ func TestFolderBackupChunked_ChangedSince(t *testing.T) {
 		wantExcluded   []string
 	}{
 		{
-			name: "skips old files, includes new files and directory entries",
+			name: "no parent: changed_since ignored, all files included (new item safety)",
 			settings: map[string]any{
 				"changed_since": changedSince.Format(time.RFC3339),
 			},
@@ -40,8 +48,7 @@ func TestFolderBackupChunked_ChangedSince(t *testing.T) {
 				{name: "new.txt", content: "new", offset: +2 * time.Hour},
 				{name: "subdir/sub_old.txt", content: "sub old", offset: -3 * time.Hour},
 			},
-			wantInManifest: []string{"new.txt", "subdir"},
-			wantExcluded:   []string{"old.txt", filepath.Join("subdir", "sub_old.txt")},
+			wantInManifest: []string{"old.txt", "new.txt", "subdir", filepath.Join("subdir", "sub_old.txt")},
 		},
 		{
 			name:     "omitting changed_since produces a full backup",
@@ -62,7 +69,7 @@ func TestFolderBackupChunked_ChangedSince(t *testing.T) {
 			wantInManifest: []string{"b.txt"},
 		},
 		{
-			name: "file with mtime equal to changed_since is excluded",
+			name: "no parent: boundary mtime file included (full walk)",
 			settings: map[string]any{
 				"changed_since": changedSince.Format(time.RFC3339),
 			},
@@ -70,8 +77,7 @@ func TestFolderBackupChunked_ChangedSince(t *testing.T) {
 				{name: "boundary.txt", content: "equal", atExact: changedSince},
 				{name: "after.txt", content: "after", offset: +1 * time.Hour},
 			},
-			wantInManifest: []string{"after.txt"},
-			wantExcluded:   []string{"boundary.txt"},
+			wantInManifest: []string{"boundary.txt", "after.txt"},
 		},
 	}
 
@@ -94,7 +100,7 @@ func TestFolderBackupChunked_ChangedSince(t *testing.T) {
 				Name:     "test-folder",
 				Type:     "folder",
 				Settings: tt.settings,
-			}, repo, func(string, int, string) {})
+			}, repo, nil, func(string, int, string) {})
 			if err != nil {
 				t.Fatalf("BackupChunked: %v", err)
 			}
@@ -116,6 +122,143 @@ func TestFolderBackupChunked_ChangedSince(t *testing.T) {
 				if _, ok := m.Files[name]; ok {
 					t.Errorf("expected %q to be excluded from manifest", name)
 				}
+			}
+		})
+	}
+}
+
+// TestFolderBackupChunked_ChangedSince_CarriesForward is the regression test
+// for the dedup-path half of issue #320. When a parent manifest is supplied,
+// a file skipped by changed_since must be carried forward from the parent so
+// the differential manifest stays complete and single-point restore does not
+// drop base files.
+func TestFolderBackupChunked_ChangedSince_CarriesForward(t *testing.T) {
+	t.Parallel()
+
+	changedSince := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	src := t.TempDir()
+
+	old := testFile{name: "old.txt", content: "old", offset: -3 * time.Hour}
+	boundary := testFile{name: "boundary.txt", content: "equal", atExact: changedSince}
+	newFile := testFile{name: "new.txt", content: "new", offset: +2 * time.Hour}
+	old.write(t, src, changedSince)
+	boundary.write(t, src, changedSince)
+	newFile.write(t, src, changedSince)
+
+	repo, _, cleanup := dedup.NewTestRepoForEngine(t)
+	defer cleanup()
+
+	h := &FolderHandler{}
+	item := BackupItem{Name: "test-folder", Type: "folder", Settings: map[string]any{"path": src}}
+
+	// Full backup: both files present (no changed_since).
+	fullID, err := h.BackupChunked(context.Background(), item, repo, nil, func(string, int, string) {})
+	if err != nil {
+		t.Fatalf("full BackupChunked: %v", err)
+	}
+	if err := repo.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	parent, err := repo.GetManifest(fullID)
+	if err != nil {
+		t.Fatalf("GetManifest(parent): %v", err)
+	}
+
+	// Differential: old.txt is unchanged (mtime predates changed_since), so it
+	// must be carried forward from the parent; new.txt is newly chunked.
+	item.Settings["changed_since"] = changedSince.Format(time.RFC3339)
+	diffID, err := h.BackupChunked(context.Background(), item, repo, &parent, func(string, int, string) {})
+	if err != nil {
+		t.Fatalf("differential BackupChunked: %v", err)
+	}
+	if err := repo.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	m, err := repo.GetManifest(diffID)
+	if err != nil {
+		t.Fatalf("GetManifest(diff): %v", err)
+	}
+
+	for _, name := range []string{"old.txt", "boundary.txt", "new.txt"} {
+		if _, ok := m.Files[name]; !ok {
+			t.Errorf("differential manifest missing %q — unchanged files must be carried forward", name)
+		}
+	}
+}
+
+// TestFolderBackupChunked_ChangedSince_NewFileNotInParent is the regression
+// test for the folder half of issue #320's data-loss class: a file added
+// between backups whose mtime predates changed_since (e.g. copied in with
+// timestamps preserved) is NOT in the parent manifest, so carry-forward must
+// fall through to a full chunk rather than silently dropping the entry.
+func TestFolderBackupChunked_ChangedSince_NewFileNotInParent(t *testing.T) {
+	t.Parallel()
+
+	changedSince := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+
+	tests := []struct {
+		name      string
+		addedFile testFile
+	}{
+		{
+			name:      "new file with preserved old mtime is chunked, not dropped",
+			addedFile: testFile{name: "added.txt", content: "added", offset: -3 * time.Hour},
+		},
+		{
+			name:      "new file with fresh mtime is chunked",
+			addedFile: testFile{name: "added.txt", content: "added", offset: +1 * time.Hour},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			src := t.TempDir()
+			old := testFile{name: "old.txt", content: "old", offset: -3 * time.Hour}
+			old.write(t, src, changedSince)
+
+			repo, _, cleanup := dedup.NewTestRepoForEngine(t)
+			defer cleanup()
+
+			h := &FolderHandler{}
+			item := BackupItem{Name: "test-folder", Type: "folder", Settings: map[string]any{"path": src}}
+
+			// Full backup: only old.txt present.
+			fullID, err := h.BackupChunked(context.Background(), item, repo, nil, func(string, int, string) {})
+			if err != nil {
+				t.Fatalf("full BackupChunked: %v", err)
+			}
+			if err := repo.Flush(); err != nil {
+				t.Fatalf("Flush: %v", err)
+			}
+			parent, err := repo.GetManifest(fullID)
+			if err != nil {
+				t.Fatalf("GetManifest(parent): %v", err)
+			}
+
+			// Add a new file after the full backup.
+			tt.addedFile.write(t, src, changedSince)
+
+			// Differential: old.txt carried forward; added.txt must be present.
+			item.Settings["changed_since"] = changedSince.Format(time.RFC3339)
+			diffID, err := h.BackupChunked(context.Background(), item, repo, &parent, func(string, int, string) {})
+			if err != nil {
+				t.Fatalf("differential BackupChunked: %v", err)
+			}
+			if err := repo.Flush(); err != nil {
+				t.Fatalf("Flush: %v", err)
+			}
+			m, err := repo.GetManifest(diffID)
+			if err != nil {
+				t.Fatalf("GetManifest(diff): %v", err)
+			}
+
+			if _, ok := m.Files["old.txt"]; !ok {
+				t.Errorf("differential manifest missing %q — unchanged file not carried forward", "old.txt")
+			}
+			if _, ok := m.Files["added.txt"]; !ok {
+				t.Errorf("differential manifest missing %q — new file silently dropped", "added.txt")
 			}
 		})
 	}

--- a/internal/engine/folder_chunked_milestones_test.go
+++ b/internal/engine/folder_chunked_milestones_test.go
@@ -58,7 +58,7 @@ func TestFolderBackupChunked_PhaseMilestones(t *testing.T) {
 
 	h := &FolderHandler{}
 	item := BackupItem{Name: "Flash Drive", Type: "folder", Settings: map[string]any{"path": src}}
-	if _, err := h.BackupChunked(context.Background(), item, repo, progress); err != nil {
+	if _, err := h.BackupChunked(context.Background(), item, repo, nil, progress); err != nil {
 		t.Fatalf("BackupChunked: %v", err)
 	}
 	if err := repo.Flush(); err != nil {

--- a/internal/engine/folder_chunked_skip_test.go
+++ b/internal/engine/folder_chunked_skip_test.go
@@ -53,7 +53,7 @@ func TestFolderBackupChunked_SkipsInaccessible(t *testing.T) {
 
 	h := &FolderHandler{}
 	item := BackupItem{Name: "t", Type: "folder", Settings: map[string]any{"path": src}}
-	manifestID, err := h.BackupChunked(context.Background(), item, repo, nil)
+	manifestID, err := h.BackupChunked(context.Background(), item, repo, nil, nil)
 	if err != nil {
 		t.Fatalf("BackupChunked must skip unreadable files, got: %v", err)
 	}

--- a/internal/engine/folder_test.go
+++ b/internal/engine/folder_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ruaan-deysel/vault/internal/dedup"
 )
@@ -88,6 +89,82 @@ func TestFolderHandlerBackupRestoreRoundTrip(t *testing.T) {
 		t.Errorf("restore missing a.txt: %v", err)
 	} else if string(data) != "hello" {
 		t.Errorf("a.txt content mismatch: %q", data)
+	}
+}
+
+// TestFolderHandlerBackupDifferentialIncludesNewFileWithStaleMtime is the
+// classic-path regression test for issue #320: after a full backup, a NEW file
+// added with a stale mtime (e.g. copied in with timestamps preserved) must be
+// present in the differential archive. The runner passes the previous backup's
+// effective-listing paths via "prev_listing_paths"; the engine archives files
+// absent from that set regardless of mtime, while unchanged files stay skipped.
+func TestFolderHandlerBackupDifferentialIncludesNewFileWithStaleMtime(t *testing.T) {
+	t.Parallel()
+
+	changedSince := time.Now().Add(-1 * time.Hour)
+	stale := time.Now().Add(-3 * time.Hour)
+
+	src := t.TempDir()
+	write := func(name, content string, mtime time.Time) {
+		p := filepath.Join(src, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !mtime.IsZero() {
+			if err := os.Chtimes(p, mtime, mtime); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	write("old.txt", "old", stale)
+
+	h := &FolderHandler{}
+	progress := func(string, int, string) {}
+
+	// Full backup: only old.txt present.
+	fullDest := t.TempDir()
+	if _, err := h.Backup(context.Background(), BackupItem{
+		Name: "test-folder", Type: "folder", Settings: map[string]any{"path": src},
+	}, fullDest, progress); err != nil {
+		t.Fatalf("full Backup: %v", err)
+	}
+
+	// Add a NEW file with a stale mtime after the full backup.
+	write("added.txt", "added", stale)
+
+	// Differential backup: changed_since plus the previous listing paths.
+	diffDest := t.TempDir()
+	if _, err := h.Backup(context.Background(), BackupItem{
+		Name: "test-folder",
+		Type: "folder",
+		Settings: map[string]any{
+			"path":               src,
+			"changed_since":      changedSince.Format(time.RFC3339),
+			"prev_listing_paths": []string{"old.txt"},
+		},
+	}, diffDest, progress); err != nil {
+		t.Fatalf("differential Backup: %v", err)
+	}
+
+	archive, err := findArchive(diffDest, "data.tar")
+	if err != nil {
+		t.Fatalf("findArchive: %v", err)
+	}
+	extract := t.TempDir()
+	if err := untarDirectory(context.Background(), archive, extract); err != nil {
+		t.Fatalf("untar: %v", err)
+	}
+
+	// The NEW file must be archived (the fix) …
+	if _, err := os.Stat(filepath.Join(extract, "added.txt")); err != nil {
+		t.Errorf("differential archive missing added.txt (new file with stale mtime): %v", err)
+	}
+	// … while the unchanged file is still skipped (present in the full backup).
+	if _, err := os.Stat(filepath.Join(extract, "old.txt")); err == nil {
+		t.Errorf("differential archive should skip unchanged old.txt")
 	}
 }
 

--- a/internal/engine/folder_test.go
+++ b/internal/engine/folder_test.go
@@ -250,7 +250,7 @@ func TestFolderChunkedRoundTrip(t *testing.T) {
 	h := &FolderHandler{}
 	item := BackupItem{Name: "test", Type: "folder", Settings: map[string]any{"path": src}}
 	ctx := context.Background()
-	manifestID, err := h.BackupChunked(ctx, item, r, nil)
+	manifestID, err := h.BackupChunked(ctx, item, r, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,7 +305,7 @@ func TestFolderChunkedRestoresReservedName(t *testing.T) {
 	h := &FolderHandler{}
 	item := BackupItem{Name: "reserved", Type: "folder", Settings: map[string]any{"path": src}}
 	ctx := context.Background()
-	manifestID, err := h.BackupChunked(ctx, item, r, nil)
+	manifestID, err := h.BackupChunked(ctx, item, r, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -336,14 +336,14 @@ func TestFolderChunkedDedupSkipsRepeats(t *testing.T) {
 	defer cleanup()
 	h := &FolderHandler{}
 	item := BackupItem{Name: "test", Type: "folder", Settings: map[string]any{"path": src}}
-	if _, err := h.BackupChunked(context.Background(), item, r, nil); err != nil {
+	if _, err := h.BackupChunked(context.Background(), item, r, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := r.Flush(); err != nil {
 		t.Fatal(err)
 	}
 	after1 := r.Stats().TotalChunks
-	if _, err := h.BackupChunked(context.Background(), item, r, nil); err != nil {
+	if _, err := h.BackupChunked(context.Background(), item, r, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := r.Flush(); err != nil {
@@ -370,7 +370,7 @@ func TestFolderChunkedSkipsNonRegularFiles(t *testing.T) {
 	defer cleanup()
 	h := &FolderHandler{}
 	item := BackupItem{Name: "test", Type: "folder", Settings: map[string]any{"path": src}}
-	mID, err := h.BackupChunked(context.Background(), item, r, nil)
+	mID, err := h.BackupChunked(context.Background(), item, r, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -422,7 +422,7 @@ func TestFolderChunkedHonoursExclusions(t *testing.T) {
 			"exclude_paths": []string{"*.log", "logs"},
 		},
 	}
-	manifestID, err := h.BackupChunked(context.Background(), item, r, nil)
+	manifestID, err := h.BackupChunked(context.Background(), item, r, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -536,7 +536,7 @@ func TestFolderBackupFollowsSymlinkSource(t *testing.T) {
 			Type:     "folder",
 			Settings: map[string]any{"path": linkDir},
 		}
-		manifestID, err := h.BackupChunked(ctx, item, r, nil)
+		manifestID, err := h.BackupChunked(ctx, item, r, nil, nil)
 		if err != nil {
 			t.Fatalf("chunked backup: %v", err)
 		}

--- a/internal/engine/folder_walk_branches_test.go
+++ b/internal/engine/folder_walk_branches_test.go
@@ -65,7 +65,7 @@ func TestFolderBackupChunked_WalkErrBranches(t *testing.T) {
 
 		repo := newChunkTestRepo(t)
 		item := BackupItem{Name: "t", Type: "folder", Settings: map[string]any{"path": src}}
-		manifestID, err := h.BackupChunked(context.Background(), item, repo, nil)
+		manifestID, err := h.BackupChunked(context.Background(), item, repo, nil, nil)
 		if err != nil {
 			t.Fatalf("unlistable subdir must be skipped, got: %v", err)
 		}
@@ -90,7 +90,7 @@ func TestFolderBackupChunked_WalkErrBranches(t *testing.T) {
 
 		repo := newChunkTestRepo(t)
 		item := BackupItem{Name: "t", Type: "folder", Settings: map[string]any{"path": src}}
-		if _, err := h.BackupChunked(context.Background(), item, repo, nil); err == nil {
+		if _, err := h.BackupChunked(context.Background(), item, repo, nil, nil); err == nil {
 			t.Fatal("an unlistable source root must fail the item, not succeed empty")
 		}
 	})

--- a/internal/engine/incremental.go
+++ b/internal/engine/incremental.go
@@ -36,6 +36,18 @@ func parseChangedSince(settings map[string]any) (time.Time, bool) {
 }
 
 func pathChangedSince(ctx context.Context, path string, changedSince time.Time) (bool, error) {
+	return pathChangedSinceWithPrev(ctx, path, changedSince, nil)
+}
+
+// pathChangedSinceWithPrev is pathChangedSince plus a prevPaths set of paths
+// recorded in the parent restore point's effective listing for this tree. A
+// regular file whose mtime predates changedSince but is ABSENT from prevPaths
+// is a NEW file copied in with a stale timestamp, so the path is reported
+// changed instead of skipped (issue #320). A nil prevPaths preserves the
+// mtime-only behaviour of pathChangedSince. Non-directory roots and symlinks
+// keep their existing mtime-only handling; prevPaths only affects the
+// directory walk.
+func pathChangedSinceWithPrev(ctx context.Context, path string, changedSince time.Time, prevPaths map[string]struct{}) (bool, error) {
 	if changedSince.IsZero() {
 		return true, nil
 	}
@@ -67,6 +79,17 @@ func pathChangedSince(ctx context.Context, path string, changedSince time.Time) 
 		}
 		if walkInfo.ModTime().After(changedSince) {
 			return errPathChanged
+		}
+		// A file that predates changedSince is normally unchanged — unless it
+		// is absent from the parent's listing, in which case it is NEW with a
+		// stale timestamp (issue #320). Directories keep their mtime as the
+		// signal, matching pathChangedSince.
+		if !walkInfo.IsDir() && prevPaths != nil {
+			if rel, relErr := filepath.Rel(path, current); relErr == nil && rel != "." {
+				if _, exists := prevPaths[rel]; !exists {
+					return errPathChanged
+				}
+			}
 		}
 		return nil
 	})

--- a/internal/engine/incremental_test.go
+++ b/internal/engine/incremental_test.go
@@ -171,3 +171,76 @@ func TestPathChangedSinceHonoursCancellation(t *testing.T) {
 		})
 	}
 }
+
+// TestPathChangedSinceWithPrevDetectsNewStaleMtimeFile verifies the listing-aware
+// change gate: a file whose mtime predates changedSince but is ABSENT from the
+// parent listing is reported changed (a NEW file with a stale timestamp —
+// issue #320). nil prevPaths preserves the mtime-only behaviour.
+func TestPathChangedSinceWithPrevDetectsNewStaleMtimeFile(t *testing.T) {
+	t.Parallel()
+
+	reference := time.Now().Add(-1 * time.Hour)
+	stale := time.Now().Add(-3 * time.Hour)
+
+	// newTree builds a dir with two stale-mtime files (old.txt, sub/nested.txt)
+	// and pins every dir mtime to `stale` too, so pathChangedSince sees a
+	// stable unchanged answer for the mtime-only case.
+	newTree := func(t *testing.T) string {
+		t.Helper()
+		dir := t.TempDir()
+		sub := filepath.Join(dir, "sub")
+		if err := os.MkdirAll(sub, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for _, p := range []string{filepath.Join(dir, "old.txt"), filepath.Join(sub, "nested.txt")} {
+			if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chtimes(p, stale, stale); err != nil {
+				t.Fatal(err)
+			}
+		}
+		for _, d := range []string{dir, sub} {
+			if err := os.Chtimes(d, stale, stale); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return dir
+	}
+
+	cases := []struct {
+		name      string
+		prevPaths map[string]struct{}
+		want      bool
+	}{
+		{
+			name:      "nil prevPaths keeps mtime-only behaviour",
+			prevPaths: nil,
+			want:      false,
+		},
+		{
+			name:      "file present in prevPaths stays unchanged",
+			prevPaths: map[string]struct{}{"old.txt": {}, "sub/nested.txt": {}},
+			want:      false,
+		},
+		{
+			name:      "new file absent from prevPaths is changed",
+			prevPaths: map[string]struct{}{"old.txt": {}},
+			want:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := newTree(t)
+			got, err := pathChangedSinceWithPrev(context.Background(), dir, reference, tc.prevPaths)
+			if err != nil {
+				t.Fatalf("pathChangedSinceWithPrev: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("pathChangedSinceWithPrev(...) = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/engine/listing.go
+++ b/internal/engine/listing.go
@@ -77,3 +77,75 @@ func WriteEffectiveListing(srcPath, archivePath string, exclusions []string) err
 	}
 	return nil
 }
+
+// prevListingSet parses the "prev_listing_paths" setting (injected by the
+// runner for differential/incremental classic folder backups) into a lookup
+// set of item-relative paths. Returns nil when the setting is absent or empty,
+// so tarDirectoryFilteredWithPrev degrades to its mtime-only behaviour.
+func prevListingSet(settings map[string]any) map[string]struct{} {
+	raw, ok := settings["prev_listing_paths"]
+	if !ok || raw == nil {
+		return nil
+	}
+	paths := stringSlice(raw)
+	if paths == nil {
+		return nil
+	}
+	return pathsToSet(paths)
+}
+
+// stringSlice normalises a settings value that may be a Go []string or a
+// JSON-decoded []any into []string. Returns nil when the value is not a
+// slice of strings.
+func stringSlice(raw any) []string {
+	switch v := raw.(type) {
+	case []string:
+		return v
+	case []any:
+		paths := make([]string, 0, len(v))
+		for _, p := range v {
+			if s, ok := p.(string); ok {
+				paths = append(paths, s)
+			}
+		}
+		return paths
+	}
+	return nil
+}
+
+func pathsToSet(paths []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		set[p] = struct{}{}
+	}
+	return set
+}
+
+// prevVolumeListingSet parses the "prev_volume_listing_paths" setting (injected
+// by the runner for differential/incremental classic container backups) into a
+// per-volume lookup keyed by mount source host path -> volume-relative path
+// set recorded in the parent restore point's per-volume effective listing.
+// Returns nil when the setting is absent, so pathChangedSinceWithPrev and
+// tarDirectoryFilteredWithPrev degrade to their mtime-only behaviour. Both the
+// typed map[string][]string (direct runner->engine calls) and the JSON-decoded
+// map[string]any forms are accepted.
+func prevVolumeListingSet(settings map[string]any) map[string]map[string]struct{} {
+	raw, ok := settings["prev_volume_listing_paths"]
+	if !ok || raw == nil {
+		return nil
+	}
+	out := map[string]map[string]struct{}{}
+	switch v := raw.(type) {
+	case map[string][]string:
+		for src, paths := range v {
+			out[src] = pathsToSet(paths)
+		}
+	case map[string]any:
+		for src, val := range v {
+			if paths := stringSlice(val); paths != nil {
+				out[src] = pathsToSet(paths)
+			}
+		}
+	}
+	return out
+}

--- a/internal/engine/listing_test.go
+++ b/internal/engine/listing_test.go
@@ -1,0 +1,157 @@
+package engine
+
+import "testing"
+
+// TestPrevListingSet verifies the "prev_listing_paths" setting is parsed into a
+// lookup set for the classic differential/incremental folder path (issue #320).
+// Absent or nil settings produce nil so tarDirectoryFilteredWithPrev falls back
+// to its mtime-only behaviour; an empty listing yields an empty (non-nil) set
+// so a file added to a previously-empty source is still treated as new.
+func TestPrevListingSet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		settings map[string]any
+		wantNil  bool
+		wantLen  int
+		wantKeys []string
+	}{
+		{
+			name:     "absent setting returns nil",
+			settings: map[string]any{},
+			wantNil:  true,
+		},
+		{
+			name:     "nil value returns nil",
+			settings: map[string]any{"prev_listing_paths": nil},
+			wantNil:  true,
+		},
+		{
+			name:     "empty slice yields an empty (non-nil) set",
+			settings: map[string]any{"prev_listing_paths": []string{}},
+			wantLen:  0,
+		},
+		{
+			name:     "string slice is parsed",
+			settings: map[string]any{"prev_listing_paths": []string{"a.txt", "sub/b.txt"}},
+			wantLen:  2,
+			wantKeys: []string{"a.txt", "sub/b.txt"},
+		},
+		{
+			name:     "any slice is parsed (JSON-decoded form)",
+			settings: map[string]any{"prev_listing_paths": []any{"a.txt", "sub/b.txt"}},
+			wantLen:  2,
+			wantKeys: []string{"a.txt", "sub/b.txt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := prevListingSet(tt.settings)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil set, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil set")
+			}
+			if len(got) != tt.wantLen {
+				t.Errorf("set length = %d, want %d", len(got), tt.wantLen)
+			}
+			for _, k := range tt.wantKeys {
+				if _, ok := got[k]; !ok {
+					t.Errorf("expected key %q in set", k)
+				}
+			}
+		})
+	}
+}
+
+// TestPrevVolumeListingSet verifies the "prev_volume_listing_paths" setting is
+// parsed into a per-volume lookup (mount source host path -> volume-relative
+// path set) for the classic container differential/incremental path
+// (issue #320). Absent/nil settings produce nil; both the typed map and the
+// JSON-decoded map forms are accepted.
+func TestPrevVolumeListingSet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		settings map[string]any
+		wantNil  bool
+		wantSrc  string
+		wantKeys []string
+	}{
+		{
+			name:     "absent setting returns nil",
+			settings: map[string]any{},
+			wantNil:  true,
+		},
+		{
+			name:     "nil value returns nil",
+			settings: map[string]any{"prev_volume_listing_paths": nil},
+			wantNil:  true,
+		},
+		{
+			name: "typed string map is parsed",
+			settings: map[string]any{
+				"prev_volume_listing_paths": map[string][]string{
+					"/mnt/cache/appdata/foo": {"a.txt", "sub/b.txt"},
+				},
+			},
+			wantSrc:  "/mnt/cache/appdata/foo",
+			wantKeys: []string{"a.txt", "sub/b.txt"},
+		},
+		{
+			name: "json-decoded any map with string slices is parsed",
+			settings: map[string]any{
+				"prev_volume_listing_paths": map[string]any{
+					"/mnt/cache/appdata/foo": []string{"a.txt"},
+				},
+			},
+			wantSrc:  "/mnt/cache/appdata/foo",
+			wantKeys: []string{"a.txt"},
+		},
+		{
+			name: "json-decoded any map with any slices is parsed",
+			settings: map[string]any{
+				"prev_volume_listing_paths": map[string]any{
+					"/mnt/cache/appdata/foo": []any{"a.txt", "sub/b.txt"},
+				},
+			},
+			wantSrc:  "/mnt/cache/appdata/foo",
+			wantKeys: []string{"a.txt", "sub/b.txt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := prevVolumeListingSet(tt.settings)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil map, got %v", got)
+				}
+				return
+			}
+			set, ok := got[tt.wantSrc]
+			if !ok {
+				t.Fatalf("expected key %q in map, got %v", tt.wantSrc, got)
+			}
+			if len(set) != len(tt.wantKeys) {
+				t.Errorf("set length = %d, want %d", len(set), len(tt.wantKeys))
+			}
+			for _, k := range tt.wantKeys {
+				if _, ok := set[k]; !ok {
+					t.Errorf("expected key %q in set", k)
+				}
+			}
+		})
+	}
+}

--- a/internal/engine/plugin.go
+++ b/internal/engine/plugin.go
@@ -225,7 +225,7 @@ func pluginPlgFilePath(name string) string {
 // When no .plg file is present (a plugin without an installer, or tests) the
 // manifest holds only the config files, exactly as the folder backup produced
 // before this change, so existing restore points are unaffected.
-func (h *PluginHandler) BackupChunked(ctx context.Context, item BackupItem, repo *dedup.Repo, progress ProgressFunc) (dedup.ID, error) {
+func (h *PluginHandler) BackupChunked(ctx context.Context, item BackupItem, repo *dedup.Repo, parent *dedup.Manifest, progress ProgressFunc) (dedup.ID, error) {
 	src, _ := item.Settings["path"].(string)
 	if src == "" {
 		src = pluginPath(item.Name)
@@ -235,7 +235,7 @@ func (h *PluginHandler) BackupChunked(ctx context.Context, item BackupItem, repo
 	}
 	proxy := BackupItem{Name: item.Name, Type: "folder", Settings: map[string]any{"path": src}}
 	fh := &FolderHandler{}
-	m, _, _, err := fh.buildChunkedManifest(ctx, proxy, repo, progress)
+	m, _, _, err := fh.buildChunkedManifest(ctx, proxy, repo, parent, progress)
 	if err != nil {
 		return dedup.ID{}, fmt.Errorf("plugin: chunking config for %q: %w", item.Name, err)
 	}

--- a/internal/engine/plugin_stub.go
+++ b/internal/engine/plugin_stub.go
@@ -35,7 +35,7 @@ func (h *PluginHandler) Restore(_ context.Context, item BackupItem, sourceDir st
 }
 
 // BackupChunked is not supported on this platform.
-func (h *PluginHandler) BackupChunked(_ context.Context, _ BackupItem, _ *dedup.Repo, _ ProgressFunc) (dedup.ID, error) {
+func (h *PluginHandler) BackupChunked(_ context.Context, _ BackupItem, _ *dedup.Repo, _ *dedup.Manifest, _ ProgressFunc) (dedup.ID, error) {
 	return dedup.ID{}, errors.New("plugin: unsupported on this platform")
 }
 

--- a/internal/engine/plugin_stub_test.go
+++ b/internal/engine/plugin_stub_test.go
@@ -65,7 +65,7 @@ func TestPluginHandlerBackupChunkedStubReturnsError(t *testing.T) {
 	t.Parallel()
 
 	h := &PluginHandler{}
-	id, err := h.BackupChunked(context.Background(), BackupItem{Name: "ignored"}, nil, nil)
+	id, err := h.BackupChunked(context.Background(), BackupItem{Name: "ignored"}, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected platform-not-supported error from PluginHandler.BackupChunked on non-Linux")
 	}

--- a/internal/engine/plugin_test.go
+++ b/internal/engine/plugin_test.go
@@ -39,7 +39,7 @@ func TestPluginChunkedRoundTrip(t *testing.T) {
 	// Override source via the "path" Settings key (matches what folder uses).
 	item := BackupItem{Name: "test-plugin", Type: "plugin", Settings: map[string]any{"path": src}}
 	ctx := context.Background()
-	manifestID, err := h.BackupChunked(ctx, item, r, nil)
+	manifestID, err := h.BackupChunked(ctx, item, r, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func TestPluginChunkedRestoreHonoursFilePicker(t *testing.T) {
 	h := &PluginHandler{}
 	item := BackupItem{Name: "test-plugin", Type: "plugin", Settings: map[string]any{"path": src}}
 	ctx := context.Background()
-	manifestID, err := h.BackupChunked(ctx, item, r, nil)
+	manifestID, err := h.BackupChunked(ctx, item, r, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestPluginChunkedInstaller(t *testing.T) {
 			h := &PluginHandler{}
 			item := BackupItem{Name: pluginName, Type: "plugin", Settings: map[string]any{"path": src}}
 			ctx := context.Background()
-			manifestID, err := h.BackupChunked(ctx, item, r, nil)
+			manifestID, err := h.BackupChunked(ctx, item, r, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -225,7 +225,7 @@ func TestPluginChunkedRestoreDestination(t *testing.T) {
 	defer cleanup()
 	h := &PluginHandler{}
 	ctx := context.Background()
-	manifestID, err := h.BackupChunked(ctx, BackupItem{Name: "p", Type: "plugin", Settings: map[string]any{"path": src}}, r, nil)
+	manifestID, err := h.BackupChunked(ctx, BackupItem{Name: "p", Type: "plugin", Settings: map[string]any{"path": src}}, r, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -45,6 +45,6 @@ type Handler interface {
 // don't satisfy this interface continue to use the classic tar path on
 // dedup destinations.
 type ChunkedHandler interface {
-	BackupChunked(ctx context.Context, item BackupItem, repo *dedup.Repo, progress ProgressFunc) (dedup.ID, error)
+	BackupChunked(ctx context.Context, item BackupItem, repo *dedup.Repo, parent *dedup.Manifest, progress ProgressFunc) (dedup.ID, error)
 	RestoreChunked(ctx context.Context, item BackupItem, repo *dedup.Repo, manifestID dedup.ID, destPath string, progress ProgressFunc) error
 }

--- a/internal/runner/backup_item_coverage_test.go
+++ b/internal/runner/backup_item_coverage_test.go
@@ -30,6 +30,7 @@ func TestBackupItem_UnknownType(t *testing.T) {
 		"",
 		"none",
 		1,
+		nil,
 	)
 	if err == nil {
 		t.Fatal("expected unknown-type error")
@@ -55,6 +56,7 @@ func TestBackupItem_VMHandlerError(t *testing.T) {
 		"",
 		"none",
 		1,
+		nil,
 	)
 	if err == nil {
 		t.Fatal("expected VMHandler init error on non-Linux")
@@ -88,7 +90,7 @@ func TestBackupItem_FolderHappyPath(t *testing.T) {
 		},
 	}
 
-	_, checksums, err := r.backupItem(context.Background(), 0, item, dest, "rp-test", false, "", "none", 1)
+	_, checksums, err := r.backupItem(context.Background(), 0, item, dest, "rp-test", false, "", "none", 1, nil)
 	if err != nil {
 		t.Fatalf("backupItem: %v", err)
 	}

--- a/internal/runner/chain_restore_test.go
+++ b/internal/runner/chain_restore_test.go
@@ -1,11 +1,14 @@
 package runner
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -96,6 +99,248 @@ func TestStageRestorePointItemOverlaysChainFiles(t *testing.T) {
 	assertFileContents(t, tmpDir, "config.json", "child-config")
 	assertFileContents(t, tmpDir, "image.tar", "base-image")
 	assertFileContents(t, tmpDir, "volume_0.tar.gz", "child-volume")
+}
+
+// TestStageContainerChainMerged exercises the container branch of
+// restoreMergedChain's per-step staging + merge (the new code path for
+// issue #320) without requiring a Docker daemon. The full step's volume_0.tar
+// holds old.txt; the differential step's volume_0.tar holds only new.txt. The
+// merged staging dir must contain a single volume_0.tar with BOTH files, so a
+// later ContainerHandler.Restore would restore the complete volume.
+func TestStageContainerChainMerged(t *testing.T) {
+	t.Parallel()
+
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	storageRoot := t.TempDir()
+	storageConfig := fmt.Sprintf(`{"path":%q}`, storageRoot)
+	storageID, err := database.CreateStorageDestination(db.StorageDestination{
+		Name:   "local",
+		Type:   "local",
+		Config: storageConfig,
+	})
+	if err != nil {
+		t.Fatalf("CreateStorageDestination: %v", err)
+	}
+
+	jobID, err := database.CreateJob(db.Job{
+		Name:            "chain-test",
+		Enabled:         true,
+		BackupTypeChain: "incremental",
+		Compression:     "none",
+		StorageDestID:   storageID,
+	})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+
+	adapter, err := storage.NewAdapter("local", storageConfig)
+	if err != nil {
+		t.Fatalf("NewAdapter: %v", err)
+	}
+	t.Cleanup(func() { storage.CloseAdapter(adapter) })
+
+	fullTar := tarArchive(t, map[string]string{"old.txt": "old"})
+	diffTar := tarArchive(t, map[string]string{"new.txt": "new"})
+
+	baseChecksums := writeStorageFiles(t, adapter, map[string]string{
+		"chain-test/1_full/my-item/volume_0.tar": string(fullTar),
+	})
+	childChecksums := writeStorageFiles(t, adapter, map[string]string{
+		"chain-test/2_inc/my-item/volume_0.tar": string(diffTar),
+	})
+
+	baseRP := db.RestorePoint{
+		ID:          1,
+		JobID:       jobID,
+		BackupType:  "full",
+		StoragePath: "chain-test/1_full",
+		Metadata:    restorePointMetadata("my-item", baseChecksums),
+		CreatedAt:   time.Now().Add(-time.Hour),
+	}
+	childRP := db.RestorePoint{
+		ID:                   2,
+		JobID:                jobID,
+		BackupType:           "incremental",
+		StoragePath:          "chain-test/2_inc",
+		Metadata:             restorePointMetadata("my-item", childChecksums),
+		ParentRestorePointID: 1,
+		CreatedAt:            time.Now(),
+	}
+
+	r := New(database, ws.NewHub(), nil)
+	tmpDir := t.TempDir()
+	reporter := restoreProgressReporter{ItemName: "my-item", ItemType: "container", ItemsTotal: 1}
+
+	mergedDir, err := r.stageContainerChainMerged(context.Background(), []db.RestorePoint{baseRP, childRP}, "my-item", "", reporter, tmpDir)
+	if err != nil {
+		t.Fatalf("stageContainerChainMerged: %v", err)
+	}
+
+	names := tarEntryNames(t, filepath.Join(mergedDir, "volume_0.tar"))
+	for _, want := range []string{"old.txt", "new.txt"} {
+		if !names[want] {
+			t.Errorf("merged volume missing %s", want)
+		}
+	}
+}
+
+// TestStageContainerChainMergedRunLog asserts that classic container chain
+// staging mirrors the VM and flat folder chain paths by emitting a
+// structured "Staging chain step X/Y" entry into the restore run log for
+// each step (issue #320 review follow-up: the container branch previously
+// logged via log.Printf only, losing these user-facing run-log lines).
+func TestStageContainerChainMergedRunLog(t *testing.T) {
+	t.Parallel()
+	r, d := newTestRunner(t)
+
+	storageRoot := t.TempDir()
+	storageConfig := fmt.Sprintf(`{"path":%q}`, storageRoot)
+	storageID, err := d.CreateStorageDestination(db.StorageDestination{
+		Name:   "local",
+		Type:   "local",
+		Config: storageConfig,
+	})
+	if err != nil {
+		t.Fatalf("CreateStorageDestination: %v", err)
+	}
+
+	jobID, err := d.CreateJob(db.Job{
+		Name:            "chain-test-runlog",
+		Enabled:         true,
+		BackupTypeChain: "incremental",
+		Compression:     "none",
+		StorageDestID:   storageID,
+	})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+
+	// runLog persists to run_log_entries, which carries a foreign key on
+	// runs — seed a real job run so the staged steps can be stored.
+	runID, err := d.CreateJobRun(db.JobRun{JobID: jobID, Status: "running", BackupType: "full"})
+	if err != nil {
+		t.Fatalf("CreateJobRun: %v", err)
+	}
+
+	adapter, err := storage.NewAdapter("local", storageConfig)
+	if err != nil {
+		t.Fatalf("NewAdapter: %v", err)
+	}
+	t.Cleanup(func() { storage.CloseAdapter(adapter) })
+
+	fullTar := tarArchive(t, map[string]string{"old.txt": "old"})
+	diffTar := tarArchive(t, map[string]string{"new.txt": "new"})
+
+	baseChecksums := writeStorageFiles(t, adapter, map[string]string{
+		"chain-test/1_full/my-item/volume_0.tar": string(fullTar),
+	})
+	childChecksums := writeStorageFiles(t, adapter, map[string]string{
+		"chain-test/2_inc/my-item/volume_0.tar": string(diffTar),
+	})
+
+	baseRP := db.RestorePoint{
+		ID:          1,
+		JobID:       jobID,
+		BackupType:  "full",
+		StoragePath: "chain-test/1_full",
+		Metadata:    restorePointMetadata("my-item", baseChecksums),
+		CreatedAt:   time.Now().Add(-time.Hour),
+	}
+	childRP := db.RestorePoint{
+		ID:                   2,
+		JobID:                jobID,
+		BackupType:           "incremental",
+		StoragePath:          "chain-test/2_inc",
+		Metadata:             restorePointMetadata("my-item", childChecksums),
+		ParentRestorePointID: 1,
+		CreatedAt:            time.Now(),
+	}
+
+	tmpDir := t.TempDir()
+	reporter := restoreProgressReporter{RunID: runID, ItemName: "my-item", ItemType: "container", ItemsTotal: 1}
+
+	if _, err := r.stageContainerChainMerged(context.Background(), []db.RestorePoint{baseRP, childRP}, "my-item", "", reporter, tmpDir); err != nil {
+		t.Fatalf("stageContainerChainMerged: %v", err)
+	}
+
+	entries, err := d.ListRunLogEntries(context.Background(), runID, 0, 100)
+	if err != nil {
+		t.Fatalf("ListRunLogEntries: %v", err)
+	}
+	var msgs []string
+	for _, e := range entries {
+		msgs = append(msgs, e.Message)
+	}
+	joined := strings.Join(msgs, "\n")
+
+	// One row per chain step: the merged container staging must narrate
+	// each step with the same structured run-log line the VM and folder
+	// chain paths already emit.
+	cases := []struct {
+		name string
+		want string
+	}{
+		{name: "full step staged", want: "Staging chain step 1/2 (type=full, id=1)"},
+		{name: "incremental step staged", want: "Staging chain step 2/2 (type=incremental, id=2)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(joined, tc.want) {
+				t.Errorf("run log missing %q; got:\n%s", tc.want, joined)
+			}
+		})
+	}
+}
+
+// tarArchive builds an uncompressed tar archive from a name→content map.
+func tarArchive(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for name, content := range files {
+		hdr := &tar.Header{Name: name, Mode: 0o644, Size: int64(len(content)), Typeflag: tar.TypeReg}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// tarEntryNames returns the set of regular-file entry names in an
+// uncompressed tar archive.
+func tarEntryNames(t *testing.T, path string) map[string]bool {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	names := map[string]bool{}
+	tr := tar.NewReader(f)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading tar %s: %v", path, err)
+		}
+		if hdr.Typeflag == tar.TypeReg {
+			names[hdr.Name] = true
+		}
+	}
+	return names
 }
 
 func TestProtectedRestorePointIDsKeepsAncestors(t *testing.T) {

--- a/internal/runner/chain_restore_test.go
+++ b/internal/runner/chain_restore_test.go
@@ -110,82 +110,95 @@ func TestStageRestorePointItemOverlaysChainFiles(t *testing.T) {
 func TestStageContainerChainMerged(t *testing.T) {
 	t.Parallel()
 
-	database, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("db.Open: %v", err)
+	tests := []struct {
+		name        string
+		wantInMerged []string
+	}{
+		{
+			name:        "differential step's partial volume overlays the full step's",
+			wantInMerged: []string{"old.txt", "new.txt"},
+		},
 	}
-	t.Cleanup(func() { _ = database.Close() })
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database, err := db.Open(":memory:")
+			if err != nil {
+				t.Fatalf("db.Open: %v", err)
+			}
+			t.Cleanup(func() { _ = database.Close() })
 
-	storageRoot := t.TempDir()
-	storageConfig := fmt.Sprintf(`{"path":%q}`, storageRoot)
-	storageID, err := database.CreateStorageDestination(db.StorageDestination{
-		Name:   "local",
-		Type:   "local",
-		Config: storageConfig,
-	})
-	if err != nil {
-		t.Fatalf("CreateStorageDestination: %v", err)
-	}
+			storageRoot := t.TempDir()
+			storageConfig := fmt.Sprintf(`{"path":%q}`, storageRoot)
+			storageID, err := database.CreateStorageDestination(db.StorageDestination{
+				Name:   "local",
+				Type:   "local",
+				Config: storageConfig,
+			})
+			if err != nil {
+				t.Fatalf("CreateStorageDestination: %v", err)
+			}
 
-	jobID, err := database.CreateJob(db.Job{
-		Name:            "chain-test",
-		Enabled:         true,
-		BackupTypeChain: "incremental",
-		Compression:     "none",
-		StorageDestID:   storageID,
-	})
-	if err != nil {
-		t.Fatalf("CreateJob: %v", err)
-	}
+			jobID, err := database.CreateJob(db.Job{
+				Name:            "chain-test",
+				Enabled:         true,
+				BackupTypeChain: "incremental",
+				Compression:     "none",
+				StorageDestID:   storageID,
+			})
+			if err != nil {
+				t.Fatalf("CreateJob: %v", err)
+			}
 
-	adapter, err := storage.NewAdapter("local", storageConfig)
-	if err != nil {
-		t.Fatalf("NewAdapter: %v", err)
-	}
-	t.Cleanup(func() { storage.CloseAdapter(adapter) })
+			adapter, err := storage.NewAdapter("local", storageConfig)
+			if err != nil {
+				t.Fatalf("NewAdapter: %v", err)
+			}
+			t.Cleanup(func() { storage.CloseAdapter(adapter) })
 
-	fullTar := tarArchive(t, map[string]string{"old.txt": "old"})
-	diffTar := tarArchive(t, map[string]string{"new.txt": "new"})
+			fullTar := tarArchive(t, map[string]string{"old.txt": "old"})
+			diffTar := tarArchive(t, map[string]string{"new.txt": "new"})
 
-	baseChecksums := writeStorageFiles(t, adapter, map[string]string{
-		"chain-test/1_full/my-item/volume_0.tar": string(fullTar),
-	})
-	childChecksums := writeStorageFiles(t, adapter, map[string]string{
-		"chain-test/2_inc/my-item/volume_0.tar": string(diffTar),
-	})
+			baseChecksums := writeStorageFiles(t, adapter, map[string]string{
+				"chain-test/1_full/my-item/volume_0.tar": string(fullTar),
+			})
+			childChecksums := writeStorageFiles(t, adapter, map[string]string{
+				"chain-test/2_inc/my-item/volume_0.tar": string(diffTar),
+			})
 
-	baseRP := db.RestorePoint{
-		ID:          1,
-		JobID:       jobID,
-		BackupType:  "full",
-		StoragePath: "chain-test/1_full",
-		Metadata:    restorePointMetadata("my-item", baseChecksums),
-		CreatedAt:   time.Now().Add(-time.Hour),
-	}
-	childRP := db.RestorePoint{
-		ID:                   2,
-		JobID:                jobID,
-		BackupType:           "incremental",
-		StoragePath:          "chain-test/2_inc",
-		Metadata:             restorePointMetadata("my-item", childChecksums),
-		ParentRestorePointID: 1,
-		CreatedAt:            time.Now(),
-	}
+			baseRP := db.RestorePoint{
+				ID:          1,
+				JobID:       jobID,
+				BackupType:  "full",
+				StoragePath: "chain-test/1_full",
+				Metadata:    restorePointMetadata("my-item", baseChecksums),
+				CreatedAt:   time.Now().Add(-time.Hour),
+			}
+			childRP := db.RestorePoint{
+				ID:                   2,
+				JobID:                jobID,
+				BackupType:           "incremental",
+				StoragePath:          "chain-test/2_inc",
+				Metadata:             restorePointMetadata("my-item", childChecksums),
+				ParentRestorePointID: 1,
+				CreatedAt:            time.Now(),
+			}
 
-	r := New(database, ws.NewHub(), nil)
-	tmpDir := t.TempDir()
-	reporter := restoreProgressReporter{ItemName: "my-item", ItemType: "container", ItemsTotal: 1}
+			r := New(database, ws.NewHub(), nil)
+			tmpDir := t.TempDir()
+			reporter := restoreProgressReporter{ItemName: "my-item", ItemType: "container", ItemsTotal: 1}
 
-	mergedDir, err := r.stageContainerChainMerged(context.Background(), []db.RestorePoint{baseRP, childRP}, "my-item", "", reporter, tmpDir)
-	if err != nil {
-		t.Fatalf("stageContainerChainMerged: %v", err)
-	}
+			mergedDir, err := r.stageContainerChainMerged(context.Background(), []db.RestorePoint{baseRP, childRP}, "my-item", "", reporter, tmpDir)
+			if err != nil {
+				t.Fatalf("stageContainerChainMerged: %v", err)
+			}
 
-	names := tarEntryNames(t, filepath.Join(mergedDir, "volume_0.tar"))
-	for _, want := range []string{"old.txt", "new.txt"} {
-		if !names[want] {
-			t.Errorf("merged volume missing %s", want)
-		}
+			names := tarEntryNames(t, filepath.Join(mergedDir, "volume_0.tar"))
+			for _, want := range tt.wantInMerged {
+				if !names[want] {
+					t.Errorf("merged volume missing %s", want)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/runner/folder_runlog_test.go
+++ b/internal/runner/folder_runlog_test.go
@@ -113,7 +113,7 @@ func TestBackupItem_FolderDedupRunLogMilestones(t *testing.T) {
 		Settings:    map[string]any{"path": src, "preset": "flash"},
 		Compression: "none",
 	}
-	if _, _, err := r.backupItem(context.Background(), runID, item, dest, "rp", false, "", "none", 1); err != nil {
+	if _, _, err := r.backupItem(context.Background(), runID, item, dest, "rp", false, "", "none", 1, nil); err != nil {
 		t.Fatalf("backupItem (dedup): %v", err)
 	}
 

--- a/internal/runner/runlog_mirror_test.go
+++ b/internal/runner/runlog_mirror_test.go
@@ -172,7 +172,7 @@ func TestBackupItem_FolderDedupPhaseAndStatsLog(t *testing.T) {
 		Settings:    map[string]any{"path": src, "preset": "flash"},
 		Compression: "none",
 	}
-	if _, _, err := r.backupItem(context.Background(), runID, item, dest, "rp", false, "", "none", 1); err != nil {
+	if _, _, err := r.backupItem(context.Background(), runID, item, dest, "rp", false, "", "none", 1, nil); err != nil {
 		t.Fatalf("backupItem (dedup): %v", err)
 	}
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1316,7 +1316,7 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 			continue
 		}
 
-		result, checksums, backupErr := r.backupItem(ctx, runID, backupItem, dest, itemPath, job.VerifyBackup, encryptPassphrase, job.Compression, job.EffectiveUploadConcurrency())
+		result, checksums, backupErr := r.backupItem(ctx, runID, backupItem, dest, itemPath, job.VerifyBackup, encryptPassphrase, job.Compression, job.EffectiveUploadConcurrency(), btResult.ParentRP)
 		if backupErr != nil {
 			// If the context was cancelled, stop processing remaining items.
 			if ctx.Err() != nil {
@@ -2292,14 +2292,14 @@ func (r *Runner) collectLiveManifestIDs(repo *dedup.Repo, destID int64) ([]dedup
 // engine.ChunkedHandler, the call is routed to backupItemChunked instead of
 // the classic tar pipeline. Handlers that don't support chunking (vm, zfs)
 // transparently fall through to the classic path even on dedup destinations.
-func (r *Runner) backupItem(ctx context.Context, runID int64, item engine.BackupItem, dest db.StorageDestination, storagePath string, verify bool, passphrase string, compression string, concurrency int) (*engine.BackupResult, map[string]string, error) {
+func (r *Runner) backupItem(ctx context.Context, runID int64, item engine.BackupItem, dest db.StorageDestination, storagePath string, verify bool, passphrase string, compression string, concurrency int, parentRP *db.RestorePoint) (*engine.BackupResult, map[string]string, error) {
 	if dest.DedupEnabled {
 		handler, err := newHandler(item.Type)
 		if err != nil {
 			return nil, nil, err
 		}
 		if chunked, ok := handler.(engine.ChunkedHandler); ok {
-			return r.backupItemChunked(ctx, runID, item, dest, chunked)
+			return r.backupItemChunked(ctx, runID, item, dest, parentRP, chunked)
 		}
 		// Fall through to classic tar for non-chunked handlers (VM, ZFS).
 	}
@@ -2322,7 +2322,7 @@ func (r *Runner) backupItem(ctx context.Context, runID int64, item engine.Backup
 // handler's BackupChunked, flushes any pending pack, and returns a
 // BackupResult whose Meta carries the manifest ID for the runner to
 // persist on the resulting restore_points row.
-func (r *Runner) backupItemChunked(ctx context.Context, runID int64, item engine.BackupItem, dest db.StorageDestination, handler engine.ChunkedHandler) (*engine.BackupResult, map[string]string, error) {
+func (r *Runner) backupItemChunked(ctx context.Context, runID int64, item engine.BackupItem, dest db.StorageDestination, parentRP *db.RestorePoint, handler engine.ChunkedHandler) (*engine.BackupResult, map[string]string, error) {
 	adapter, err := storage.NewAdapter(dest.Type, dest.Config)
 	if err != nil {
 		return nil, nil, fmt.Errorf("adapter: %w", err)
@@ -2341,6 +2341,23 @@ func (r *Runner) backupItemChunked(ctx context.Context, runID int64, item engine
 	repo, err := r.openDedupRepo(heartbeat, dest)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open dedup repo: %w", err)
+	}
+
+	// For differential/incremental backups, load the parent item's manifest
+	// so the handler can carry forward unchanged entries and keep the new
+	// manifest complete for single-point restore (issue #320). A missing or
+	// unreadable parent manifest degrades to a nil parent (the handler still
+	// honours changed_since and produces a partial manifest), so a corrupted
+	// parent can't hard-fail the backup.
+	var parent *dedup.Manifest
+	if parentRP != nil {
+		if pid, ok := resolveManifestID(*parentRP, item.Name); ok {
+			if pm, gErr := repo.GetManifest(pid); gErr == nil {
+				parent = &pm
+			} else {
+				log.Printf("runner: dedup item %q: loading parent manifest: %v (continuing without carry-forward)", item.Name, gErr)
+			}
+		}
 	}
 
 	admit := newBroadcastThrottle()
@@ -2368,7 +2385,7 @@ func (r *Runner) backupItemChunked(ctx context.Context, runID int64, item engine
 		})
 	}
 
-	manifestID, err := handler.BackupChunked(ctx, item, repo, progress)
+	manifestID, err := handler.BackupChunked(ctx, item, repo, parent, progress)
 	if err != nil {
 		return nil, nil, fmt.Errorf("backup chunked: %w", err)
 	}
@@ -3200,13 +3217,14 @@ func (r *Runner) restoreItemChain(ctx context.Context, restorePoint db.RestorePo
 			return fmt.Errorf("building restore chain: %w", err)
 		}
 		// Dedup restore points (folder, container, plugin) carry a COMPLETE
-		// manifest — BackupChunked walks the whole item every run, so
-		// increments reuse chunks, not manifest entries. Restoring the
-		// selected point alone reproduces the exact point-in-time state and
-		// cannot resurrect files deleted or excluded after the base full
-		// backup (issue #231). This must run BEFORE the merged-chain dispatch
-		// because containers use merged chains but dedup containers must
-		// take the single-point chunked restore path.
+		// manifest — BackupChunked walks the item and, for differential/
+		// incremental runs, carries unchanged entries forward from the parent
+		// manifest (issue #320). Restoring the selected point alone
+		// reproduces the exact point-in-time state and cannot resurrect files
+		// deleted or excluded after the base full backup (issue #231). This
+		// must run BEFORE the merged-chain dispatch because containers use
+		// merged chains but dedup containers must take the single-point
+		// chunked restore path.
 		if _, ok := resolveManifestID(restorePoint, itemName); ok {
 			log.Printf("runner: dedup restore point %d has a complete manifest — restoring it directly (no chain replay)", restorePoint.ID)
 			r.runLog(reporter.RunID, runLogLevelInfo,
@@ -3523,8 +3541,9 @@ func (r *Runner) restoreMergedChain(ctx context.Context, chain []db.RestorePoint
 // (issue #320).
 //
 // NOTE: the merge is a pure union — a file deleted after the base full is
-// merged back in (classic-container deletion pruning is issue #231, out of
-// scope for #320).
+// merged back in. The folder classic path compensates via pruneChainResurrected
+// (issue #231, folder-scoped and closed); the container path has no equivalent
+// prune yet, so deleted files can reappear on restore. Out of scope for #320.
 func (r *Runner) stageContainerChainMerged(ctx context.Context, chain []db.RestorePoint, itemName, passphrase string, reporter restoreProgressReporter, tmpDir string) (string, error) {
 	stepDirs := make([]string, 0, len(chain))
 	for i, rp := range chain {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1204,6 +1204,29 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 
 		if btResult.ParentRP != nil && (item.ItemType == "container" || item.ItemType == "folder") {
 			backupItem.Settings["changed_since"] = btResult.ParentRP.CreatedAt.Format(time.RFC3339)
+			// Classic (non-dedup) folder differentials/incrementals: load the
+			// parent's effective listing so the engine can detect NEW files with
+			// stale mtimes (issue #320). The dedup path carries forward via the
+			// parent manifest instead.
+			if !dest.DedupEnabled && item.ItemType == "folder" {
+				if paths := r.loadParentListingPaths(btResult.ParentRP, dest, item.ItemName, encryptPassphrase); paths != nil {
+					backupItem.Settings["prev_listing_paths"] = paths
+				} else {
+					log.Printf("runner: warning: parent listing unavailable for %s — falling back to mtime-only differential filtering", item.ItemName)
+				}
+			}
+			// Classic (non-dedup) container differentials/incrementals: load the
+			// parent's per-volume listings keyed by mount source host path, so
+			// the engine detects NEW files with stale mtimes in each volume
+			// (issue #320). Dedup containers carry forward via the parent
+			// manifest instead.
+			if !dest.DedupEnabled && item.ItemType == "container" {
+				if bySource := r.loadParentVolumeListingPaths(btResult.ParentRP, dest, item.ItemName, encryptPassphrase); bySource != nil {
+					backupItem.Settings["prev_volume_listing_paths"] = bySource
+				} else {
+					log.Printf("runner: warning: parent volume listings unavailable for %s — falling back to mtime-only differential filtering", item.ItemName)
+				}
+			}
 		}
 
 		// Folder items need the path from settings.
@@ -3447,6 +3470,138 @@ func (r *Runner) readItemSidecar(adapter storage.Adapter, rp db.RestorePoint, it
 		return engine.TarIndex{}, false
 	}
 	return idx, true
+}
+
+// loadParentListingPaths returns the item-relative path set recorded in the
+// parent restore point's effective listing, so a differential/incremental
+// classic folder backup can detect NEW files whose mtime predates changed_since
+// (issue #320). Returns nil when no listing is available (pre-listing backups,
+// or a read failure), which degrades the engine to its mtime-only filter.
+func (r *Runner) loadParentListingPaths(parentRP *db.RestorePoint, dest db.StorageDestination, itemName, passphrase string) []string {
+	adapter, err := storage.NewAdapter(dest.Type, dest.Config)
+	if err != nil {
+		return nil
+	}
+	defer storage.CloseAdapter(adapter)
+
+	listing, ok := r.readItemSidecar(adapter, *parentRP, itemName, engine.ListingSuffix, passphrase)
+	if !ok {
+		return nil
+	}
+	paths := make([]string, 0, len(listing.Files))
+	for _, f := range listing.Files {
+		paths = append(paths, f.Path)
+	}
+	return paths
+}
+
+// loadParentVolumeListingPaths reads the parent restore point's volumes.json
+// manifest and each backed-up volume's effective-listing sidecar, returning a
+// map keyed by mount source host path -> volume-relative paths. Used by classic
+// container differentials/incrementals to detect NEW files whose mtime predates
+// changed_since (issue #320). Returns nil when no listing is available
+// (pre-listing backups or a read failure), which degrades the engine to its
+// mtime-only filter.
+func (r *Runner) loadParentVolumeListingPaths(parentRP *db.RestorePoint, dest db.StorageDestination, itemName, passphrase string) map[string][]string {
+	adapter, err := storage.NewAdapter(dest.Type, dest.Config)
+	if err != nil {
+		return nil
+	}
+	defer storage.CloseAdapter(adapter)
+
+	itemPrefix := path.Join(parentRP.StoragePath, itemName)
+	entries, err := adapter.List(itemPrefix)
+	if err != nil {
+		return nil
+	}
+
+	// Index files by base name so the manifest's archive names resolve to
+	// their listing sidecars (encrypted variants included).
+	byName := make(map[string]storage.FileInfo, len(entries))
+	for _, e := range entries {
+		if !e.IsDir {
+			byName[path.Base(e.Path)] = e
+		}
+	}
+
+	resolvePass := func() string {
+		if passphrase != "" {
+			return passphrase
+		}
+		return r.ResolvePassphrase()
+	}
+
+	// openSidecar locates a file by base name (or its .age variant), opens it,
+	// and decrypts it when needed. ok=false on any failure.
+	openSidecar := func(name string) (io.ReadCloser, bool) {
+		info, ok := byName[name]
+		if !ok {
+			info, ok = byName[name+".age"]
+			if !ok {
+				return nil, false
+			}
+		}
+		rc, err := adapter.Read(info.Path)
+		if err != nil {
+			return nil, false
+		}
+		if !strings.HasSuffix(info.Path, ".age") {
+			return rc, true
+		}
+		pass := resolvePass()
+		if pass == "" {
+			_ = rc.Close()
+			return nil, false
+		}
+		dec, decErr := crypto.DecryptReader(pass, rc)
+		if decErr != nil {
+			_ = rc.Close()
+			return nil, false
+		}
+		return dec, true
+	}
+
+	// volumes.json maps each backed-up volume's source host path to its
+	// archive base name (e.g. volume_0.tar.gz). The mount source is the stable
+	// correlation key — the volume_N index can shift when mounts are reordered.
+	manifestRC, ok := openSidecar("volumes.json")
+	if !ok {
+		return nil
+	}
+	var vols []struct {
+		Source  string `json:"source"`
+		Archive string `json:"archive,omitempty"`
+	}
+	decodeErr := json.NewDecoder(manifestRC).Decode(&vols)
+	_ = manifestRC.Close()
+	if decodeErr != nil {
+		return nil
+	}
+
+	out := make(map[string][]string)
+	for _, v := range vols {
+		if v.Archive == "" {
+			continue
+		}
+		listingRC, ok := openSidecar(v.Archive + engine.ListingSuffix)
+		if !ok {
+			continue
+		}
+		idx, err := engine.ReadTarIndex(listingRC)
+		_ = listingRC.Close()
+		if err != nil {
+			continue
+		}
+		paths := make([]string, 0, len(idx.Files))
+		for _, f := range idx.Files {
+			paths = append(paths, f.Path)
+		}
+		out[v.Source] = paths
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // guardPanic recovers and logs a panic in a fire-and-forget worker goroutine

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -2368,9 +2368,9 @@ func (r *Runner) backupItemChunked(ctx context.Context, runID int64, item engine
 	// For differential/incremental backups, load the parent item's manifest
 	// so the handler can carry forward unchanged entries and keep the new
 	// manifest complete for single-point restore (issue #320). A missing or
-	// unreadable parent manifest degrades to a nil parent (the handler still
-	// honours changed_since and produces a partial manifest), so a corrupted
-	// parent can't hard-fail the backup.
+	// unreadable parent manifest degrades to a nil parent, in which case the
+	// handler ignores changed_since and chunks the item FULLY, so a corrupted
+	// parent costs extra work but never drops files or fails the backup.
 	var parent *dedup.Manifest
 	if parentRP != nil {
 		if pid, ok := resolveManifestID(*parentRP, item.Name); ok {
@@ -3516,9 +3516,12 @@ func (r *Runner) loadParentListingPaths(parentRP *db.RestorePoint, dest db.Stora
 // manifest and each backed-up volume's effective-listing sidecar, returning a
 // map keyed by mount source host path -> volume-relative paths. Used by classic
 // container differentials/incrementals to detect NEW files whose mtime predates
-// changed_since (issue #320). Returns nil when no listing is available
-// (pre-listing backups or a read failure); the caller then clears changed_since
-// to degrade to a full archive (see applyClassicDiffListing).
+// changed_since (issue #320). Resolution is all-or-nothing: nil is returned
+// when ANY backed-up volume's listing is missing or unreadable (pre-listing
+// backups, a partial write, or a read failure); the caller then clears
+// changed_since to degrade to a full archive (see applyClassicDiffListing) —
+// never a partial map that would leave the unresolved volume on mtime-only
+// filtering.
 func (r *Runner) loadParentVolumeListingPaths(parentRP *db.RestorePoint, dest db.StorageDestination, itemName, passphrase string) map[string][]string {
 	adapter, err := storage.NewAdapter(dest.Type, dest.Config)
 	if err != nil {
@@ -3602,12 +3605,17 @@ func (r *Runner) loadParentVolumeListingPaths(parentRP *db.RestorePoint, dest db
 		}
 		listingRC, ok := openSidecar(v.Archive + engine.ListingSuffix)
 		if !ok {
-			continue
+			// All-or-nothing (issue #320 review follow-up): a single
+			// missing listing would leave that volume on mtime-only
+			// filtering in the engine — silently dropping a NEW
+			// stale-mtime file. Returning nil makes the caller clear
+			// changed_since and degrade to a full archive instead.
+			return nil
 		}
 		idx, err := engine.ReadTarIndex(listingRC)
 		_ = listingRC.Close()
 		if err != nil {
-			continue
+			return nil
 		}
 		paths := make([]string, 0, len(idx.Files))
 		for _, f := range idx.Files {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -3460,8 +3460,7 @@ func (r *Runner) restoreMergedChain(ctx context.Context, chain []db.RestorePoint
 	// VM qcow2 chains must be assembled per-step then flattened with
 	// qemu-img so each chain step keeps its own dirty-block deltas. For
 	// non-VM items we keep the simple flat staging where each chain step
-	// can safely overlay files in the same directory (folder rsync,
-	// container layered tar, etc.).
+	// can safely overlay files in the same directory (folder rsync, etc.).
 	if itemType == "vm" && len(chain) > 1 {
 		stepDirs := make([]string, 0, len(chain))
 		for i, rp := range chain {
@@ -3489,6 +3488,18 @@ func (r *Runner) restoreMergedChain(ctx context.Context, chain []db.RestorePoint
 		return r.restoreStagedItem(ctx, chain[len(chain)-1].JobID, itemName, itemType, destination, flattenedDir, filePaths, reporter, 40, 100)
 	}
 
+	if itemType == "container" {
+		// Classic container chains must be merged, not flattened: a
+		// differential/incremental step's partial volume_N.tar would
+		// otherwise overwrite the full step's complete archive in the shared
+		// staging dir, dropping base files (issue #320).
+		mergedDir, err := r.stageContainerChainMerged(ctx, chain, itemName, passphrase, reporter, tmpDir)
+		if err != nil {
+			return err
+		}
+		return r.restoreStagedItem(ctx, chain[len(chain)-1].JobID, itemName, itemType, destination, mergedDir, filePaths, reporter, 40, 100)
+	}
+
 	for i, rp := range chain {
 		r.runLog(reporter.RunID, runLogLevelInfo,
 			fmt.Sprintf("Staging chain step %d/%d (type=%s, id=%d)", i+1, len(chain), rp.BackupType, rp.ID),
@@ -3502,6 +3513,42 @@ func (r *Runner) restoreMergedChain(ctx context.Context, chain []db.RestorePoint
 	}
 
 	return r.restoreStagedItem(ctx, chain[len(chain)-1].JobID, itemName, itemType, destination, tmpDir, filePaths, reporter, 40, 100)
+}
+
+// stageContainerChainMerged stages each restore point in a classic container
+// chain into its own step directory and merges the per-step volume archives
+// oldest-first into a single directory that ContainerHandler.Restore can
+// consume. A differential/incremental step's partial volume_N.tar must not
+// overwrite the full step's complete archive, or base files would be dropped
+// (issue #320).
+//
+// NOTE: the merge is a pure union — a file deleted after the base full is
+// merged back in (classic-container deletion pruning is issue #231, out of
+// scope for #320).
+func (r *Runner) stageContainerChainMerged(ctx context.Context, chain []db.RestorePoint, itemName, passphrase string, reporter restoreProgressReporter, tmpDir string) (string, error) {
+	stepDirs := make([]string, 0, len(chain))
+	for i, rp := range chain {
+		r.runLog(reporter.RunID, runLogLevelInfo,
+			fmt.Sprintf("Staging chain step %d/%d (type=%s, id=%d)", i+1, len(chain), rp.BackupType, rp.ID),
+			map[string]any{"step": i + 1, "steps": len(chain), "backup_type": rp.BackupType, "restore_point_id": rp.ID})
+		log.Printf("runner: staging chain step %d/%d (type=%s, id=%d)", i+1, len(chain), rp.BackupType, rp.ID)
+		stepDir := filepath.Join(tmpDir, fmt.Sprintf("step_%d", i))
+		if err := os.MkdirAll(stepDir, 0o755); err != nil {
+			return "", fmt.Errorf("creating chain step dir: %w", err)
+		}
+		phaseStart := (i * 40) / len(chain)
+		phaseEnd := ((i + 1) * 40) / len(chain)
+		if err := r.stageRestorePointItem(ctx, rp, itemName, stepDir, passphrase, phaseStart, phaseEnd, reporter); err != nil {
+			return "", fmt.Errorf("staging chain step %d (id=%d): %w", i+1, rp.ID, err)
+		}
+		stepDirs = append(stepDirs, stepDir)
+	}
+
+	mergedDir := filepath.Join(tmpDir, "merged")
+	if err := engine.MergeContainerChainStaging(ctx, stepDirs, mergedDir); err != nil {
+		return "", fmt.Errorf("merging container chain: %w", err)
+	}
+	return mergedDir, nil
 }
 
 // restoreSinglePoint restores a single restore point (without chain logic).

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1204,27 +1204,26 @@ func (r *Runner) runJobInternal(jobID int64, opts runOptions) {
 
 		if btResult.ParentRP != nil && (item.ItemType == "container" || item.ItemType == "folder") {
 			backupItem.Settings["changed_since"] = btResult.ParentRP.CreatedAt.Format(time.RFC3339)
-			// Classic (non-dedup) folder differentials/incrementals: load the
-			// parent's effective listing so the engine can detect NEW files with
-			// stale mtimes (issue #320). The dedup path carries forward via the
-			// parent manifest instead.
-			if !dest.DedupEnabled && item.ItemType == "folder" {
-				if paths := r.loadParentListingPaths(btResult.ParentRP, dest, item.ItemName, encryptPassphrase); paths != nil {
-					backupItem.Settings["prev_listing_paths"] = paths
+			// Classic (non-dedup) differentials/incrementals load the parent's
+			// effective listing (folder: item-relative paths; container:
+			// per-volume paths keyed by mount source) so the engine can detect
+			// NEW files with stale mtimes (issue #320). When the listing is
+			// unavailable the engine degrades to a FULL archive instead of
+			// silently mtime-only filtering — which would drop a NEW stale-mtime
+			// file (e.g. cp -a), the literal issue #320 data-loss class. The
+			// dedup path carries forward via the parent manifest in the engine,
+			// so it never takes this branch.
+			if !dest.DedupEnabled {
+				var listingPaths []string
+				var volumeListingPaths map[string][]string
+				if item.ItemType == "folder" {
+					listingPaths = r.loadParentListingPaths(btResult.ParentRP, dest, item.ItemName, encryptPassphrase)
 				} else {
-					log.Printf("runner: warning: parent listing unavailable for %s — falling back to mtime-only differential filtering", item.ItemName)
+					volumeListingPaths = r.loadParentVolumeListingPaths(btResult.ParentRP, dest, item.ItemName, encryptPassphrase)
 				}
-			}
-			// Classic (non-dedup) container differentials/incrementals: load the
-			// parent's per-volume listings keyed by mount source host path, so
-			// the engine detects NEW files with stale mtimes in each volume
-			// (issue #320). Dedup containers carry forward via the parent
-			// manifest instead.
-			if !dest.DedupEnabled && item.ItemType == "container" {
-				if bySource := r.loadParentVolumeListingPaths(btResult.ParentRP, dest, item.ItemName, encryptPassphrase); bySource != nil {
-					backupItem.Settings["prev_volume_listing_paths"] = bySource
-				} else {
-					log.Printf("runner: warning: parent volume listings unavailable for %s — falling back to mtime-only differential filtering", item.ItemName)
+				applyClassicDiffListing(backupItem.Settings, item.ItemType, listingPaths, volumeListingPaths)
+				if _, hasChangedSince := backupItem.Settings["changed_since"]; !hasChangedSince {
+					log.Printf("runner: parent listing unavailable for %s — degrading %s backup to a full archive (mtime-only filtering would drop stale-mtime new files)", item.ItemName, btResult.BackupType)
 				}
 			}
 		}
@@ -3476,7 +3475,8 @@ func (r *Runner) readItemSidecar(adapter storage.Adapter, rp db.RestorePoint, it
 // parent restore point's effective listing, so a differential/incremental
 // classic folder backup can detect NEW files whose mtime predates changed_since
 // (issue #320). Returns nil when no listing is available (pre-listing backups,
-// or a read failure), which degrades the engine to its mtime-only filter.
+// or a read failure); the caller then clears changed_since to degrade to a
+// full archive (see applyClassicDiffListing).
 func (r *Runner) loadParentListingPaths(parentRP *db.RestorePoint, dest db.StorageDestination, itemName, passphrase string) []string {
 	adapter, err := storage.NewAdapter(dest.Type, dest.Config)
 	if err != nil {
@@ -3500,8 +3500,8 @@ func (r *Runner) loadParentListingPaths(parentRP *db.RestorePoint, dest db.Stora
 // map keyed by mount source host path -> volume-relative paths. Used by classic
 // container differentials/incrementals to detect NEW files whose mtime predates
 // changed_since (issue #320). Returns nil when no listing is available
-// (pre-listing backups or a read failure), which degrades the engine to its
-// mtime-only filter.
+// (pre-listing backups or a read failure); the caller then clears changed_since
+// to degrade to a full archive (see applyClassicDiffListing).
 func (r *Runner) loadParentVolumeListingPaths(parentRP *db.RestorePoint, dest db.StorageDestination, itemName, passphrase string) map[string][]string {
 	adapter, err := storage.NewAdapter(dest.Type, dest.Config)
 	if err != nil {
@@ -3602,6 +3602,31 @@ func (r *Runner) loadParentVolumeListingPaths(parentRP *db.RestorePoint, dest db
 		return nil
 	}
 	return out
+}
+
+// applyClassicDiffListing resolves the changed_since / prev-listing settings
+// for a classic (non-dedup) differential/incremental folder or container item.
+// When the parent's effective listing is available it is attached so the engine
+// detects NEW files with stale mtimes (issue #320); when it is unavailable the
+// changed_since gate is CLEARED so the engine degrades to a FULL archive —
+// never silent mtime-only filtering, which would drop a NEW stale-mtime file
+// (e.g. cp -a), the literal issue #320 data-loss class. Dedup items carry
+// forward via the parent manifest in the engine and never reach this helper.
+func applyClassicDiffListing(settings map[string]any, itemType string, listingPaths []string, volumeListingPaths map[string][]string) {
+	switch itemType {
+	case "folder":
+		if listingPaths != nil {
+			settings["prev_listing_paths"] = listingPaths
+		} else {
+			delete(settings, "changed_since")
+		}
+	case "container":
+		if volumeListingPaths != nil {
+			settings["prev_volume_listing_paths"] = volumeListingPaths
+		} else {
+			delete(settings, "changed_since")
+		}
+	}
 }
 
 // guardPanic recovers and logs a panic in a fire-and-forget worker goroutine

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -3420,6 +3420,24 @@ func (r *Runner) ReadItemSidecar(dest db.StorageDestination, rp db.RestorePoint,
 	return r.readItemSidecar(adapter, rp, itemName, suffix, "")
 }
 
+// isSidecarBase reports whether base is a valid per-item sidecar name for the
+// given suffix: it must end in suffix (or suffix+".age") AND the part before
+// the suffix must itself be an archive base name — every engine archive
+// (data.tar[.gz|.zst], volume_N.tar[.gz|.zst], image.tar, config.tar) carries
+// ".tar". This rejects unrelated files that merely end in the suffix, which
+// the previous bare HasSuffix match would have accepted (issue #320 review
+// feedback).
+func isSidecarBase(base, suffix string) bool {
+	rest, ok := strings.CutSuffix(base, suffix+".age")
+	if !ok {
+		rest, ok = strings.CutSuffix(base, suffix)
+		if !ok {
+			return false
+		}
+	}
+	return strings.Contains(rest, ".tar")
+}
+
 // readItemSidecar reads a per-item JSON sidecar (tar index or effective
 // listing) for a restore point, decrypting .age variants with the supplied
 // passphrase (falling back to the configured one when empty).
@@ -3434,8 +3452,7 @@ func (r *Runner) readItemSidecar(adapter storage.Adapter, rp db.RestorePoint, it
 		if e.IsDir {
 			continue
 		}
-		base := path.Base(e.Path)
-		if strings.HasSuffix(base, suffix) || strings.HasSuffix(base, suffix+".age") {
+		if isSidecarBase(path.Base(e.Path), suffix) {
 			candidate = e.Path
 			break
 		}

--- a/internal/runner/runner_listing_test.go
+++ b/internal/runner/runner_listing_test.go
@@ -48,6 +48,16 @@ func TestLoadParentVolumeListingPaths(t *testing.T) {
 			},
 		},
 		{
+			name: "compressed archive name resolves via manifest",
+			files: map[string]string{
+				itemPrefix + "/volumes.json":                 `[{"index":0,"source":"` + sourcePath + `","destination":"/data","backed_up":true,"archive":"volume_0.tar.gz"}]`,
+				itemPrefix + "/volume_0.tar.gz.listing.json": `{"version":1,"archive":"volume_0.tar.gz","files":[{"path":"old.txt"},{"path":"sub/nested.txt"}]}`,
+			},
+			want: map[string][]string{
+				sourcePath: {"old.txt", "sub/nested.txt"},
+			},
+		},
+		{
 			name:  "missing manifest returns nil",
 			files: map[string]string{},
 			want:  nil,
@@ -248,6 +258,45 @@ func TestApplyClassicDiffListing(t *testing.T) {
 				if _, ok := settings["prev_volume_listing_paths"]; ok {
 					t.Fatalf("unexpected prev_volume_listing_paths set: %#v", settings)
 				}
+			}
+		})
+	}
+}
+
+// TestIsSidecarBase verifies the tightened sidecar-name match (issue #320
+// review feedback): only a real <archive>.{listing,index}.json name — one whose
+// prefix carries ".tar" — is accepted, while unrelated files that merely end in
+// the suffix are rejected.
+func TestIsSidecarBase(t *testing.T) {
+	t.Parallel()
+
+	const (
+		listing = ".listing.json"
+		index   = ".index.json"
+	)
+
+	cases := []struct {
+		name   string
+		base   string
+		suffix string
+		want   bool
+	}{
+		{name: "plain listing", base: "data.tar.listing.json", suffix: listing, want: true},
+		{name: "gzip listing", base: "data.tar.gz.listing.json", suffix: listing, want: true},
+		{name: "zstd listing", base: "data.tar.zst.listing.json", suffix: listing, want: true},
+		{name: "encrypted listing", base: "data.tar.zst.listing.json.age", suffix: listing, want: true},
+		{name: "volume listing", base: "volume_0.tar.listing.json", suffix: listing, want: true},
+		{name: "compressed volume listing", base: "volume_0.tar.gz.listing.json", suffix: listing, want: true},
+		{name: "index sidecar", base: "data.tar.zst.index.json", suffix: index, want: true},
+		{name: "unrelated file ending in suffix is rejected", base: "unrelated.listing.json", suffix: listing, want: false},
+		{name: "unrelated encrypted file ending in suffix is rejected", base: "unrelated.listing.json.age", suffix: listing, want: false},
+		{name: "bare suffix is rejected", base: ".listing.json", suffix: listing, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSidecarBase(tc.base, tc.suffix); got != tc.want {
+				t.Errorf("isSidecarBase(%q, %q) = %v, want %v", tc.base, tc.suffix, got, tc.want)
 			}
 		})
 	}

--- a/internal/runner/runner_listing_test.go
+++ b/internal/runner/runner_listing_test.go
@@ -69,6 +69,23 @@ func TestLoadParentVolumeListingPaths(t *testing.T) {
 			},
 			want: nil,
 		},
+		{
+			// All-or-nothing (issue #320 review follow-up): one backed-up
+			// volume's listing resolving while another's is missing must
+			// return nil — a partial map would keep changed_since set and
+			// leave the unresolved volume on mtime-only filtering, silently
+			// dropping a NEW stale-mtime file. The caller degrades to a full
+			// archive instead.
+			name: "partial listing resolution returns nil",
+			files: map[string]string{
+				itemPrefix + "/volumes.json": `[
+					{"index":0,"source":"` + sourcePath + `","destination":"/data","backed_up":true,"archive":"volume_0.tar"},
+					{"index":1,"source":"/mnt/cache/appdata/bar","destination":"/config","backed_up":true,"archive":"volume_1.tar"}
+				]`,
+				itemPrefix + "/volume_0.tar.listing.json": `{"version":1,"archive":"volume_0.tar","files":[{"path":"old.txt"}]}`,
+			},
+			want: nil,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/runner/runner_listing_test.go
+++ b/internal/runner/runner_listing_test.go
@@ -175,3 +175,80 @@ func TestLoadParentVolumeListingPaths_Encrypted(t *testing.T) {
 		})
 	}
 }
+
+// TestApplyClassicDiffListing is the regression test for the classic-path
+// degradation of issue #320. When the parent's effective listing is
+// unavailable for a classic differential/incremental folder or container item,
+// changed_since must be CLEARED so the engine degrades to a full archive
+// instead of silently mtime-only filtering (which drops NEW stale-mtime files).
+func TestApplyClassicDiffListing(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name               string
+		itemType           string
+		listingPaths       []string
+		volumeListingPaths map[string][]string
+		wantChangedSince   bool
+		wantPrevKey        string
+		wantPrevValue      any
+	}{
+		{
+			name:             "folder with listing keeps changed_since and attaches prev_listing_paths",
+			itemType:         "folder",
+			listingPaths:     []string{"old.txt", "sub/new.txt"},
+			wantChangedSince: true,
+			wantPrevKey:      "prev_listing_paths",
+			wantPrevValue:    []string{"old.txt", "sub/new.txt"},
+		},
+		{
+			name:             "folder with nil listing clears changed_since (full archive)",
+			itemType:         "folder",
+			listingPaths:     nil,
+			wantChangedSince: false,
+		},
+		{
+			name:               "container with listing keeps changed_since and attaches prev_volume_listing_paths",
+			itemType:           "container",
+			volumeListingPaths: map[string][]string{"/mnt/appdata": {"old.txt"}},
+			wantChangedSince:   true,
+			wantPrevKey:        "prev_volume_listing_paths",
+			wantPrevValue:      map[string][]string{"/mnt/appdata": {"old.txt"}},
+		},
+		{
+			name:               "container with nil listing clears changed_since (full archive)",
+			itemType:           "container",
+			volumeListingPaths: nil,
+			wantChangedSince:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			settings := map[string]any{"changed_since": "2026-08-24T00:00:00Z"}
+			applyClassicDiffListing(settings, tc.itemType, tc.listingPaths, tc.volumeListingPaths)
+
+			_, hasChangedSince := settings["changed_since"]
+			if hasChangedSince != tc.wantChangedSince {
+				t.Fatalf("changed_since present = %v, want %v (settings = %#v)", hasChangedSince, tc.wantChangedSince, settings)
+			}
+
+			if tc.wantPrevKey != "" {
+				got, ok := settings[tc.wantPrevKey]
+				if !ok {
+					t.Fatalf("settings missing %q: %#v", tc.wantPrevKey, settings)
+				}
+				if !reflect.DeepEqual(got, tc.wantPrevValue) {
+					t.Fatalf("%s = %#v, want %#v", tc.wantPrevKey, got, tc.wantPrevValue)
+				}
+			} else {
+				if _, ok := settings["prev_listing_paths"]; ok {
+					t.Fatalf("unexpected prev_listing_paths set: %#v", settings)
+				}
+				if _, ok := settings["prev_volume_listing_paths"]; ok {
+					t.Fatalf("unexpected prev_volume_listing_paths set: %#v", settings)
+				}
+			}
+		})
+	}
+}

--- a/internal/runner/runner_listing_test.go
+++ b/internal/runner/runner_listing_test.go
@@ -1,0 +1,177 @@
+package runner
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ruaan-deysel/vault/internal/crypto"
+	"github.com/ruaan-deysel/vault/internal/db"
+	"github.com/ruaan-deysel/vault/internal/storage"
+	"github.com/ruaan-deysel/vault/internal/ws"
+)
+
+// TestLoadParentVolumeListingPaths verifies the runner reads the parent
+// restore point's volumes.json manifest and per-volume effective-listing
+// sidecars into a mount-source -> path-list map for classic container
+// differentials (issue #320).
+func TestLoadParentVolumeListingPaths(t *testing.T) {
+	t.Parallel()
+
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	const (
+		sourcePath = "/mnt/cache/appdata/foo"
+		itemPrefix = "chain-test/1_full/my-item"
+	)
+
+	cases := []struct {
+		name  string
+		files map[string]string
+		want  map[string][]string
+	}{
+		{
+			name: "manifest and listing resolve to per-volume paths",
+			files: map[string]string{
+				itemPrefix + "/volumes.json":              `[{"index":0,"source":"` + sourcePath + `","destination":"/data","backed_up":true,"archive":"volume_0.tar"}]`,
+				itemPrefix + "/volume_0.tar.listing.json": `{"version":1,"archive":"volume_0.tar","files":[{"path":"old.txt"},{"path":"sub/nested.txt"}]}`,
+			},
+			want: map[string][]string{
+				sourcePath: {"old.txt", "sub/nested.txt"},
+			},
+		},
+		{
+			name:  "missing manifest returns nil",
+			files: map[string]string{},
+			want:  nil,
+		},
+		{
+			name: "manifest without a listing returns nil",
+			files: map[string]string{
+				itemPrefix + "/volumes.json": `[{"index":0,"source":"` + sourcePath + `","destination":"/data","backed_up":true,"archive":"volume_0.tar"}]`,
+			},
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			storageRoot := t.TempDir()
+			storageConfig := fmt.Sprintf(`{"path":%q}`, storageRoot)
+			adapter, err := storage.NewAdapter("local", storageConfig)
+			if err != nil {
+				t.Fatalf("NewAdapter: %v", err)
+			}
+			t.Cleanup(func() { storage.CloseAdapter(adapter) })
+
+			writeStorageFiles(t, adapter, tc.files)
+
+			dest := db.StorageDestination{Type: "local", Config: storageConfig}
+			parentRP := db.RestorePoint{StoragePath: "chain-test/1_full"}
+
+			r := New(database, ws.NewHub(), nil)
+			got := r.loadParentVolumeListingPaths(&parentRP, dest, "my-item", "")
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("loadParentVolumeListingPaths() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+// writeEncryptedStorageFile writes content to adapter at path as an
+// age-encrypted blob — the on-disk form the encrypted upload path produces
+// (the storage name carries a .age suffix, which the caller encodes in path).
+func writeEncryptedStorageFile(t *testing.T, adapter storage.Adapter, path, content, passphrase string) {
+	t.Helper()
+	enc, err := crypto.EncryptReader(passphrase, strings.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encBytes, err := io.ReadAll(enc)
+	_ = enc.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Write(path, bytes.NewReader(encBytes)); err != nil {
+		t.Fatalf("adapter.Write(%s): %v", path, err)
+	}
+}
+
+// TestLoadParentVolumeListingPaths_Encrypted verifies that a classic container
+// differential's per-volume effective-listing sidecars are encrypted at rest
+// (stored as .age) and correctly decrypted back on read. The listing carries
+// the full file set used to detect stale-mtime new files (issue #320), so it
+// must not leak plaintext paths when the job has encryption enabled.
+func TestLoadParentVolumeListingPaths_Encrypted(t *testing.T) {
+	t.Parallel()
+
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	const (
+		sourcePath = "/mnt/cache/appdata/foo"
+		itemPrefix = "chain-test/1_full/my-item"
+		passphrase = "hunter2"
+	)
+
+	cases := []struct {
+		name       string
+		passphrase string
+		want       map[string][]string
+	}{
+		{
+			name:       "correct passphrase decrypts the encrypted listing",
+			passphrase: passphrase,
+			want:       map[string][]string{sourcePath: {"old.txt", "sub/nested.txt"}},
+		},
+		{
+			name:       "wrong passphrase returns nil",
+			passphrase: "wrong-passphrase",
+			want:       nil,
+		},
+		{
+			name:       "no passphrase returns nil",
+			passphrase: "",
+			want:       nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			storageRoot := t.TempDir()
+			storageConfig := fmt.Sprintf(`{"path":%q}`, storageRoot)
+			adapter, err := storage.NewAdapter("local", storageConfig)
+			if err != nil {
+				t.Fatalf("NewAdapter: %v", err)
+			}
+			t.Cleanup(func() { storage.CloseAdapter(adapter) })
+
+			// Write both the volumes.json manifest and the volume listing
+			// sidecar encrypted with `passphrase`, under their .age names —
+			// the exact on-disk form the encrypted upload path produces.
+			writeEncryptedStorageFile(t, adapter, itemPrefix+"/volumes.json.age",
+				`[{"index":0,"source":"`+sourcePath+`","destination":"/data","backed_up":true,"archive":"volume_0.tar"}]`, passphrase)
+			writeEncryptedStorageFile(t, adapter, itemPrefix+"/volume_0.tar.listing.json.age",
+				`{"version":1,"archive":"volume_0.tar","files":[{"path":"old.txt"},{"path":"sub/nested.txt"}]}`, passphrase)
+
+			dest := db.StorageDestination{Type: "local", Config: storageConfig}
+			parentRP := db.RestorePoint{StoragePath: "chain-test/1_full"}
+
+			r := New(database, ws.NewHub(), nil)
+			got := r.loadParentVolumeListingPaths(&parentRP, dest, "my-item", tc.passphrase)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("loadParentVolumeListingPaths() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #320 — differential/incremental backups were silently dropping **new files whose mtime predates the parent restore point** (e.g. `cp -a` preserving timestamps), in **both** the classic (tar) and dedup (chunked) paths.

## What changed

### Classic (tar) path — new-file detection via the parent's effective listing

- Each classic backup writes a per-item (folder) / per-volume (container) effective-listing sidecar (`.listing.json`) — the full post-exclusion file set at backup time.
- On a differential/incremental, the runner loads the parent restore point's listing and passes it to the engine as `prev_listing_paths` / `prev_volume_listing_paths`.
- The engine archives a regular file whose mtime predates `changed_since` but is **absent** from the parent listing (a NEW stale-mtime file), instead of skipping it as "unchanged".
- **Degrade-to-full:** when the parent listing is unavailable (pre-listing parent, dedup→classic chain, or a decrypt/read failure), `changed_since` is cleared so the item archives **fully** — never silent mtime-only filtering. Mirrors the dedup path's full-chunk fallback.

### Dedup (chunked) path

- Unchanged entries are carried forward from the parent manifest; new stale-mtime files (absent from the parent's `Files` map) are chunked.
- The chunked stop pre-check is now **prev-aware**: it derives the per-volume previous listing from the parent manifest's volume sub-manifests, so a running container whose only change is a stale-mtime new file is stopped for a consistent backup (parity with the classic stop check).

### Classic container chain restore

- Each chain step's staging is merged oldest-first so unchanged base files survive a differential/incremental overlay (previously a differential restore dropped them).

### Housekeeping

- Tightened the sidecar-name match so `.listing.json` / `.index.json` must derive from a `*.tar` archive (unrelated suffix-matching files are no longer picked up).
- Renamed a misleading test case.

## Out of scope (follow-ups)

- **#345 (open):** classic container chain restore is a pure union merge — files deleted after the base full can reappear on restore. The folder path compensates via `pruneChainResurrected` (#231); the container path has no equivalent prune yet. (The merge itself only fixes the inverse bug — differential restores dropping unchanged base files.)
- New empty directories with stale mtimes are not detected (directories are excluded from the prevPaths check).
- Merged chain archives are re-tarred uncompressed.

## Test plan

- [x] `go test ./internal/engine/ -count=1`
- [x] `go test ./internal/runner/ -count=1`
- [x] `go vet ./internal/engine/ ./internal/runner/`
- New table-driven tests: `TestApplyClassicDiffListing`, `TestBackupChunkedStopDecisionPrevAware`, `TestChunkedPrevBySource`, `TestIsSidecarBase`, plus a compressed-archive-name case in `TestLoadParentVolumeListingPaths`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Differential and incremental backups now include newly added files even when their modification times are older than the backup cutoff.
  * Unchanged files and volumes are retained correctly across deduplicated backups.
  * Restored container chains now preserve files from earlier backup points.
  * Backups safely fall back to complete archives when previous file listings are unavailable.

* **Improvements**
  * Improved handling of compressed and encrypted backup archives during restore and incremental processing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->