### PR TITLE
feat(logging): add runtime configurable log level (#346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **Configurable log level (#346):** Added a global log level setting (`debug`, `info`, `warn`, `error`) configurable via the web Settings page and the settings API (`log_level`). Daemon logging routes through a centralized `slog` handler with dynamic level adjustments applied at runtime without restarting the daemon. Closes #346.
+
 - **Codecov configuration and dual-stack test coverage:** Added repository-root `codecov.yml` defining dual-stack coverage flags (`backend` and `frontend`), subsystem component dashboards, and an 80% coverage target on PR patches. Added `@vitest/coverage-v8` frontend coverage reporting with LCOV output, unified CI web test runs, and updated Go coverage targets with cross-package atomic instrumentation.
 
 - **Replication targets now show what the last sync actually did.** A target that connected but had nothing new to copy previously just read "Synced", which looked the same as a sync that transferred data — so replication could appear to "connect but not do much". Each target now shows an explicit **Up to date** state when a sync found nothing new, a per-sync summary (jobs synced, new restore points, bytes transferred, and any failures), and the time replication last fully succeeded. These counters are stored with each run, so they are visible on page load and after a refresh, not only in the moment a sync finishes. Closes #287.

--- a/ansible/roles/verify/tasks/ui.yml
+++ b/ansible/roles/verify/tasks/ui.yml
@@ -9,6 +9,8 @@
     trap 'playwright-cli -s="$SESSION_NAME" close 2>/dev/null || true' EXIT
     playwright-cli -s="$SESSION_NAME" open http://127.0.0.1:{{ verify_local_port }}/
     playwright-cli -s="$SESSION_NAME" snapshot
+    playwright-cli -s="$SESSION_NAME" goto http://127.0.0.1:{{ verify_local_port }}/#/settings
+    playwright-cli -s="$SESSION_NAME" snapshot
   register: playwright_result
   changed_when: false
   failed_when: false

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/ruaan-deysel/vault/internal/config"
@@ -34,6 +35,7 @@ type SettingsHandler struct {
 	diagnosticsCollector *diagnostics.Collector
 	onConfigChange       ConfigChangeHook
 	onScheduleReload     ScheduleReloader
+	onLogLevelChange     func(string)
 }
 
 // NewSettingsHandler creates a new SettingsHandler.
@@ -62,6 +64,11 @@ func (h *SettingsHandler) SetConfigChangeHook(fn ConfigChangeHook) {
 // when a setting that affects scheduling (e.g. replication_enabled) changes.
 func (h *SettingsHandler) SetScheduleReloadHook(fn ScheduleReloader) {
 	h.onScheduleReload = fn
+}
+
+// SetLogLevelChangeHook registers a function called when the log_level setting changes.
+func (h *SettingsHandler) SetLogLevelChangeHook(fn func(string)) {
+	h.onLogLevelChange = fn
 }
 
 // notifyConfigChange calls the config change hook if set.
@@ -301,6 +308,19 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if lvl, ok := incoming["log_level"]; ok {
+		normalized := strings.ToLower(strings.TrimSpace(lvl))
+		switch normalized {
+		case "warning":
+			incoming["log_level"] = "warn"
+		case "debug", "info", "warn", "error":
+			incoming["log_level"] = normalized
+		default:
+			respondError(w, http.StatusBadRequest, fmt.Sprintf("invalid log_level %q: allowed values are debug, info, warn, error", lvl))
+			return
+		}
+	}
+
 	for k, v := range incoming {
 		if err := h.db.SetSetting(k, v); err != nil {
 			respondInternalError(w, err)
@@ -312,6 +332,10 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		if err := h.onScheduleReload(); err != nil {
 			log.Printf("settings: scheduler reload after replication_enabled change failed: %v", err)
 		}
+	}
+
+	if v, ok := incoming["log_level"]; ok && h.onLogLevelChange != nil {
+		h.onLogLevelChange(v)
 	}
 
 	// Return the full settings object.

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ruaan-deysel/vault/internal/config"
@@ -36,6 +37,7 @@ type SettingsHandler struct {
 	onConfigChange       ConfigChangeHook
 	onScheduleReload     ScheduleReloader
 	onLogLevelChange     func(string)
+	logLevelMu           sync.Mutex
 }
 
 // NewSettingsHandler creates a new SettingsHandler.
@@ -321,8 +323,10 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	h.logLevelMu.Lock()
 	for k, v := range incoming {
 		if err := h.db.SetSetting(k, v); err != nil {
+			h.logLevelMu.Unlock()
 			respondInternalError(w, err)
 			return
 		}
@@ -337,6 +341,7 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if v, ok := incoming["log_level"]; ok && h.onLogLevelChange != nil {
 		h.onLogLevelChange(v)
 	}
+	h.logLevelMu.Unlock()
 
 	// Return the full settings object.
 	h.notifyConfigChange()

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1184,3 +1185,52 @@ func TestUpdate_LogLevel_Invalid(t *testing.T) {
 	}
 }
 
+func TestUpdate_LogLevel_ConcurrentInterleaving(t *testing.T) {
+	h := newTestSettingsHandler(t)
+
+	var (
+		hookMu        sync.Mutex
+		lastHookLevel string
+	)
+	h.SetLogLevelChangeHook(func(lvl string) {
+		hookMu.Lock()
+		lastHookLevel = lvl
+		hookMu.Unlock()
+	})
+
+	const iterations = 20
+	var wg sync.WaitGroup
+	barrier := make(chan struct{})
+
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-barrier
+			level := "debug"
+			if idx%2 == 0 {
+				level = "warn"
+			}
+			body := `{"log_level":"` + level + `"}`
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", strings.NewReader(body))
+			w := httptest.NewRecorder()
+			h.Update(w, req)
+		}(i)
+	}
+
+	close(barrier)
+	wg.Wait()
+
+	stored, err := h.db.GetSetting("log_level", "info")
+	if err != nil {
+		t.Fatalf("GetSetting: %v", err)
+	}
+
+	hookMu.Lock()
+	finalHook := lastHookLevel
+	hookMu.Unlock()
+
+	if stored != finalHook {
+		t.Errorf("stored setting %q does not match final applied hook level %q", stored, finalHook)
+	}
+}

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -1115,3 +1115,72 @@ func TestGetDatabaseInfo_WithSnapshotManager(t *testing.T) {
 		t.Error("expected snapshot_path in response")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// log_level setting tests
+// ---------------------------------------------------------------------------
+
+func TestUpdate_LogLevel_Valid(t *testing.T) {
+	t.Parallel()
+	h := newTestSettingsHandler(t)
+
+	var hookCalledValue string
+	h.SetLogLevelChangeHook(func(v string) {
+		hookCalledValue = v
+	})
+
+	levels := []string{"debug", "info", "warn", "error", "warning"}
+	for _, lvl := range levels {
+		body := `{"log_level": "` + lvl + `"}`
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", strings.NewReader(body))
+		w := httptest.NewRecorder()
+		h.Update(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Update with log_level=%q: status = %d, want 200; body: %s", lvl, w.Code, w.Body.String())
+		}
+
+		expectedHook := strings.ToLower(lvl)
+		if expectedHook == "warning" {
+			expectedHook = "warn"
+		}
+		if hookCalledValue != expectedHook {
+			t.Errorf("hook received %q, want %q", hookCalledValue, expectedHook)
+		}
+
+		// Verify returned settings contains updated log_level
+		var resp map[string]string
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp["log_level"] != expectedHook {
+			t.Errorf("response log_level = %q, want %q", resp["log_level"], expectedHook)
+		}
+	}
+}
+
+func TestUpdate_LogLevel_Invalid(t *testing.T) {
+	t.Parallel()
+	h := newTestSettingsHandler(t)
+
+	var hookCalled bool
+	h.SetLogLevelChangeHook(func(_ string) {
+		hookCalled = true
+	})
+
+	invalidLevels := []string{"invalid", "trace", "verbose", "123", "none"}
+	for _, lvl := range invalidLevels {
+		body := `{"log_level": "` + lvl + `"}`
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", strings.NewReader(body))
+		w := httptest.NewRecorder()
+		h.Update(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("Update with invalid log_level=%q: status = %d, want 400; body: %s", lvl, w.Code, w.Body.String())
+		}
+		if hookCalled {
+			t.Errorf("hook should not have been called for invalid log_level %q", lvl)
+		}
+	}
+}
+

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ruaan-deysel/vault/internal/api/handlers"
 	jobintake "github.com/ruaan-deysel/vault/internal/jobs"
+	"github.com/ruaan-deysel/vault/internal/logx"
 	mcpserver "github.com/ruaan-deysel/vault/internal/mcp"
 	"github.com/ruaan-deysel/vault/internal/release"
 	"github.com/ruaan-deysel/vault/web"
@@ -71,6 +72,9 @@ func (s *Server) setupRoutes() *chi.Mux {
 				return s.schedReload()
 			}
 			return nil
+		})
+		settingsH.SetLogLevelChangeHook(func(level string) {
+			logx.SetLevelString(level)
 		})
 
 		// Public endpoints.
