### PR TITLE
feat(restore): indicate base full backup for chained restore points (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **Restore points now show the base full backup for chained restores (#318):** Differential and incremental restore points in the restore timeline and wizard now display the date and size of the root full backup they depend on, and the `Chain ×N` badge includes an explanatory tooltip describing chain length and replay behavior. Closes #318.
+
 - **Configurable log level (#346):** Added a global log level setting (`debug`, `info`, `warn`, `error`) configurable via the web Settings page and the settings API (`log_level`). Daemon logging routes through a centralized `slog` handler with dynamic level adjustments applied at runtime without restarting the daemon. Closes #346.
 
 - **Codecov configuration and dual-stack test coverage:** Added repository-root `codecov.yml` defining dual-stack coverage flags (`backend` and `frontend`), subsystem component dashboards, and an 80% coverage target on PR patches. Added `@vitest/coverage-v8` frontend coverage reporting with LCOV output, unified CI web test runs, and updated Go coverage targets with cross-package atomic instrumentation.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -121,7 +121,7 @@ After at least one successful backup:
 3. Click a restore point to open the guided wizard
 4. Choose which items to restore and confirm
 
-Each restore point also shows chain health annotations so you can see if a full parent is available for an incremental or differential point.
+Each restore point also shows chain health annotations so you can see the referenced full backup that anchors the chain for an incremental or differential point, along with chain depth tooltips.
 
 ![Restore page](screenshots/06-restore.png)
 

--- a/docs/guides/backup-jobs.md
+++ b/docs/guides/backup-jobs.md
@@ -275,7 +275,7 @@ To keep that from turning a running backup into an apparent freeze, Vault **defe
 
 If you set a passphrase under **Settings → Security → Encryption**, all backup archives are encrypted with your backup password (age encryption — a modern, audited standard) before they leave the host. Without the passphrase, restoring is not possible. Encryption is transparent to storage destinations — it applies equally to local, SFTP, SMB, NFS, WebDAV, and S3.
 
-The encryption status is shown on the Dashboard's 3-2-1 compliance widget, and on each restore point's chain-health badge.
+The encryption status is shown on the Dashboard's 3-2-1 compliance widget, and on each restore point's chain-health badge (along with details on the referenced full backup for chained restores).
 
 ---
 

--- a/internal/runner/chain_health.go
+++ b/internal/runner/chain_health.go
@@ -12,12 +12,15 @@ import (
 // retention-preservation information for the restore UI.
 type AnnotatedRestorePoint struct {
 	db.RestorePoint
-	ChainStatus                 string `json:"chain_status"`
-	ChainDepth                  int    `json:"chain_depth"`
-	ChainWarning                string `json:"chain_warning,omitempty"`
-	MissingParentRestorePointID int64  `json:"missing_parent_restore_point_id,omitempty"`
-	RetentionPreserved          bool   `json:"retention_preserved,omitempty"`
-	RetentionPreservedFor       int    `json:"retention_preserved_for,omitempty"`
+	ChainStatus                 string     `json:"chain_status"`
+	ChainDepth                  int        `json:"chain_depth"`
+	ChainWarning                string     `json:"chain_warning,omitempty"`
+	MissingParentRestorePointID int64      `json:"missing_parent_restore_point_id,omitempty"`
+	RetentionPreserved          bool       `json:"retention_preserved,omitempty"`
+	RetentionPreservedFor       int        `json:"retention_preserved_for,omitempty"`
+	BaseFullRestorePointID      int64      `json:"base_full_restore_point_id,omitempty"`
+	BaseFullCreatedAt           *time.Time `json:"base_full_created_at,omitempty"`
+	BaseFullSizeBytes           int64      `json:"base_full_size_bytes,omitempty"`
 }
 
 // AnnotateRestorePoints enriches restore points with chain-health information
@@ -47,13 +50,18 @@ func annotateRestorePoints(job db.Job, points []db.RestorePoint, now time.Time) 
 
 	annotated := make([]AnnotatedRestorePoint, 0, len(points))
 	for _, rp := range points {
-		status, depth, missingParentID, warning := restorePointChainState(rp, byID)
+		status, depth, missingParentID, warning, base := restorePointChainState(rp, byID)
 		entry := AnnotatedRestorePoint{
 			RestorePoint:                rp,
 			ChainStatus:                 status,
 			ChainDepth:                  depth,
 			ChainWarning:                warning,
 			MissingParentRestorePointID: missingParentID,
+		}
+		if (status == "healthy" || status == "standalone") && base != nil && base.BackupType == "full" {
+			entry.BaseFullRestorePointID = base.ID
+			entry.BaseFullCreatedAt = &base.CreatedAt
+			entry.BaseFullSizeBytes = base.SizeBytes
 		}
 		if _, isProtected := protected[rp.ID]; isProtected {
 			if _, isDirectKeep := directKeep[rp.ID]; !isDirectKeep && dependencyCounts[rp.ID] > 0 {
@@ -133,9 +141,9 @@ func retainedDependencyCounts(points []db.RestorePoint, directKeep map[int64]str
 	return counts
 }
 
-func restorePointChainState(rp db.RestorePoint, byID map[int64]db.RestorePoint) (string, int, int64, string) {
+func restorePointChainState(rp db.RestorePoint, byID map[int64]db.RestorePoint) (string, int, int64, string, *db.RestorePoint) {
 	if rp.ParentRestorePointID <= 0 {
-		return "standalone", 1, 0, ""
+		return "standalone", 1, 0, "", &rp
 	}
 
 	depth := 1
@@ -145,15 +153,15 @@ func restorePointChainState(rp db.RestorePoint, byID map[int64]db.RestorePoint) 
 		depth++
 		parentID := current.ParentRestorePointID
 		if _, ok := seen[parentID]; ok {
-			return "broken", depth, parentID, fmt.Sprintf("Restore chain loops back to restore point #%d.", parentID)
+			return "broken", depth, parentID, fmt.Sprintf("Restore chain loops back to restore point #%d.", parentID), nil
 		}
 		parent, ok := byID[parentID]
 		if !ok {
-			return "broken", depth, parentID, fmt.Sprintf("Parent restore point #%d is missing. Restore from this point will fail until the chain is repaired.", parentID)
+			return "broken", depth, parentID, fmt.Sprintf("Parent restore point #%d is missing. Restore from this point will fail until the chain is repaired.", parentID), nil
 		}
 		seen[parentID] = struct{}{}
 		current = parent
 	}
 
-	return "healthy", depth, 0, ""
+	return "healthy", depth, 0, "", &current
 }

--- a/internal/runner/chain_health_more_test.go
+++ b/internal/runner/chain_health_more_test.go
@@ -44,7 +44,10 @@ func TestRestorePointChainStateLoop(t *testing.T) {
 	rp11 := db.RestorePoint{ID: 11, ParentRestorePointID: 10}
 	byID := map[int64]db.RestorePoint{10: rp10, 11: rp11}
 
-	status, _, missingParent, warning := restorePointChainState(rp10, byID)
+	status, _, missingParent, warning, base := restorePointChainState(rp10, byID)
+	if base != nil {
+		t.Errorf("base = %+v, want nil on loop", base)
+	}
 	if status != "broken" {
 		t.Errorf("status = %q, want broken on loop", status)
 	}

--- a/internal/runner/chain_health_test.go
+++ b/internal/runner/chain_health_test.go
@@ -120,3 +120,96 @@ func TestAnnotateRestorePointsUsesNewestOrderForRetention(t *testing.T) {
 		t.Fatalf("latest ChainDepth = %d, want 3", byID[22].ChainDepth)
 	}
 }
+
+func TestAnnotateRestorePointsSurfacesBaseFullBackup(t *testing.T) {
+	t.Parallel()
+
+	baseTime := time.Date(2026, 3, 8, 8, 0, 0, 0, time.UTC)
+	inc1Time := time.Date(2026, 3, 8, 9, 0, 0, 0, time.UTC)
+	diffTime := time.Date(2026, 3, 8, 10, 0, 0, 0, time.UTC)
+
+	job := db.Job{Name: "base-full-chain", RetentionCount: 5}
+	points := []db.RestorePoint{
+		{
+			ID:         100,
+			BackupType: "full",
+			SizeBytes:  1024 * 1024,
+			CreatedAt:  baseTime,
+		},
+		{
+			ID:                   101,
+			BackupType:           "incremental",
+			ParentRestorePointID: 100,
+			SizeBytes:            512 * 1024,
+			CreatedAt:            inc1Time,
+		},
+		{
+			ID:                   102,
+			BackupType:           "differential",
+			ParentRestorePointID: 100,
+			SizeBytes:            768 * 1024,
+			CreatedAt:            diffTime,
+		},
+		{
+			ID:                   103,
+			BackupType:           "incremental",
+			ParentRestorePointID: 999,
+			SizeBytes:            256 * 1024,
+			CreatedAt:            diffTime.Add(time.Hour),
+		},
+	}
+
+	annotated := annotateRestorePoints(job, points, diffTime.Add(2*time.Hour))
+	byID := make(map[int64]AnnotatedRestorePoint, len(annotated))
+	for _, rp := range annotated {
+		byID[rp.ID] = rp
+	}
+
+	// Standalone full point reports itself as base full backup
+	fullPt := byID[100]
+	if fullPt.BaseFullRestorePointID != 100 {
+		t.Errorf("full BaseFullRestorePointID = %d, want 100", fullPt.BaseFullRestorePointID)
+	}
+	if fullPt.BaseFullCreatedAt == nil || !fullPt.BaseFullCreatedAt.Equal(baseTime) {
+		t.Errorf("full BaseFullCreatedAt = %v, want %v", fullPt.BaseFullCreatedAt, baseTime)
+	}
+	if fullPt.BaseFullSizeBytes != 1024*1024 {
+		t.Errorf("full BaseFullSizeBytes = %d, want %d", fullPt.BaseFullSizeBytes, 1024*1024)
+	}
+
+	// Incremental child point reports base full backup
+	incPt := byID[101]
+	if incPt.BaseFullRestorePointID != 100 {
+		t.Errorf("inc BaseFullRestorePointID = %d, want 100", incPt.BaseFullRestorePointID)
+	}
+	if incPt.BaseFullCreatedAt == nil || !incPt.BaseFullCreatedAt.Equal(baseTime) {
+		t.Errorf("inc BaseFullCreatedAt = %v, want %v", incPt.BaseFullCreatedAt, baseTime)
+	}
+	if incPt.BaseFullSizeBytes != 1024*1024 {
+		t.Errorf("inc BaseFullSizeBytes = %d, want %d", incPt.BaseFullSizeBytes, 1024*1024)
+	}
+
+	// Differential child point reports base full backup
+	diffPt := byID[102]
+	if diffPt.BaseFullRestorePointID != 100 {
+		t.Errorf("diff BaseFullRestorePointID = %d, want 100", diffPt.BaseFullRestorePointID)
+	}
+	if diffPt.BaseFullCreatedAt == nil || !diffPt.BaseFullCreatedAt.Equal(baseTime) {
+		t.Errorf("diff BaseFullCreatedAt = %v, want %v", diffPt.BaseFullCreatedAt, baseTime)
+	}
+	if diffPt.BaseFullSizeBytes != 1024*1024 {
+		t.Errorf("diff BaseFullSizeBytes = %d, want %d", diffPt.BaseFullSizeBytes, 1024*1024)
+	}
+
+	// Broken chain does not report base full backup
+	brokenPt := byID[103]
+	if brokenPt.BaseFullRestorePointID != 0 {
+		t.Errorf("broken BaseFullRestorePointID = %d, want 0", brokenPt.BaseFullRestorePointID)
+	}
+	if brokenPt.BaseFullCreatedAt != nil {
+		t.Errorf("broken BaseFullCreatedAt = %v, want nil", brokenPt.BaseFullCreatedAt)
+	}
+	if brokenPt.BaseFullSizeBytes != 0 {
+		t.Errorf("broken BaseFullSizeBytes = %d, want 0", brokenPt.BaseFullSizeBytes)
+	}
+}

--- a/web/src/components/RestorePointTimeline.svelte
+++ b/web/src/components/RestorePointTimeline.svelte
@@ -1,5 +1,6 @@
 <script>
-  import { formatBytes, relTime } from '../lib/utils.js'
+  import { formatBytes, formatDate, relTime } from '../lib/utils.js'
+  import Tooltip from './Tooltip.svelte'
 
   let {
     points = [],
@@ -146,7 +147,10 @@
                 {#if rp.chain_status === 'broken'}
                   <span class="text-[11px] px-1.5 py-0.5 rounded-full font-medium bg-danger/15 text-danger">Broken chain</span>
                 {:else if chainDeps(rp) > 0}
-                  <span class="text-[11px] px-1.5 py-0.5 rounded-full font-medium bg-info/15 text-info">Chain ×{rp.chain_depth}</span>
+                  <span class="inline-flex items-center gap-0.5">
+                    <span class="text-[11px] px-1.5 py-0.5 rounded-full font-medium bg-info/15 text-info">Chain ×{rp.chain_depth}</span>
+                    <Tooltip text="Chain length is {rp.chain_depth}. Restoring replays the base full backup plus intermediate backups in this chain." />
+                  </span>
                 {/if}
                 {#if rp.retention_preserved}
                   <span class="text-[11px] px-1.5 py-0.5 rounded-full font-medium bg-warning/15 text-warning">Retained for chain</span>
@@ -184,7 +188,12 @@
             {#if rp.chain_status === 'broken'}
               <p class="mt-2 text-xs text-danger">{rp.chain_warning}</p>
             {:else if chainDeps(rp) > 0}
-              <p class="mt-2 text-xs text-info">Restore replays {chainDeps(rp)} earlier backup{chainDeps(rp) === 1 ? '' : 's'} in this chain.</p>
+              <div class="mt-2 space-y-0.5 text-xs">
+                <p class="text-info">Restore replays {chainDeps(rp)} earlier backup{chainDeps(rp) === 1 ? '' : 's'} in this chain.</p>
+                {#if rp.base_full_created_at}
+                  <p class="text-text-muted">Based on the full backup from {formatDate(rp.base_full_created_at)}{rp.base_full_size_bytes ? ` (${formatBytes(rp.base_full_size_bytes)})` : ''}.</p>
+                {/if}
+              </div>
             {/if}
           </div>
         {/each}

--- a/web/src/components/RestoreWizard.svelte
+++ b/web/src/components/RestoreWizard.svelte
@@ -702,7 +702,7 @@
           <span class="text-text-muted">Chain Health</span>
           <span class="inline-flex items-center gap-1">
             <span class="text-xs font-medium {chainHealthTone(selectedPoint)}">{chainHealthLabel(selectedPoint)}</span>
-            {#if chainDependencies(selectedPoint) > 0}
+            {#if selectedPoint?.chain_status !== 'broken' && chainDependencies(selectedPoint) > 0}
               <Tooltip text="Chain length is {selectedPoint.chain_depth}. Restoring replays the base full backup plus intermediate backups in this chain." />
             {/if}
           </span>

--- a/web/src/components/RestoreWizard.svelte
+++ b/web/src/components/RestoreWizard.svelte
@@ -8,6 +8,7 @@
   import PathBrowser from './PathBrowser.svelte'
   import Spinner from './Spinner.svelte'
   import RestorePointTimeline from './RestorePointTimeline.svelte'
+  import Tooltip from './Tooltip.svelte'
 
   let { jobs = [], onrestore = () => {}, initialJobId = null, initialType = null, initialName = null } = $props()
 
@@ -699,7 +700,12 @@
         </div>
         <div class="flex justify-between">
           <span class="text-text-muted">Chain Health</span>
-          <span class="text-xs font-medium {chainHealthTone(selectedPoint)}">{chainHealthLabel(selectedPoint)}</span>
+          <span class="inline-flex items-center gap-1">
+            <span class="text-xs font-medium {chainHealthTone(selectedPoint)}">{chainHealthLabel(selectedPoint)}</span>
+            {#if chainDependencies(selectedPoint) > 0}
+              <Tooltip text="Chain length is {selectedPoint.chain_depth}. Restoring replays the base full backup plus intermediate backups in this chain." />
+            {/if}
+          </span>
         </div>
       </div>
     </div>
@@ -722,6 +728,9 @@
         <div>
           <p class="text-sm font-medium text-info">Restore will replay the full chain</p>
           <p class="text-xs text-text-muted mt-0.5">This point depends on {chainDependencies(selectedPoint)} earlier backup{chainDependencies(selectedPoint) === 1 ? '' : 's'} and Vault will stage them before restoring.</p>
+          {#if selectedPoint?.base_full_created_at}
+            <p class="text-xs text-text-muted mt-0.5">Based on the full backup from {formatDate(selectedPoint.base_full_created_at)}{selectedPoint.base_full_size_bytes ? ` (${formatBytes(selectedPoint.base_full_size_bytes)})` : ''}.</p>
+          {/if}
         </div>
       </div>
     {/if}


### PR DESCRIPTION
## Summary

Surfaces the root `full` restore point (ID, creation timestamp, and size) for chained differential and incremental restore points in the API response, and updates the restore timeline and wizard UI to display which full backup a restore point depends on, alongside an explanatory tooltip on the `Chain ×N` badge.

- Closes #318

## Changes

### Backend (`internal/runner`)
- Extended `AnnotatedRestorePoint` with `base_full_restore_point_id`, `base_full_created_at`, and `base_full_size_bytes` fields (populated when `healthy` or `standalone` with a base `full` backup).
- Updated `restorePointChainState` to return the terminal ancestor restore point reached when walking the chain.
- Added `TestAnnotateRestorePointsSurfacesBaseFullBackup` in `internal/runner/chain_health_test.go` verifying base full backup resolution on incremental, differential, standalone, and broken chains.
- Updated `TestRestorePointChainStateLoop` in `internal/runner/chain_health_more_test.go`.

### Frontend (`web/src`)
- In `web/src/components/RestorePointTimeline.svelte`, added explanatory `Tooltip` to the `Chain ×{rp.chain_depth}` badge and rendered the referenced base full backup details below the replay summary.
- In `web/src/components/RestoreWizard.svelte`, added the same chain-explanation tooltip to the confirmation step's Chain Health row and displayed the referenced base full backup line in the replay banner.

### Documentation & Changelog
- Updated `docs/guides/backup-jobs.md` and `docs/getting-started.md` to mention the referenced full backup annotations.
- Added entry to `CHANGELOG.md` under `[Unreleased]` -> `Added`.

## Verification
- Unit & integration tests: `make test` passed.
- Frontend tests, lint & build: `npm --prefix web test`, `npm --prefix web run lint`, `npm --prefix web run build` passed.
- Ansible build, deployment & verification: `make build`, `make deploy`, `make verify` passed.
- CodeRabbit CLI review: 0 findings across all 8 modified files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Restore timelines and the restore wizard now show the date and size of the full backup anchoring incremental or differential restore points.
  - Added tooltips explaining restore-chain length and replay behaviour.

- **Documentation**
  - Updated restore-point and backup-job guides to describe chain-health annotations and full-backup details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->