### PR TITLE
feat(engine): display real plugin names and filter hidden files (#329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **Display real plugin names and filter hidden files (#329):** Plugin discovery now extracts readable plugin names from `.plg` DOCTYPE entity declarations and root XML attributes, rendering human-friendly display names across the item picker and job configuration while keeping internal identifiers intact. AppleDouble files (`._*`) and other hidden files are now automatically filtered out from discovered plugin items. Closes #329.
+
 - **Restore points now show the base full backup for chained restores (#318):** Differential and incremental restore points in the restore timeline and wizard now display the date and size of the root full backup they depend on, and the `Chain ×N` badge includes an explanatory tooltip describing chain length and replay behavior. Closes #318.
 
 - **Configurable log level (#346):** Added a global log level setting (`debug`, `info`, `warn`, `error`) configurable via the web Settings page and the settings API (`log_level`). Daemon logging routes through a centralized `slog` handler with dynamic level adjustments applied at runtime without restarting the daemon. Closes #346.

--- a/internal/engine/plugin.go
+++ b/internal/engine/plugin.go
@@ -3,15 +3,65 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/ruaan-deysel/vault/internal/dedup"
 )
+
+// entityDeclPattern matches DOCTYPE <!ENTITY name "value"> declarations in .plg files.
+var entityDeclPattern = regexp.MustCompile(`(?i)<!ENTITY\s+([a-zA-Z0-9._-]+)\s+["']([^"']*)["']\s*>`)
+
+// pluginDisplayName extracts the human-readable plugin name from a .plg file.
+// It parses DOCTYPE entity declarations and decodes the root <PLUGIN> element.
+// Returns an empty string on any error or if the name attribute is absent.
+func pluginDisplayName(plgPath string) string {
+	data, err := os.ReadFile(plgPath) // #nosec G304 — plgPath constructed from pluginsDir and entry.Name from ReadDir
+	if err != nil {
+		return ""
+	}
+	return parsePluginDisplayName(data)
+}
+
+// parsePluginDisplayName extracts the name attribute of the root <PLUGIN> element
+// from .plg XML bytes, resolving any DOCTYPE <!ENTITY ...> references.
+func parsePluginDisplayName(data []byte) string {
+	entities := make(map[string]string)
+	matches := entityDeclPattern.FindAllSubmatch(data, -1)
+	for _, m := range matches {
+		if len(m) == 3 {
+			entities[string(m[1])] = string(m[2])
+		}
+	}
+
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	decoder.Strict = false
+	decoder.Entity = entities
+
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			return ""
+		}
+		if se, ok := tok.(xml.StartElement); ok {
+			if strings.EqualFold(se.Name.Local, "plugin") {
+				for _, attr := range se.Attr {
+					if strings.EqualFold(attr.Name.Local, "name") {
+						return strings.TrimSpace(attr.Value)
+					}
+				}
+			}
+			return ""
+		}
+	}
+}
 
 // pluginsDir is the base directory where Unraid plugins are installed. It is a
 // var (not a const) only so tests can redirect plugin reads/writes to a
@@ -51,7 +101,7 @@ func (h *PluginHandler) ListItems() ([]BackupItem, error) {
 
 	items := make([]BackupItem, 0)
 	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".plg") {
+		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") || !strings.HasSuffix(entry.Name(), ".plg") {
 			continue
 		}
 		name := strings.TrimSuffix(entry.Name(), ".plg")
@@ -64,14 +114,20 @@ func (h *PluginHandler) ListItems() ([]BackupItem, error) {
 			hasConfig = true
 		}
 
+		displayName := pluginDisplayName(plgPath)
+		if displayName == "" {
+			displayName = name
+		}
+
 		items = append(items, BackupItem{
 			Name: name,
 			Type: "plugin",
 			Settings: map[string]any{
-				"id":         name,
-				"plg_path":   plgPath,
-				"config_dir": configDir,
-				"has_config": hasConfig,
+				"id":           name,
+				"display_name": displayName,
+				"plg_path":     plgPath,
+				"config_dir":   configDir,
+				"has_config":   hasConfig,
 			},
 		})
 	}