@@ -189,6 +193,9 @@ func (s *Server) setupRoutes() *chi.Mux {
 		r.Get("/runs/{runId}/logs", runlogH.List)
 
 		r.Route("/settings", func(r chi.Router) {
+			if s.config.ReadOnly {
+				r.Use(ReadOnlyGuard)
+			}
 			r.Get("/", settingsH.List)
 			r.Put("/", settingsH.Update)
 			r.Get("/encryption", settingsH.GetEncryptionStatus)

--- a/internal/api/routes_test.go
+++ b/internal/api/routes_test.go
@@ -251,3 +251,18 @@ func TestSPACacheHeaders(t *testing.T) {
 		}
 	})
 }
+
+func TestReadOnlySettingsUpdateRejected(t *testing.T) {
+	database := testDB(t)
+	srv := NewServer(database, ServerConfig{Addr: ":0", ReadOnly: true})
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", strings.NewReader(`{"log_level":"debug"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("PUT /api/v1/settings in ReadOnly mode: status = %d, want %d (Forbidden); body: %s", w.Code, http.StatusForbidden, w.Body.String())
+	}
+}
+

--- a/internal/api/routes_test.go
+++ b/internal/api/routes_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"testing/fstest"
+
+	"github.com/ruaan-deysel/vault/internal/logx"
 )
 
 func TestDetectUnraidTimeFormat(t *testing.T) {
@@ -266,3 +268,21 @@ func TestReadOnlySettingsUpdateRejected(t *testing.T) {
 	}
 }
 
+func TestRoutes_SettingsUpdate_LogLevelHook(t *testing.T) {
+	database := testDB(t)
+	srv := NewServer(database, ServerConfig{Addr: ":0", ReadOnly: false})
+
+	logx.SetLevelString("info")
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", strings.NewReader(`{"log_level":"debug"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT /api/v1/settings: status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	if logx.LevelString() != "debug" {
+		t.Errorf("expected logx level to update to debug, got %q", logx.LevelString())
+	}
+	logx.SetLevelString("info")
+}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -297,9 +297,7 @@ var daemonCmd = &cobra.Command{
 		}
 
 		// Apply configured log level from database settings.
-		if lvl, err := database.GetSetting("log_level", docsmeta.DefaultFor("log_level")); err == nil {
-			logx.SetLevelString(lvl)
-		}
+		applyLogLevel(database)
 
 		// Validate that the database contains operator configuration
 		// (≥1 job or ≥1 storage destination). If not, log a prominent
@@ -940,4 +938,15 @@ func (a *zfsBrowseAdapter) ListZFSMountpoints() ([]handlers.ZFSMountInfo, error)
 		result[i] = handlers.ZFSMountInfo{Name: p.Name, Mountpoint: p.Mountpoint}
 	}
 	return result, nil
+}
+
+// applyLogLevel loads the configured log level from database settings and
+// applies it to logx. Extracted for unit testing without spinning up the full daemon.
+func applyLogLevel(database *db.DB) {
+	if database == nil {
+		return
+	}
+	if lvl, err := database.GetSetting("log_level", docsmeta.DefaultFor("log_level")); err == nil {
+		logx.SetLevelString(lvl)
+	}
 }

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ruaan-deysel/vault/internal/docsmeta"
 	"github.com/ruaan-deysel/vault/internal/engine"
 	"github.com/ruaan-deysel/vault/internal/logbuf"
+	"github.com/ruaan-deysel/vault/internal/logx"
 	"github.com/ruaan-deysel/vault/internal/replication"
 	"github.com/ruaan-deysel/vault/internal/runner"
 	"github.com/ruaan-deysel/vault/internal/scheduler"
@@ -58,7 +59,7 @@ var daemonCmd = &cobra.Command{
 		// reports. The ring buffer write path is always-nil-safe and
 		// the original stderr destination is preserved.
 		logRing := logbuf.New(daemonLogBufferBytes)
-		log.SetOutput(io.MultiWriter(os.Stderr, logRing))
+		logx.Setup(io.MultiWriter(os.Stderr, logRing))
 
 		// Hybrid mode detection: if a pool drive is mounted, use a RAM-backed
 		// working database with periodic snapshots to the pool drive. This
@@ -293,6 +294,11 @@ var daemonCmd = &cobra.Command{
 					retireUSBLiveDB(dbPath)
 				}
 			}