--- a/internal/engine/plugin_test.go
+++ b/internal/engine/plugin_test.go
@@ -259,3 +259,199 @@ func TestPluginChunkedRestoreDestination(t *testing.T) {
 		}
 	})
 }
+
+// TestPluginListItems tests PluginHandler.ListItems() directly using a temporary directory,
+// verifying filtering of hidden and AppleDouble ._* files, and parsing of display names.
+func TestPluginListItems(t *testing.T) {
+	base := t.TempDir()
+	orig := pluginsDir
+	pluginsDir = base
+	t.Cleanup(func() { pluginsDir = orig })
+
+	// 1. Literal name attribute
+	caPLG := `<?xml version="1.0" standalone="yes"?>
+<PLUGIN name="Community Applications" version="2026.01.01">
+</PLUGIN>`
+	if err := os.WriteFile(filepath.Join(base, "community.applications.plg"), []byte(caPLG), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. DTD entity-based name attribute (double quotes) + config directory
+	vaultPLG := `<?xml version="1.0" standalone="yes"?>
+<!DOCTYPE PLUGIN [
+    <!ENTITY name "Vault Backup Manager">
+]>
+<PLUGIN name="&name;" author="Ruaan Deysel">
+</PLUGIN>`
+	if err := os.WriteFile(filepath.Join(base, "vault.plg"), []byte(vaultPLG), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(base, "vault"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// 3. DTD entity-based name attribute (single quotes)
+	udPLG := `<?xml version="1.0" standalone="yes"?>
+<!DOCTYPE PLUGIN [
+    <!ENTITY name 'Unassigned Devices'>
+]>
+<PLUGIN name="&name;">
+</PLUGIN>`
+	if err := os.WriteFile(filepath.Join(base, "unassigned.devices.plg"), []byte(udPLG), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 4. AppleDouble ._* artifact file (must be excluded)
+	if err := os.WriteFile(filepath.Join(base, "._vault.plg"), []byte{0x00, 0x05, 0x16, 0x07}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 5. Hidden dot file (must be excluded)
+	if err := os.WriteFile(filepath.Join(base, ".hidden.plg"), []byte("<PLUGIN name=\"Hidden\"></PLUGIN>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 6. Malformed XML (falls back to filename stem)
+	if err := os.WriteFile(filepath.Join(base, "broken.plg"), []byte("this is not xml <><"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 7. Missing name attribute (falls back to filename stem)
+	if err := os.WriteFile(filepath.Join(base, "noname.plg"), []byte("<PLUGIN author=\"Unknown\"></PLUGIN>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h, err := NewPluginHandler()
+	if err != nil {
+		t.Fatalf("NewPluginHandler: %v", err)
+	}
+
+	items, err := h.ListItems()
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+
+	itemsByName := make(map[string]BackupItem)
+	for _, item := range items {
+		itemsByName[item.Name] = item
+	}
+
+	// Assert ._ and hidden entries are excluded
+	if _, found := itemsByName["._vault"]; found {
+		t.Errorf("expected ._vault.plg to be excluded from ListItems()")
+	}
+	if _, found := itemsByName[".hidden"]; found {
+		t.Errorf("expected .hidden.plg to be excluded from ListItems()")
+	}
+
+	// Assert valid fixtures
+	wantItems := map[string]struct {
+		displayName string
+		hasConfig   bool
+	}{
+		"community.applications": {displayName: "Community Applications", hasConfig: false},
+		"vault":                  {displayName: "Vault Backup Manager", hasConfig: true},
+		"unassigned.devices":     {displayName: "Unassigned Devices", hasConfig: false},
+		"broken":                 {displayName: "broken", hasConfig: false},
+		"noname":                 {displayName: "noname", hasConfig: false},
+	}
+
+	if len(items) != len(wantItems) {
+		t.Errorf("got %d items, want %d", len(items), len(wantItems))
+	}
+
+	for name, want := range wantItems {
+		item, ok := itemsByName[name]
+		if !ok {
+			t.Errorf("missing expected plugin %q in results", name)
+			continue
+		}
+		if item.Type != "plugin" {
+			t.Errorf("item %q Type = %q, want plugin", name, item.Type)
+		}
+		disp, _ := item.Settings["display_name"].(string)
+		if disp != want.displayName {
+			t.Errorf("item %q display_name = %q, want %q", name, disp, want.displayName)
+		}
+		id, _ := item.Settings["id"].(string)
+		if id != name {
+			t.Errorf("item %q id = %q, want %q", name, id, name)
+		}
+		hasConfig, _ := item.Settings["has_config"].(bool)
+		if hasConfig != want.hasConfig {
+			t.Errorf("item %q has_config = %v, want %v", name, hasConfig, want.hasConfig)
+		}
+	}
+}
+
+func TestParsePluginDisplayName(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "literal name",
+			input:    `<PLUGIN name="My Plugin"></PLUGIN>`,
+			expected: "My Plugin",
+		},
+		{
+			name: "entity double quotes",
+			input: `<?xml version="1.0"?>
+<!DOCTYPE PLUGIN [
+<!ENTITY name "Dyn Name">
+]>
+<PLUGIN name="&name;">
+</PLUGIN>`,
+			expected: "Dyn Name",
+		},
+		{
+			name: "entity single quotes",
+			input: `<!DOCTYPE PLUGIN [
+<!ENTITY name 'Single Quote'>
+]>
+<PLUGIN name="&name;">`,
+			expected: "Single Quote",
+		},
+		{
+			name:     "lowercase plugin tag",
+			input:    `<plugin name="Lower Tag">`,
+			expected: "Lower Tag",
+		},
+		{
+			name:     "empty attribute",
+			input:    `<PLUGIN name="">`,
+			expected: "",
+		},
+		{
+			name:     "missing name attribute",
+			input:    `<PLUGIN author="Someone">`,
+			expected: "",
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "non-plugin root element",
+			input:    `<OTHER name="Not a plugin">`,
+			expected: "",
+		},
+		{
+			name:     "invalid XML",
+			input:    `random garbage bytes not xml`,
+			expected: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parsePluginDisplayName([]byte(tc.input))
+			if got != tc.expected {
+				t.Errorf("parsePluginDisplayName() = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+

--- a/internal/engine/plugin_test.go
+++ b/internal/engine/plugin_test.go
@@ -455,3 +455,21 @@ func TestParsePluginDisplayName(t *testing.T) {
 	}
 }
 
+func TestPluginDisplayName(t *testing.T) {
+	// Missing file should gracefully return empty string
+	if got := pluginDisplayName("/nonexistent/path/plugin.plg"); got != "" {
+		t.Errorf("pluginDisplayName() = %q, want empty string", got)
+	}
+
+	// Valid file
+	dir := t.TempDir()
+	p := filepath.Join(dir, "test.plg")
+	if err := os.WriteFile(p, []byte(`<PLUGIN name="Direct Test"></PLUGIN>`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := pluginDisplayName(p); got != "Direct Test" {
+		t.Errorf("pluginDisplayName() = %q, want %q", got, "Direct Test")
+	}
+}
+
+

--- a/web/src/components/ItemPicker.svelte
+++ b/web/src/components/ItemPicker.svelte
@@ -208,7 +208,9 @@
   function filteredPlugins() {
     if (!search) return plugins
     const q = search.toLowerCase()
-    return plugins.filter((p) => p.name.toLowerCase().includes(q))
+    return plugins.filter(
+      (p) => p.name.toLowerCase().includes(q) || (p.settings?.display_name || '').toLowerCase().includes(q),
+    )
   }
 
   function filteredZFS() {
@@ -776,7 +778,7 @@
                 {/if}
               </div>
               <div class="flex-1 min-w-0">
-                <div class="text-sm font-medium text-text truncate">{plugin.name}</div>
+                <div class="text-sm font-medium text-text truncate">{plugin.settings?.display_name || plugin.name}</div>
                 <div class="text-xs text-text-muted">Unraid Plugin</div>
               </div>
               {#if plugin.settings?.has_config}

--- a/web/src/lib/utils.js
+++ b/web/src/lib/utils.js
@@ -346,9 +346,12 @@ export function itemDisplayLabel(item) {
   if (typeof item === 'string') return item
   const itemType = item.item_type || item.type || ''
   const itemName = item.item_name || item.name || ''
-  if (itemType !== 'folder') return itemName
   const parsedSettings = parseConfig(item.settings)
   const settings = parsedSettings && typeof parsedSettings === 'object' ? parsedSettings : {}
+  if (itemType !== 'folder') {
+    if (typeof settings.display_name === 'string' && settings.display_name.trim()) return settings.display_name.trim()
+    return itemName
+  }
   if (settings.preset) return itemName
   if (typeof settings.path === 'string' && settings.path.trim()) return settings.path.trim()
   const itemId = typeof item.item_id === 'string' ? item.item_id : typeof item.id === 'string' ? item.id : ''

--- a/web/src/lib/utils.test.js
+++ b/web/src/lib/utils.test.js
@@ -312,11 +312,30 @@ describe('itemDisplayLabel', () => {
     expect(itemDisplayLabel(flashObjItem)).toBe('Flash Drive')
   })
 
-  it('returns item_name unchanged for non-folder items', () => {
+  it('returns item_name unchanged for non-folder items without display_name', () => {
     expect(itemDisplayLabel({ item_type: 'container', item_name: 'plex', item_id: '12345' })).toBe('plex')
     expect(itemDisplayLabel({ item_type: 'vm', item_name: 'homeassistant', item_id: 'vmid1' })).toBe('homeassistant')
     expect(itemDisplayLabel({ item_type: 'plugin', item_name: 'community.applications', item_id: 'ca' })).toBe('community.applications')
     expect(itemDisplayLabel({ item_type: 'zfs', item_name: 'tank/data', item_id: 'tank/data' })).toBe('tank/data')
+  })
+
+  it('prefers settings.display_name for plugin and other non-folder items when present', () => {
+    expect(
+      itemDisplayLabel({
+        item_type: 'plugin',
+        item_name: 'community.applications',
+        item_id: 'community.applications',
+        settings: '{"display_name":"Community Applications"}',
+      }),
+    ).toBe('Community Applications')
+
+    expect(
+      itemDisplayLabel({
+        type: 'plugin',
+        name: 'vault',
+        settings: { display_name: 'Vault Backup Manager' },
+      }),
+    ).toBe('Vault Backup Manager')
   })
 
   it('handles name/type/id aliases on item object', () => {


### PR DESCRIPTION
## Summary

Resolves #329 by improving Unraid plugin discovery:
- Filters out AppleDouble (`._*`) and hidden files during directory traversal in `PluginHandler.ListItems()`.
- Parses readable plugin display names from `.plg` XML/DOCTYPE entity declarations and root `<PLUGIN name="...">` attributes.
- Renders display names in the UI item picker and selected items list while preserving backend identifiers (`id`, `name`, `plg_path`, etc.) for backup and restore operations.
- Enhances plugin item picker search to match against both plugin name and display name.

## Validation & Testing

- Unit tests added in `internal/engine/plugin_test.go` and `web/src/lib/utils.test.js`.
- `make test` & `npm --prefix web test` (225/225 tests passing).
- `make lint` & `make build` clean.
- `make deploy` & `make verify` passed on Unraid host `192.168.20.21`.
- Live browser verification with `playwright-cli` confirmed `display_name` rendering, absence of `._*` entries, item selection, and search filtering.
- CodeRabbit CLI review completed with 0 findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin lists now show readable display names from plugin metadata, with filename fallback when unavailable.
  * Plugin search matches both plugin names and display names.
  * Hidden plugin files, including AppleDouble artefacts, are excluded from discovery.

* **Bug Fixes**
  * Improved handling of missing, malformed, or empty plugin metadata.
  * Updated changelog documentation to cover display-name discovery and hidden-file exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->