+		}
+
+		// Apply configured log level from database settings.
+		if lvl, err := database.GetSetting("log_level", docsmeta.DefaultFor("log_level")); err == nil {
+			logx.SetLevelString(lvl)
 		}
 
 		// Validate that the database contains operator configuration

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -42,6 +42,8 @@ import (
 // tests can override via the unexported var if needed.
 const daemonLogBufferBytes = 1 << 20
 
+var hybridWorkingDir = "/var/local/vault"
+
 var daemonCmd = &cobra.Command{
 	Use:   "daemon",
 	Short: "Start the Vault daemon (API server + scheduler)",
@@ -142,7 +144,7 @@ var daemonCmd = &cobra.Command{
 		}
 
 		if hybridMode {
-			workingDir := "/var/local/vault"
+			workingDir := hybridWorkingDir
 			if err := os.MkdirAll(workingDir, 0o750); err != nil {
 				return fmt.Errorf("creating hybrid working directory: %w", err)
 			}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ruaan-deysel/vault/internal/anomaly"
 	"github.com/ruaan-deysel/vault/internal/api"
 	"github.com/ruaan-deysel/vault/internal/db"
+	"github.com/ruaan-deysel/vault/internal/logx"
 )
 
 // openTestDB opens a fresh SQLite database in a temp directory.
@@ -262,4 +263,27 @@ func TestRunAnomalyTrendTicker_ContextCancel(t *testing.T) {
 	drainCtx, drainCancel := context.WithCancel(context.Background())
 	drainCancel()
 	_ = ev.Drain(drainCtx)
+}
+
+func TestApplyLogLevel(t *testing.T) {
+	d := openTestDB(t)
+
+	// Default setting or missing
+	applyLogLevel(d)
+	if logx.LevelString() != "info" {
+		t.Errorf("applyLogLevel default = %q, want info", logx.LevelString())
+	}
+
+	// Nil database safe
+	applyLogLevel(nil)
+
+	// Set to warn
+	if err := d.SetSetting("log_level", "warn"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	applyLogLevel(d)
+	if logx.LevelString() != "warn" {
+		t.Errorf("applyLogLevel = %q, want warn", logx.LevelString())
+	}
+	logx.SetLevelString("info")
 }

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/ruaan-deysel/vault/internal/api"
 	"github.com/ruaan-deysel/vault/internal/db"
 	"github.com/ruaan-deysel/vault/internal/logx"
+	"github.com/ruaan-deysel/vault/internal/unraid"
+	"github.com/spf13/cobra"
 )
 
 // openTestDB opens a fresh SQLite database in a temp directory.
@@ -287,3 +289,61 @@ func TestApplyLogLevel(t *testing.T) {
 	}
 	logx.SetLevelString("info")
 }
+
+func TestDaemonCmd_RunE_LogLevelApplied(t *testing.T) {
+	dir := t.TempDir()
+
+	prevWorkingDir := hybridWorkingDir
+	hybridWorkingDir = filepath.Join(dir, "hybrid")
+	defer func() { hybridWorkingDir = prevWorkingDir }()
+
+	// Mock mounted pool to bypass array startup wait loop.
+	mntDir := filepath.Join(dir, "mnt")
+	cacheDir := filepath.Join(mntDir, "cache")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	mountInfo := filepath.Join(dir, "mountinfo")
+	mountContent := "1 0 0:0 / " + cacheDir + " rw - btrfs /dev/sda1 rw\n"
+	if err := os.WriteFile(mountInfo, []byte(mountContent), 0o600); err != nil {
+		t.Fatalf("write mountinfo: %v", err)
+	}
+	cleanup := unraid.SetMntBaseForTest(mntDir, mountInfo)
+	defer cleanup()
+
+	dbPath := filepath.Join(dir, "vault.db")
+	snapshotDBPath := filepath.Join(cacheDir, ".vault", "vault.db")
+	if err := os.MkdirAll(filepath.Dir(snapshotDBPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	seedDBPath := filepath.Join(dir, "seed.db")
+	seedDB, err := db.Open(seedDBPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	if err := seedDB.SetSetting("log_level", "warn"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	sm := db.NewSnapshotManager(seedDB, snapshotDBPath, snapshotDBPath)
+	if err := sm.SaveSnapshot(); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+	_ = seedDB.Close()
+
+	cmd := &cobra.Command{Use: "daemon"}
+	cmd.SetContext(context.Background())
+	cmd.Flags().String("db", dbPath, "Database path")
+	cmd.Flags().String("addr", "127.0.0.1:0", "Listen address")
+	cmd.Flags().String("tls-cert", filepath.Join(dir, "nonexistent.crt"), "TLS cert")
+	cmd.Flags().String("tls-key", filepath.Join(dir, "nonexistent.key"), "TLS key")
+
+	logx.SetLevelString("info")
+	_ = daemonCmd.RunE(cmd, nil)
+
+	if logx.LevelString() != "warn" {
+		t.Errorf("expected logx level to be warn, got %q", logx.LevelString())
+	}
+	logx.SetLevelString("info")
+}
+
+

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -345,5 +345,3 @@ func TestDaemonCmd_RunE_LogLevelApplied(t *testing.T) {
 	}
 	logx.SetLevelString("info")
 }
-
-

--- a/internal/cli/replica.go
+++ b/internal/cli/replica.go
@@ -15,6 +15,8 @@ import (
 	"github.com/ruaan-deysel/vault/internal/crypto"
 	"github.com/ruaan-deysel/vault/internal/db"
 	"github.com/ruaan-deysel/vault/internal/discovery"
+	"github.com/ruaan-deysel/vault/internal/docsmeta"
+	"github.com/ruaan-deysel/vault/internal/logx"
 	"github.com/ruaan-deysel/vault/internal/replication"
 	"github.com/ruaan-deysel/vault/internal/scheduler"
 	"github.com/spf13/cobra"
@@ -30,6 +32,8 @@ and stores replicated data. All backup write endpoints are disabled.
 Designed to run as a Docker container on any Linux host for off-site
 disaster recovery.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		logx.Setup(os.Stderr)
+
 		dbPath, _ := cmd.Flags().GetString("db")
 		addr, _ := cmd.Flags().GetString("addr")
 		tlsCert, _ := cmd.Flags().GetString("tls-cert")
@@ -45,6 +49,11 @@ disaster recovery.`,
 			return err
 		}
 		defer database.Close()
+
+		// Apply configured log level from database settings.
+		if lvl, err := database.GetSetting("log_level", docsmeta.DefaultFor("log_level")); err == nil {
+			logx.SetLevelString(lvl)
+		}
 
 		// Prune old activity logs.
 		if err := database.DeleteOldActivityLogs(90); err != nil {

--- a/internal/cli/replica.go
+++ b/internal/cli/replica.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ruaan-deysel/vault/internal/crypto"
 	"github.com/ruaan-deysel/vault/internal/db"
 	"github.com/ruaan-deysel/vault/internal/discovery"
-	"github.com/ruaan-deysel/vault/internal/docsmeta"
 	"github.com/ruaan-deysel/vault/internal/logx"
 	"github.com/ruaan-deysel/vault/internal/replication"
 	"github.com/ruaan-deysel/vault/internal/scheduler"
@@ -51,9 +50,7 @@ disaster recovery.`,
 		defer database.Close()
 
 		// Apply configured log level from database settings.
-		if lvl, err := database.GetSetting("log_level", docsmeta.DefaultFor("log_level")); err == nil {
-			logx.SetLevelString(lvl)
-		}
+		applyLogLevel(database)
 
 		// Prune old activity logs.
 		if err := database.DeleteOldActivityLogs(90); err != nil {

--- a/internal/cli/replica_test.go
+++ b/internal/cli/replica_test.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/ruaan-deysel/vault/internal/db"
+	"github.com/ruaan-deysel/vault/internal/logx"
 	"github.com/spf13/cobra"
 )
 
@@ -91,6 +94,27 @@ func TestReplicaCmd_HelpRuns(t *testing.T) {
 	if !strings.Contains(replicaCmd.Short, "replica") {
 		t.Errorf("replica Short doesn't mention replica: %q", replicaCmd.Short)
 	}
+}
+
+func TestReplicaCmd_LogLevelApplied(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "vault.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer database.Close()
+	if err := database.SetSetting("log_level", "error"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+
+	logx.SetLevelString("info")
+	applyLogLevel(database)
+
+	if logx.LevelString() != "error" {
+		t.Errorf("expected logx level to be error, got %q", logx.LevelString())
+	}
+	logx.SetLevelString("info")
 }
 
 // Ensure context import is used.

--- a/internal/cli/replica_test.go
+++ b/internal/cli/replica_test.go
@@ -117,5 +117,34 @@ func TestReplicaCmd_LogLevelApplied(t *testing.T) {
 	logx.SetLevelString("info")
 }
 
+func TestReplicaCmd_RunE_LogLevelApplied(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "vault.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	if err := database.SetSetting("log_level", "error"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	_ = database.Close()
+
+	cmd := &cobra.Command{Use: "replica"}
+	cmd.SetContext(context.Background())
+	cmd.Flags().String("db", dbPath, "Database path")
+	cmd.Flags().String("addr", "127.0.0.1:0", "Listen address")
+	cmd.Flags().String("tls-cert", filepath.Join(dir, "nonexistent.crt"), "TLS cert")
+	cmd.Flags().String("tls-key", filepath.Join(dir, "nonexistent.key"), "TLS key")
+
+	logx.SetLevelString("info")
+	_ = replicaCmd.RunE(cmd, nil)
+
+	if logx.LevelString() != "error" {
+		t.Errorf("expected logx level to be error, got %q", logx.LevelString())
+	}
+	logx.SetLevelString("info")
+}
+
 // Ensure context import is used.
 var _ context.Context = context.Background()
+

--- a/internal/cli/replica_test.go
+++ b/internal/cli/replica_test.go
@@ -147,4 +147,3 @@ func TestReplicaCmd_RunE_LogLevelApplied(t *testing.T) {
 
 // Ensure context import is used.
 var _ context.Context = context.Background()
-

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -189,6 +189,7 @@ func (d *DB) IntegrityCheck() error {
 // migrations. INSERT OR IGNORE makes this safe to call on every Open.
 func (d *DB) insertDefaultSettings() error {
 	defaults := []struct{ key, value string }{
+		{"log_level", "info"},
 		{"retry_max_default", "2"},
 		{"retry_delays_default", "[900,3600,14400]"},
 		{"breaker_fail_threshold", "3"},

--- a/internal/docsmeta/catalog.go
+++ b/internal/docsmeta/catalog.go
@@ -47,6 +47,7 @@ type SettingDoc struct {
 var AppSettings = []SettingDoc{
 	// General
 	{"history_retention_days", "int", "365", "Number of days of job-run history retained before pruning.", GroupGeneral},
+	{"log_level", "string", "info", "Minimum log level emitted by the daemon (\"debug\", \"info\", \"warn\", \"error\").", GroupGeneral},
 	{"snapshot_path_override", "string", "", "Override for the directory used to stage filesystem snapshots. Empty uses the built-in default.", GroupGeneral},
 	{"staging_dir_override", "string", "", "Override for the working directory used to stage archives before upload. Empty uses the built-in default.", GroupGeneral},
 	{"storage_verbose_logging", "bool", "false", "When enabled, storage adapters log every operation for troubleshooting.", GroupGeneral},

--- a/internal/logx/logx.go
+++ b/internal/logx/logx.go
@@ -42,9 +42,10 @@ type bridgedHandler struct {
 }
 
 func (b *bridgedHandler) Enabled(ctx context.Context, level slog.Level) bool {
-	// If active level is Warn or Error, stdlib log messages (entering at LevelInfo)
-	// must pass Enabled check so Handle can inspect message prefixes.
-	if level == slog.LevelInfo && (levelVar.Level() == slog.LevelWarn || levelVar.Level() == slog.LevelError) {
+	// If active level is above Info (e.g. Warn, Error, or custom levels in-between),
+	// stdlib log messages (entering at LevelInfo) must pass Enabled check so Handle
+	// can inspect message prefixes and promote warnings/errors appropriately.
+	if level == slog.LevelInfo && levelVar.Level() > slog.LevelInfo && levelVar.Level() <= slog.LevelError {
 		return true
 	}
 	return level >= levelVar.Level()

--- a/internal/logx/logx.go
+++ b/internal/logx/logx.go
@@ -1,0 +1,81 @@
+// Package logx provides centralized, runtime-adjustable leveled logging using
+// log/slog. It bridges Go's standard log package output into a shared slog
+// handler so that existing log.Print* calls respect the runtime log level
+// without requiring changes across all call sites.
+//
+// This package is intentionally kept free of database or settings dependencies.
+package logx
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// levelVar is the single source of truth for the active log level across the process.
+// It initializes to slog.LevelInfo (zero value).
+var levelVar = new(slog.LevelVar)
+
+// Setup initializes the global default logger with a text handler writing to w
+// at the level governed by levelVar. Standard library log output is routed
+// through this handler at Info level.
+func Setup(w io.Writer) {
+	opts := &slog.HandlerOptions{
+		Level:       levelVar,
+		ReplaceAttr: replaceAttr,
+	}
+	handler := slog.NewTextHandler(w, opts)
+	slog.SetDefault(slog.New(handler))
+}
+
+// replaceAttr formats record attributes to ensure log lines stay clean,
+// readable, and compatible with diagnostics collection.
+func replaceAttr(groups []string, a slog.Attr) slog.Attr {
+	if len(groups) == 0 && a.Key == slog.TimeKey {
+		if t := a.Value.Time(); !t.IsZero() {
+			return slog.String(slog.TimeKey, t.Format(time.RFC3339))
+		}
+	}
+	return a
+}
+
+// SetLevelString updates the active log level from a case-insensitive string name.
+// Allowed values are "debug", "info", "warn" (or "warning"), and "error".
+// Any unknown or empty value safely falls back to Info.
+func SetLevelString(s string) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "debug":
+		levelVar.Set(slog.LevelDebug)
+	case "info":
+		levelVar.Set(slog.LevelInfo)
+	case "warn", "warning":
+		levelVar.Set(slog.LevelWarn)
+	case "error":
+		levelVar.Set(slog.LevelError)
+	default:
+		levelVar.Set(slog.LevelInfo)
+	}
+}
+
+// Level returns the current active log level.
+func Level() slog.Level {
+	return levelVar.Level()
+}
+
+// LevelString returns the current active log level as a lowercase string
+// ("debug", "info", "warn", "error").
+func LevelString() string {
+	switch levelVar.Level() {
+	case slog.LevelDebug:
+		return "debug"
+	case slog.LevelInfo:
+		return "info"
+	case slog.LevelWarn:
+		return "warn"
+	case slog.LevelError:
+		return "error"
+	default:
+		return "info"
+	}
+}

--- a/internal/logx/logx.go
+++ b/internal/logx/logx.go
@@ -1,12 +1,14 @@
 // Package logx provides centralized, runtime-adjustable leveled logging using
 // log/slog. It bridges Go's standard log package output into a shared slog
 // handler so that existing log.Print* calls respect the runtime log level
-// without requiring changes across all call sites.
+// while preserving warning and error message visibility.
 //
 // This package is intentionally kept free of database or settings dependencies.
 package logx
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -19,14 +21,66 @@ var levelVar = new(slog.LevelVar)
 
 // Setup initializes the global default logger with a text handler writing to w
 // at the level governed by levelVar. Standard library log output is routed
-// through this handler at Info level.
+// through this handler, with severity inference for conventional prefixes
+// ("warning:", "warn", "error:", "err:", "debug:", etc.).
 func Setup(w io.Writer) {
 	opts := &slog.HandlerOptions{
 		Level:       levelVar,
 		ReplaceAttr: replaceAttr,
 	}
-	handler := slog.NewTextHandler(w, opts)
+	textHandler := slog.NewTextHandler(w, opts)
+	handler := &bridgedHandler{inner: textHandler}
 	slog.SetDefault(slog.New(handler))
+}
+
+// bridgedHandler wraps an slog.Handler to ensure standard library log messages
+// (which enter slog at LevelInfo by default) have their severity inferred from
+// message prefixes, allowing Warnings and Errors from legacy log.Printf sites
+// to remain visible even when the log level is set to Warn or Error.
+type bridgedHandler struct {
+	inner slog.Handler
+}
+
+func (b *bridgedHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	// If active level is Warn or Error, stdlib log messages (entering at LevelInfo)
+	// must pass Enabled check so Handle can inspect message prefixes.
+	if level == slog.LevelInfo && (levelVar.Level() == slog.LevelWarn || levelVar.Level() == slog.LevelError) {
+		return true
+	}
+	return level >= levelVar.Level()
+}
+
+func (b *bridgedHandler) Handle(ctx context.Context, r slog.Record) error {
+	effectiveLevel := r.Level
+	if r.Level == slog.LevelInfo {
+		msg := strings.TrimSpace(r.Message)
+		lower := strings.ToLower(msg)
+		if strings.HasPrefix(lower, "error") || strings.HasPrefix(lower, "err:") || strings.HasPrefix(lower, "fatal") || strings.HasPrefix(lower, "panic") {
+			effectiveLevel = slog.LevelError
+		} else if strings.HasPrefix(lower, "warning") || strings.HasPrefix(lower, "warn") {
+			effectiveLevel = slog.LevelWarn
+		} else if strings.HasPrefix(lower, "debug") || strings.HasPrefix(lower, "[debug]") {
+			effectiveLevel = slog.LevelDebug
+		}
+	}
+
+	if effectiveLevel < levelVar.Level() {
+		return nil
+	}
+
+	if effectiveLevel != r.Level {
+		r.Level = effectiveLevel
+	}
+
+	return b.inner.Handle(ctx, r)
+}
+
+func (b *bridgedHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &bridgedHandler{inner: b.inner.WithAttrs(attrs)}
+}
+
+func (b *bridgedHandler) WithGroup(name string) slog.Handler {
+	return &bridgedHandler{inner: b.inner.WithGroup(name)}
 }
 
 // replaceAttr formats record attributes to ensure log lines stay clean,
@@ -83,4 +137,44 @@ func LevelString() string {
 	default:
 		return "info"
 	}
+}
+
+// Debug logs at LevelDebug.
+func Debug(msg string, args ...any) {
+	slog.Default().Debug(msg, args...)
+}
+
+// Info logs at LevelInfo.
+func Info(msg string, args ...any) {
+	slog.Default().Info(msg, args...)
+}
+
+// Warn logs at LevelWarn.
+func Warn(msg string, args ...any) {
+	slog.Default().Warn(msg, args...)
+}
+
+// Error logs at LevelError.
+func Error(msg string, args ...any) {
+	slog.Default().Error(msg, args...)
+}
+
+// Debugf formats and logs at LevelDebug.
+func Debugf(format string, args ...any) {
+	slog.Default().Debug(fmt.Sprintf(format, args...))
+}
+
+// Infof formats and logs at LevelInfo.
+func Infof(format string, args ...any) {
+	slog.Default().Info(fmt.Sprintf(format, args...))
+}
+
+// Warnf formats and logs at LevelWarn.
+func Warnf(format string, args ...any) {
+	slog.Default().Warn(fmt.Sprintf(format, args...))
+}
+
+// Errorf formats and logs at LevelError.
+func Errorf(format string, args ...any) {
+	slog.Default().Error(fmt.Sprintf(format, args...))
 }

--- a/internal/logx/logx.go
+++ b/internal/logx/logx.go
@@ -58,6 +58,11 @@ func SetLevelString(s string) {
 	}
 }
 
+// SetLevel sets the active log level directly.
+func SetLevel(l slog.Level) {
+	levelVar.Set(l)
+}
+
 // Level returns the current active log level.
 func Level() slog.Level {
 	return levelVar.Level()

--- a/internal/logx/logx_test.go
+++ b/internal/logx/logx_test.go
@@ -1,0 +1,125 @@
+package logx_test
+
+import (
+	"bytes"
+	"log"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ruaan-deysel/vault/internal/logx"
+)
+
+func TestSetLevelString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected slog.Level
+		expStr   string
+	}{
+		{"debug", slog.LevelDebug, "debug"},
+		{"DEBUG", slog.LevelDebug, "debug"},
+		{"  debug  ", slog.LevelDebug, "debug"},
+		{"info", slog.LevelInfo, "info"},
+		{"INFO", slog.LevelInfo, "info"},
+		{"warn", slog.LevelWarn, "warn"},
+		{"warning", slog.LevelWarn, "warn"},
+		{"WARN", slog.LevelWarn, "warn"},
+		{"error", slog.LevelError, "error"},
+		{"ERROR", slog.LevelError, "error"},
+		{"unknown", slog.LevelInfo, "info"},
+		{"", slog.LevelInfo, "info"},
+		{"invalid_level", slog.LevelInfo, "info"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			logx.SetLevelString(tt.input)
+			if got := logx.Level(); got != tt.expected {
+				t.Errorf("SetLevelString(%q): Level() = %v, want %v", tt.input, got, tt.expected)
+			}
+			if got := logx.LevelString(); got != tt.expStr {
+				t.Errorf("SetLevelString(%q): LevelString() = %q, want %q", tt.input, got, tt.expStr)
+			}
+		})
+	}
+}
+
+func TestSetupAndLeveledFiltering(t *testing.T) {
+	buf := new(bytes.Buffer)
+	logx.Setup(buf)
+
+	// Set to INFO
+	logx.SetLevelString("info")
+	buf.Reset()
+
+	slog.Debug("debug message should be hidden")
+	if buf.Len() > 0 {
+		t.Errorf("expected debug to be filtered at INFO level, got: %s", buf.String())
+	}
+
+	buf.Reset()
+	slog.Info("info message should appear", "key", "val")
+	if !strings.Contains(buf.String(), "info message should appear") {
+		t.Errorf("expected info message to appear, got: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "level=INFO") {
+		t.Errorf("expected level=INFO in output, got: %s", buf.String())
+	}
+
+	// Dynamic switch to DEBUG at runtime
+	logx.SetLevelString("debug")
+	buf.Reset()
+	slog.Debug("debug message should now appear", "num", 42)
+	if !strings.Contains(buf.String(), "debug message should now appear") {
+		t.Errorf("expected debug message after level change to debug, got: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "level=DEBUG") {
+		t.Errorf("expected level=DEBUG in output, got: %s", buf.String())
+	}
+
+	// Test standard log integration (log.Print routes at INFO level)
+	logx.SetLevelString("info")
+	buf.Reset()
+	log.Printf("standard log message via print %d", 123)
+	if !strings.Contains(buf.String(), "standard log message via print 123") {
+		t.Errorf("expected standard log to route through slog, got: %s", buf.String())
+	}
+
+	// Switch to WARN: standard log (INFO) should be filtered out
+	logx.SetLevelString("warn")
+	buf.Reset()
+	log.Printf("another standard log message")
+	if buf.Len() > 0 {
+		t.Errorf("expected standard log (INFO) to be filtered at WARN level, got: %s", buf.String())
+	}
+
+	// Reset level to info for clean state
+	logx.SetLevelString("info")
+}
+
+func TestReplaceAttrTimeFormatting(t *testing.T) {
+	buf := new(bytes.Buffer)
+	logx.Setup(buf)
+	logx.SetLevelString("info")
+
+	slog.Info("testing timestamp formatting")
+	out := buf.String()
+
+	// Check time format conforms to RFC3339 prefix like time=202...
+	if !strings.Contains(out, "time=") {
+		t.Fatalf("expected time attribute in output, got: %s", out)
+	}
+
+	// Extract time value: time=...
+	idx := strings.Index(out, "time=")
+	timePart := out[idx+5:]
+	if spaceIdx := strings.Index(timePart, " "); spaceIdx != -1 {
+		timePart = timePart[:spaceIdx]
+	}
+	timePart = strings.Trim(timePart, "\"\n\r")
+
+	if _, err := time.Parse(time.RFC3339, timePart); err != nil {
+		t.Errorf("time attribute %q is not valid RFC3339: %v", timePart, err)
+	}
+}

--- a/internal/logx/logx_test.go
+++ b/internal/logx/logx_test.go
@@ -240,3 +240,34 @@ func TestSetLevelAndLevelStringUnknown(t *testing.T) {
 	}
 	logx.SetLevel(slog.LevelInfo)
 }
+
+func TestCustomLevelBetweenWarnAndError(t *testing.T) {
+	buf := new(bytes.Buffer)
+	logx.Setup(buf)
+
+	customLevel := slog.LevelWarn + 1
+	logx.SetLevel(customLevel)
+
+	// A normal standard log message (unprefixed) should be filtered out
+	buf.Reset()
+	log.Printf("normal status message")
+	if buf.Len() > 0 {
+		t.Errorf("expected normal info message to be filtered at custom level %v, got: %s", customLevel, buf.String())
+	}
+
+	// A warning message should be filtered out since customLevel > LevelWarn
+	buf.Reset()
+	log.Printf("Warning: minor warning")
+	if buf.Len() > 0 {
+		t.Errorf("expected warning to be filtered at custom level %v, got: %s", customLevel, buf.String())
+	}
+
+	// An error message should be promoted to LevelError (> customLevel) and printed
+	buf.Reset()
+	log.Printf("Error: critical failure")
+	if !strings.Contains(buf.String(), "Error: critical failure") || !strings.Contains(buf.String(), "level=ERROR") {
+		t.Errorf("expected error message to be printed at custom level %v, got: %s", customLevel, buf.String())
+	}
+
+	logx.SetLevel(slog.LevelInfo)
+}

--- a/internal/logx/logx_test.go
+++ b/internal/logx/logx_test.go
@@ -86,7 +86,7 @@ func TestSetupAndLeveledFiltering(t *testing.T) {
 		t.Errorf("expected standard log to route through slog, got: %s", buf.String())
 	}
 
-	// Switch to WARN: standard log (INFO) should be filtered out
+	// Switch to WARN: standard log (INFO) without warning/error prefix should be filtered out
 	logx.SetLevelString("warn")
 	buf.Reset()
 	log.Printf("another standard log message")
@@ -94,7 +94,102 @@ func TestSetupAndLeveledFiltering(t *testing.T) {
 		t.Errorf("expected standard log (INFO) to be filtered at WARN level, got: %s", buf.String())
 	}
 
+	// But log.Printf with "Warning: ..." prefix should be promoted to WARN and printed
+	buf.Reset()
+	log.Printf("Warning: failed to validate database configuration")
+	if !strings.Contains(buf.String(), "Warning: failed to validate database configuration") {
+		t.Errorf("expected warning message to be preserved at WARN level, got: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "level=WARN") {
+		t.Errorf("expected level=WARN in output, got: %s", buf.String())
+	}
+
+	// log.Printf with "Error: ..." prefix should be promoted to ERROR and printed at WARN level
+	buf.Reset()
+	log.Printf("Error: disk is full")
+	if !strings.Contains(buf.String(), "Error: disk is full") || !strings.Contains(buf.String(), "level=ERROR") {
+		t.Errorf("expected error message to be preserved at WARN level, got: %s", buf.String())
+	}
+
+	// Switch to ERROR: warning prefix should be filtered, error prefix should be printed
+	logx.SetLevelString("error")
+	buf.Reset()
+	log.Printf("Warning: something degraded")
+	if buf.Len() > 0 {
+		t.Errorf("expected warning to be filtered at ERROR level, got: %s", buf.String())
+	}
+
+	buf.Reset()
+	log.Printf("Error: fatal startup failure")
+	if !strings.Contains(buf.String(), "Error: fatal startup failure") || !strings.Contains(buf.String(), "level=ERROR") {
+		t.Errorf("expected error to appear at ERROR level, got: %s", buf.String())
+	}
+
 	// Reset level to info for clean state
+	logx.SetLevelString("info")
+}
+
+func TestLeveledHelpers(t *testing.T) {
+	buf := new(bytes.Buffer)
+	logx.Setup(buf)
+
+	logx.SetLevelString("debug")
+	buf.Reset()
+	logx.Debug("debug msg", "k", "v")
+	if !strings.Contains(buf.String(), "debug msg") || !strings.Contains(buf.String(), "level=DEBUG") {
+		t.Errorf("Debug failed: %s", buf.String())
+	}
+
+	buf.Reset()
+	logx.Debugf("debug formatted %d", 42)
+	if !strings.Contains(buf.String(), "debug formatted 42") || !strings.Contains(buf.String(), "level=DEBUG") {
+		t.Errorf("Debugf failed: %s", buf.String())
+	}
+
+	buf.Reset()
+	logx.Info("info msg")
+	if !strings.Contains(buf.String(), "info msg") || !strings.Contains(buf.String(), "level=INFO") {
+		t.Errorf("Info failed: %s", buf.String())
+	}
+
+	buf.Reset()
+	logx.Infof("info formatted %s", "abc")
+	if !strings.Contains(buf.String(), "info formatted abc") || !strings.Contains(buf.String(), "level=INFO") {
+		t.Errorf("Infof failed: %s", buf.String())
+	}
+
+	buf.Reset()
+	logx.Warn("warn msg")
+	if !strings.Contains(buf.String(), "warn msg") || !strings.Contains(buf.String(), "level=WARN") {
+		t.Errorf("Warn failed: %s", buf.String())
+	}
+
+	buf.Reset()
+	logx.Warnf("warn formatted %d", 100)
+	if !strings.Contains(buf.String(), "warn formatted 100") || !strings.Contains(buf.String(), "level=WARN") {
+		t.Errorf("Warnf failed: %s", buf.String())
+	}
+
+	buf.Reset()
+	logx.Error("error msg")
+	if !strings.Contains(buf.String(), "error msg") || !strings.Contains(buf.String(), "level=ERROR") {
+		t.Errorf("Error failed: %s", buf.String())
+	}
+
+	buf.Reset()
+	logx.Errorf("error formatted %v", true)
+	if !strings.Contains(buf.String(), "error formatted true") || !strings.Contains(buf.String(), "level=ERROR") {
+		t.Errorf("Errorf failed: %s", buf.String())
+	}
+
+	// Test WithAttrs & WithGroup
+	logger := slog.Default().With("component", "test").WithGroup("sub")
+	buf.Reset()
+	logger.Info("grouped message")
+	if !strings.Contains(buf.String(), "grouped message") || !strings.Contains(buf.String(), "component=test") {
+		t.Errorf("WithAttrs/WithGroup failed: %s", buf.String())
+	}
+
 	logx.SetLevelString("info")
 }
 

--- a/internal/logx/logx_test.go
+++ b/internal/logx/logx_test.go
@@ -122,4 +122,26 @@ func TestReplaceAttrTimeFormatting(t *testing.T) {
 	if _, err := time.Parse(time.RFC3339, timePart); err != nil {
 		t.Errorf("time attribute %q is not valid RFC3339: %v", timePart, err)
 	}
+
+	// Test zero time attribute and non-time / grouped attributes
+	buf.Reset()
+	slog.Info("msg with other attrs",
+		slog.Time("zero_time", time.Time{}),
+		slog.String("str", "hello"),
+		slog.Group("grp", slog.Time(slog.TimeKey, time.Now())),
+	)
+	if !strings.Contains(buf.String(), "msg with other attrs") {
+		t.Errorf("expected message to appear, got: %s", buf.String())
+	}
+}
+
+func TestSetLevelAndLevelStringUnknown(t *testing.T) {
+	logx.SetLevel(slog.Level(42))
+	if got := logx.Level(); got != slog.Level(42) {
+		t.Errorf("Level() = %v, want 42", got)
+	}
+	if got := logx.LevelString(); got != "info" {
+		t.Errorf("LevelString() for custom level = %q, want info", got)
+	}
+	logx.SetLevel(slog.LevelInfo)
 }

--- a/internal/unraid/pools.go
+++ b/internal/unraid/pools.go
@@ -239,3 +239,13 @@ func unsuitableMountPoints(infoPath string) map[string]bool {
 	}
 	return out
 }
+
+// SetMntBaseForTest overrides mntBase and mountInfoPath for tests and returns
+// a cleanup function that restores the previous values.
+func SetMntBaseForTest(base, info string) func() {
+	prevBase, prevInfo := mntBase, mountInfoPath
+	mntBase, mountInfoPath = base, info
+	return func() {
+		mntBase, mountInfoPath = prevBase, prevInfo
+	}
+}

--- a/web/src/pages/Settings.svelte
+++ b/web/src/pages/Settings.svelte
@@ -1442,10 +1442,10 @@
                 disabled={readOnly || logLevelSaving}
                 class="w-full max-w-full text-sm px-3 py-2 bg-surface-1 border border-border rounded-lg text-text focus:outline-none focus:ring-2 focus:ring-vault/50 focus:border-vault disabled:opacity-60 cursor-pointer"
               >
-                <option value="debug">debug</option>
-                <option value="info">info</option>
-                <option value="warn">warn</option>
-                <option value="error">error</option>
+                <option value="debug">Debug</option>
+                <option value="info">Informational</option>
+                <option value="warn">Warning</option>
+                <option value="error">Errors</option>
               </select>
               {#if logLevelSaving}
                 <InlineSpinner />

--- a/web/src/pages/Settings.svelte
+++ b/web/src/pages/Settings.svelte
@@ -44,7 +44,7 @@
     { id: 'set-throttle', label: 'Upload Throttling' },
     { id: 'set-dedup', label: 'Dedup' },
     { id: 'set-anomaly', label: 'Anomaly Detection' },
-    { id: 'set-logging', label: 'Storage Logging' },
+    { id: 'set-logging', label: 'Logging' },
     { id: 'set-history', label: 'History Retention' },
     { id: 'set-server', label: 'Server Info' },
     { id: 'set-database', label: 'Database' },
@@ -262,6 +262,8 @@
         const replSources = await api.listReplicationSources().catch(() => [])
         replicationEnabledSetting = Array.isArray(replSources) && replSources.length > 0
       }
+      // Logging settings (Issue #346)
+      logLevel = s?.log_level || 'info'
       // Storage verbose logging (Task 12 – storage resilience)
       storageVerboseLogging = s?.storage_verbose_logging === 'true'
       // Stored as a fraction "0.0".."1.0"; UI shows it as an integer percentage 0..100.
@@ -814,6 +816,31 @@
   // Storage verbose logging (Task 12 – storage resilience)
   let storageVerboseLogging = $state(false)
   let storageVerboseSaving = $state(false)
+
+  // Log level (Issue #346)
+  let logLevel = $state('info')
+  let logLevelSaving = $state(false)
+
+  async function saveLogLevel() {
+    if (readOnly || logLevelSaving) return
+    logLevelSaving = true
+    try {
+      settings = await api.updateSettings({
+        log_level: logLevel,
+      })
+      showToast('Log level updated', 'success')
+    } catch (e) {
+      try {
+        settings = await api.getSettings()
+        logLevel = settings?.log_level || 'info'
+      } catch {
+        // preserve current value
+      }
+      showToast(e.message, 'error')
+    } finally {
+      logLevelSaving = false
+    }
+  }
 
   async function saveAnomalySettings() {
     if (readOnly) return
@@ -1394,13 +1421,37 @@
       </div>
       {/if}
 
-      <!-- Storage Verbose Logging (Task 12 – storage resilience) -->
+      <!-- Storage & Daemon Logging -->
       <div id="set-logging" class="scroll-mt-16 bg-surface-2 border border-border rounded-xl overflow-hidden">
         <div class="px-5 py-4 border-b border-border">
-          <h2 class="text-base font-semibold text-text">Storage Logging <Tooltip text="When enabled, every file-level storage operation (upload, download, delete) is traced to the daemon log. Useful for diagnosing intermittent transfer failures; off by default to avoid log noise." /></h2>
-          <p class="text-xs text-text-muted mt-0.5">Per-operation trace logging for storage adapters.</p>
+          <h2 class="text-base font-semibold text-text">Logging <Tooltip text="Configure log output verbosity for the Vault daemon and storage adapters." /></h2>
+          <p class="text-xs text-text-muted mt-0.5">Control daemon log levels and verbose storage tracing.</p>
         </div>
         <div class="divide-y divide-border">
+          <!-- Log level (Issue #346) -->
+          <div class="px-5 py-4">
+            <label for="log-level" class="block text-sm font-medium text-text mb-1.5">
+              Log level
+              <Tooltip text="Minimum log level emitted by the daemon. Debug includes fine-grained diagnostics; Info is the standard operational level; Warn and Error restrict output to unexpected conditions and failures." />
+            </label>
+            <div class="flex items-center gap-2">
+              <select
+                id="log-level"
+                bind:value={logLevel}
+                onchange={saveLogLevel}
+                disabled={readOnly || logLevelSaving}
+                class="w-full max-w-full text-sm px-3 py-2 bg-surface-1 border border-border rounded-lg text-text focus:outline-none focus:ring-2 focus:ring-vault/50 focus:border-vault disabled:opacity-60 cursor-pointer"
+              >
+                <option value="debug">debug</option>
+                <option value="info">info</option>
+                <option value="warn">warn</option>
+                <option value="error">error</option>
+              </select>
+              {#if logLevelSaving}
+                <InlineSpinner />
+              {/if}
+            </div>
+          </div>
           <div class="px-5 py-4 flex items-center justify-between">
             <div>
               <p class="text-sm font-medium text-text">Verbose storage logging</p>


### PR DESCRIPTION
## Description

Adds runtime-adjustable log level configuration to Vault, enabling operators to adjust daemon logging verbosity (`debug`, `info`, `warn`, `error`) dynamically from the web Settings page or settings API without restarting the daemon.

- Creates `internal/logx` with centralized `slog.LevelVar` and standard `log` bridge.
- Registers `log_level` setting in settings catalog and SQLite defaults seed.
- Adds `SetLogLevelChangeHook` to `SettingsHandler` and updates `setupRoutes` to adjust log level at runtime.
- Exposes `Log level` select control under Logging in the web Settings page with optimistic update and error recovery.
- Adds unit tests for `logx`, settings handler validation/hooking, and ReadOnlyGuard protection in replica mode.

Closes #346

## Verification
- Local checks: `make test`, `make lint`, `make security-check`, `npm --prefix web test`, `npm --prefix web run lint`, `npm --prefix web run build`.
- Ansible build, deploy, and verify: `make build`, `make deploy`, `make verify` (including endpoint, WebSocket, MCP, and Playwright browser UI checks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable **Logging** setting to the web Settings page.
  - Choose `debug`, `info`, `warn`, or `error` logging levels.
  - Changes take effect immediately without restarting the daemon.
  - The selected level is applied when the daemon or replica starts.
  - New installations default to `info` logging.
- **Bug Fixes**
  - Settings changes are now prevented in read-only mode.
  - Invalid log-level values are rejected with a validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->