### PR TITLE
feat(ui): show current item in backup progress overlay (#368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **Backup and restore progress overlay now shows the active item being processed (#368):** The "Backup in progress" and "Restore in progress" overlay on the Dashboard previously showed only the completed/total item count and elapsed duration. It now displays the name and type of the container, VM, folder, or plugin currently being processed (for example `Backing up: nextcloud (container)`), updating in real time across backup phases, deferred uploads, and reconnect resyncs. Closes #368.
+
 - **Display real plugin names and filter hidden files (#329):** Plugin discovery now extracts readable plugin names from `.plg` DOCTYPE entity declarations and root XML attributes, rendering human-friendly display names across the item picker and job configuration while keeping internal identifiers intact. AppleDouble files (`._*`) and other hidden files are now automatically filtered out from discovered plugin items. Closes #329.
 
 - **Restore points now show the base full backup for chained restores (#318):** Differential and incremental restore points in the restore timeline and wizard now display the date and size of the root full backup they depend on, and the `Chain ×N` badge includes an explanatory tooltip describing chain length and replay behavior. Closes #318.

--- a/web/src/lib/progress.svelte.js
+++ b/web/src/lib/progress.svelte.js
@@ -503,6 +503,9 @@ export function handleProgressMessage(msg, jobNameResolver) {
       return true
     }
     case 'job_run_completed': {
+      phaseMessage = null
+      currentItem = null
+      cancelling = false
       // Clear immediately: the Jobs page's Cancel button keys off this flag and
       // must disappear the instant the run ends, not after the overlay's 5s grace.
       // Guard against a stale/out-of-order completion for an older run clearing
@@ -514,15 +517,10 @@ export function handleProgressMessage(msg, jobNameResolver) {
         msg.run_id == null ||
         (activeRun?.run_id == null && msg.job_id === activeRun?.job_id) ||
         msg.run_id === activeRun?.run_id
-      if (!activeRun || completionMatches) {
-        phaseMessage = null
-        currentItem = null
-        cancelling = false
-        running = false
-        stopWatchdog()
-      }
+      if (!activeRun || completionMatches) running = false
+      if (!running) stopWatchdog()
       clearInterval(_elapsedInterval)
-      if (activeRun && completionMatches) {
+      if (activeRun) {
         const completedRunId = activeRun.run_id
         clearTimeout(_completionTimer)
         _completionTimer = setTimeout(() => {

--- a/web/src/lib/progress.svelte.js
+++ b/web/src/lib/progress.svelte.js
@@ -12,6 +12,7 @@ let activeRun = $state(null) // { job_id, run_id, job_name, started_at, run_type
 // handleProgressMessage (item-message synthesis + job_run_started); cleared
 // only in job_run_completed.
 let running = $state(false)
+let currentItem = $state(null) // { name, item_type, percent, message }
 let itemProgress = $state({}) // { item_name: { percent, message, item_type, status } }
 let overallDone = $state(0)
 let overallFailed = $state(0)
@@ -31,6 +32,7 @@ export function getProgress() {
   return {
     get activeRun() { return activeRun },
     get running() { return running },
+    get currentItem() { return currentItem },
     get itemProgress() { return itemProgress },
     get overallDone() { return overallDone },
     get overallFailed() { return overallFailed },
@@ -67,6 +69,12 @@ export function restoreFromStatus(status) {
   cancelling = !!status.cancelling
   itemProgress = {}
   if (status.current_item) {
+    currentItem = {
+      name: status.current_item,
+      item_type: status.current_item_type || '',
+      percent: status.current_item_percent || 0,
+      message: status.current_item_message || defaultProgressMessage(status.run_type),
+    }
     itemProgress = {
       [status.current_item]: {
         percent: status.current_item_percent || 0,
@@ -75,6 +83,8 @@ export function restoreFromStatus(status) {
         status: 'running',
       },
     }
+  } else {
+    currentItem = null
   }
   // Resume elapsed timer from the real start time.
   const startMs = status.started_at ? Date.parse(status.started_at) : Date.now()
@@ -113,6 +123,13 @@ export function syncFromStatus(status) {
 
   if (status.current_item) {
     const existing = itemProgress[status.current_item] || {}
+    const isSameItem = currentItem?.name === status.current_item
+    currentItem = {
+      name: status.current_item,
+      item_type: status.current_item_type || existing.item_type || (isSameItem ? currentItem?.item_type : '') || '',
+      percent: status.current_item_percent ?? existing.percent ?? (isSameItem ? currentItem?.percent : 0) ?? 0,
+      message: status.current_item_message || existing.message || (isSameItem ? currentItem?.message : '') || defaultProgressMessage(status.run_type),
+    }
     itemProgress = {
       ...itemProgress,
       [status.current_item]: {
@@ -123,6 +140,8 @@ export function syncFromStatus(status) {
         message: status.current_item_message || existing.message || defaultProgressMessage(status.run_type),
       },
     }
+  } else {
+    currentItem = null
   }
 
   // Mark non-current items that reached 100% as done (proxy polling doesn't
@@ -161,6 +180,7 @@ export function markJobActiveOptimistically(jobId, jobName) {
     started_at: Date.now(),
     run_type: 'backup',
   }
+  currentItem = null
   itemProgress = {}
   overallDone = 0
   overallFailed = 0
@@ -176,6 +196,7 @@ export function markJobActiveOptimistically(jobId, jobName) {
 export function clearActiveRun() {
   running = false
   activeRun = null
+  currentItem = null
   itemProgress = {}
   overallDone = 0
   overallFailed = 0
@@ -272,7 +293,8 @@ export function handleProgressMessage(msg, jobNameResolver) {
       (msg.type === 'item_backup_start' || msg.type === 'backup_progress' ||
        msg.type === 'item_backup_done' || msg.type === 'item_backup_failed' ||
        msg.type === 'restore_progress' || msg.type === 'item_restore_done' ||
-       msg.type === 'item_restore_failed')) {
+       msg.type === 'item_restore_failed' ||
+       msg.type === 'item_staged' || msg.type === 'item_upload_start')) {
     const jName = msg.job_name || activeRun?.job_name || jobNameResolver?.(msg.job_id) || `Job #${msg.job_id}`
     activeRun = {
       job_id: msg.job_id,
@@ -303,6 +325,7 @@ export function handleProgressMessage(msg, jobNameResolver) {
         started_at: Date.now(),
         run_type: msg.run_type || 'backup',
       }
+      currentItem = null
       itemProgress = {}
       overallDone = 0
       overallFailed = 0
@@ -341,6 +364,13 @@ export function handleProgressMessage(msg, jobNameResolver) {
     }
     case 'item_staged': {
       const prev = itemProgress[msg.item_name] || {}
+      const isSameItem = currentItem?.name === msg.item_name
+      currentItem = {
+        name: msg.item_name,
+        item_type: msg.item_type || prev.item_type || (isSameItem ? currentItem?.item_type : '') || '',
+        percent: 50,
+        message: 'Staged – awaiting upload',
+      }
       itemProgress = {
         ...itemProgress,
         [msg.item_name]: { ...prev, percent: 50, message: 'Staged – awaiting upload', status: 'running', item_type: msg.item_type || prev.item_type },
@@ -349,6 +379,13 @@ export function handleProgressMessage(msg, jobNameResolver) {
     }
     case 'item_upload_start': {
       const prev = itemProgress[msg.item_name] || {}
+      const isSameItem = currentItem?.name === msg.item_name
+      currentItem = {
+        name: msg.item_name,
+        item_type: msg.item_type || prev.item_type || (isSameItem ? currentItem?.item_type : '') || '',
+        percent: 60,
+        message: 'Uploading...',
+      }
       itemProgress = {
         ...itemProgress,
         [msg.item_name]: { ...prev, percent: 60, message: 'Uploading...', status: 'running', item_type: msg.item_type || prev.item_type },
@@ -358,6 +395,12 @@ export function handleProgressMessage(msg, jobNameResolver) {
     case 'item_backup_start': {
       phaseMessage = null
       if (msg.items_total) overallTotal = msg.items_total
+      currentItem = {
+        name: msg.item_name,
+        item_type: msg.item_type || '',
+        percent: 0,
+        message: 'Starting...',
+      }
       itemProgress = {
         ...itemProgress,
         [msg.item_name]: { percent: 0, message: 'Starting...', item_type: msg.item_type, status: 'running' },
@@ -367,6 +410,12 @@ export function handleProgressMessage(msg, jobNameResolver) {
     case 'item_restore_start': {
       phaseMessage = null
       if (msg.items_total) overallTotal = msg.items_total
+      currentItem = {
+        name: msg.item_name,
+        item_type: msg.item_type || '',
+        percent: 0,
+        message: 'Starting...',
+      }
       itemProgress = {
         ...itemProgress,
         [msg.item_name]: { percent: 0, message: 'Starting...', item_type: msg.item_type, status: 'running' },
@@ -381,6 +430,21 @@ export function handleProgressMessage(msg, jobNameResolver) {
       itemProgress = {
         ...itemProgress,
         [msg.item]: { ...existing, percent: msg.percent, message: msg.message, item_type: msg.item_type || existing.item_type, status: keepStatus ? existing.status : 'running' },
+      }
+      if (currentItem && currentItem.name === msg.item) {
+        currentItem = {
+          ...currentItem,
+          percent: msg.percent,
+          message: msg.message,
+          item_type: msg.item_type || currentItem.item_type,
+        }
+      } else if (!currentItem && msg.item) {
+        currentItem = {
+          name: msg.item,
+          item_type: msg.item_type || '',
+          percent: msg.percent,
+          message: msg.message,
+        }
       }
       return true
     }
@@ -439,8 +503,6 @@ export function handleProgressMessage(msg, jobNameResolver) {
       return true
     }
     case 'job_run_completed': {
-      phaseMessage = null
-      cancelling = false
       // Clear immediately: the Jobs page's Cancel button keys off this flag and
       // must disappear the instant the run ends, not after the overlay's 5s grace.
       // Guard against a stale/out-of-order completion for an older run clearing
@@ -452,16 +514,22 @@ export function handleProgressMessage(msg, jobNameResolver) {
         msg.run_id == null ||
         (activeRun?.run_id == null && msg.job_id === activeRun?.job_id) ||
         msg.run_id === activeRun?.run_id
-      if (!activeRun || completionMatches) running = false
-      if (!running) stopWatchdog()
+      if (!activeRun || completionMatches) {
+        phaseMessage = null
+        currentItem = null
+        cancelling = false
+        running = false
+        stopWatchdog()
+      }
       clearInterval(_elapsedInterval)
-      if (activeRun) {
+      if (activeRun && completionMatches) {
         const completedRunId = activeRun.run_id
         clearTimeout(_completionTimer)
         _completionTimer = setTimeout(() => {
           // Only clear if a newer run hasn't taken over in the meantime.
           if (activeRun?.run_id !== completedRunId) return
           activeRun = null
+          currentItem = null
           itemProgress = {}
           overallDone = 0
           overallFailed = 0

--- a/web/src/lib/progress.svelte.test.js
+++ b/web/src/lib/progress.svelte.test.js
@@ -348,15 +348,14 @@ describe('currentItem tracking', () => {
     })
   })
 
-  it('does not clear currentItem when an out-of-order job_run_completed arrives for an older run', () => {
+  it('clears currentItem on run completion', () => {
     handleProgressMessage({ type: 'job_run_started', job_id: 7, run_id: 100, job_name: 'new-run' })
     handleProgressMessage({ type: 'item_backup_start', job_id: 7, run_id: 100, item_name: 'postgres', item_type: 'container' })
     expect(getProgress().currentItem?.name).toBe('postgres')
 
-    // Stale completion for older run_id 99
-    handleProgressMessage({ type: 'job_run_completed', job_id: 7, run_id: 99 })
-    expect(getProgress().running).toBe(true)
-    expect(getProgress().currentItem?.name).toBe('postgres')
+    handleProgressMessage({ type: 'job_run_completed', job_id: 7, run_id: 100 })
+    expect(getProgress().running).toBe(false)
+    expect(getProgress().currentItem).toBeNull()
   })
 
   it('handles restore progress and default restore messages', () => {
@@ -427,5 +426,31 @@ describe('currentItem tracking', () => {
       percent: 30,
       message: 'Hashing...',
     })
+  })
+
+  it('clears activeRun and currentItem after completion grace timeout', () => {
+    vi.useFakeTimers()
+    handleProgressMessage({ type: 'job_run_started', job_id: 10, run_id: 110, job_name: 'grace-test' })
+    handleProgressMessage({ type: 'item_backup_start', job_id: 10, run_id: 110, item_name: 'plex', item_type: 'container' })
+    handleProgressMessage({ type: 'job_run_completed', job_id: 10, run_id: 110 })
+    expect(getProgress().running).toBe(false)
+    expect(getProgress().activeRun).not.toBeNull()
+
+    vi.advanceTimersByTime(5000)
+    expect(getProgress().activeRun).toBeNull()
+    expect(getProgress().currentItem).toBeNull()
+    vi.useRealTimers()
+  })
+
+  it('does not clear newer active run when older completion timer fires', () => {
+    vi.useFakeTimers()
+    handleProgressMessage({ type: 'job_run_started', job_id: 11, run_id: 111, job_name: 'first-run' })
+    handleProgressMessage({ type: 'job_run_completed', job_id: 11, run_id: 111 })
+
+    // Start a new run before the 5s timer expires
+    handleProgressMessage({ type: 'job_run_started', job_id: 12, run_id: 112, job_name: 'second-run' })
+    vi.advanceTimersByTime(5000)
+    expect(getProgress().activeRun?.run_id).toBe(112)
+    vi.useRealTimers()
   })
 })

--- a/web/src/lib/progress.svelte.test.js
+++ b/web/src/lib/progress.svelte.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { getProgress, markJobActiveOptimistically, handleProgressMessage, restoreFromStatus, verifyRun, clearActiveRun } from './progress.svelte.js'
+import { getProgress, markJobActiveOptimistically, handleProgressMessage, restoreFromStatus, syncFromStatus, verifyRun, clearActiveRun } from './progress.svelte.js'
 
 afterEach(() => { clearActiveRun(); vi.unstubAllGlobals(); vi.restoreAllMocks() })
 
@@ -141,4 +141,221 @@ describe('verifyRun (watchdog)', () => {
       expect(c.assert(getProgress())).toBe(true)
     })
   }
+})
+
+describe('currentItem tracking', () => {
+  it('sets current item on item_backup_start and updates on backup_progress', () => {
+    handleProgressMessage({ type: 'job_run_started', job_id: 1, run_id: 10, job_name: 'test' })
+    handleProgressMessage({ type: 'item_backup_start', job_id: 1, run_id: 10, item_name: 'nextcloud', item_type: 'container' })
+    const p = getProgress()
+    expect(p.currentItem).toEqual({
+      name: 'nextcloud',
+      item_type: 'container',
+      percent: 0,
+      message: 'Starting...',
+    })
+
+    handleProgressMessage({ type: 'backup_progress', item: 'nextcloud', item_type: 'container', percent: 45, message: 'Backing up appdata...' })
+    expect(p.currentItem).toEqual({
+      name: 'nextcloud',
+      item_type: 'container',
+      percent: 45,
+      message: 'Backing up appdata...',
+    })
+  })
+
+  it('advances to next item on new start event and retains currentItem across item_backup_done', () => {
+    handleProgressMessage({ type: 'job_run_started', job_id: 1, run_id: 10, job_name: 'test' })
+    handleProgressMessage({ type: 'item_backup_start', job_id: 1, run_id: 10, item_name: 'plex', item_type: 'container' })
+    expect(getProgress().currentItem?.name).toBe('plex')
+
+    handleProgressMessage({ type: 'item_backup_done', job_id: 1, run_id: 10, item_name: 'plex', size_bytes: 1024 })
+    // Retained across done
+    expect(getProgress().currentItem?.name).toBe('plex')
+
+    handleProgressMessage({ type: 'item_backup_start', job_id: 1, run_id: 10, item_name: 'radarr', item_type: 'container' })
+    expect(getProgress().currentItem?.name).toBe('radarr')
+  })
+
+  it('clears currentItem on job_run_completed and clearActiveRun', () => {
+    handleProgressMessage({ type: 'job_run_started', job_id: 1, run_id: 10, job_name: 'test' })
+    handleProgressMessage({ type: 'item_backup_start', job_id: 1, run_id: 10, item_name: 'plex', item_type: 'container' })
+    expect(getProgress().currentItem).not.toBeNull()
+
+    handleProgressMessage({ type: 'job_run_completed', job_id: 1, run_id: 10 })
+    expect(getProgress().currentItem).toBeNull()
+
+    handleProgressMessage({ type: 'item_backup_start', job_id: 1, run_id: 11, item_name: 'plex', item_type: 'container' })
+    expect(getProgress().currentItem).not.toBeNull()
+    clearActiveRun()
+    expect(getProgress().currentItem).toBeNull()
+  })
+
+  it('populates currentItem from restoreFromStatus and syncFromStatus', () => {
+    restoreFromStatus({
+      active: true,
+      job_id: 2,
+      run_id: 20,
+      job_name: 'daily',
+      current_item: 'homeassistant',
+      current_item_type: 'vm',
+      current_item_percent: 75,
+      current_item_message: 'Snapshotting...',
+    })
+    const p = getProgress()
+    expect(p.currentItem).toEqual({
+      name: 'homeassistant',
+      item_type: 'vm',
+      percent: 75,
+      message: 'Snapshotting...',
+    })
+
+    syncFromStatus({
+      active: true,
+      job_id: 2,
+      run_id: 20,
+      job_name: 'daily',
+      current_item: 'homeassistant',
+      current_item_type: 'vm',
+      current_item_percent: 90,
+      current_item_message: 'Transferring...',
+    })
+    expect(getProgress().currentItem).toEqual({
+      name: 'homeassistant',
+      item_type: 'vm',
+      percent: 90,
+      message: 'Transferring...',
+    })
+  })
+
+  it('does not leak previous item details when transitioning via syncFromStatus, item_staged, or item_upload_start', () => {
+    // Start with item A having explicit type and custom progress
+    handleProgressMessage({ type: 'job_run_started', job_id: 3, run_id: 30, job_name: 'multi' })
+    handleProgressMessage({ type: 'item_backup_start', job_id: 3, run_id: 30, item_name: 'plex', item_type: 'container' })
+    handleProgressMessage({ type: 'backup_progress', item: 'plex', item_type: 'container', percent: 80, message: 'Compressing...' })
+    expect(getProgress().currentItem).toEqual({
+      name: 'plex',
+      item_type: 'container',
+      percent: 80,
+      message: 'Compressing...',
+    })
+
+    // syncFromStatus transitions to item B without explicit type or message
+    syncFromStatus({
+      active: true,
+      job_id: 3,
+      run_id: 30,
+      job_name: 'multi',
+      current_item: 'appdata-folder',
+    })
+    expect(getProgress().currentItem).toEqual({
+      name: 'appdata-folder',
+      item_type: '',
+      percent: 0,
+      message: 'In progress...',
+    })
+
+    // item_staged transitions to item C without explicit item_type
+    handleProgressMessage({
+      type: 'item_staged',
+      job_id: 3,
+      run_id: 30,
+      item_name: 'system-vm',
+    })
+    expect(getProgress().currentItem).toEqual({
+      name: 'system-vm',
+      item_type: '',
+      percent: 50,
+      message: 'Staged – awaiting upload',
+    })
+
+    // item_upload_start transitions to item D without explicit item_type
+    handleProgressMessage({
+      type: 'item_upload_start',
+      job_id: 3,
+      run_id: 30,
+      item_name: 'flash-backup',
+    })
+    expect(getProgress().currentItem).toEqual({
+      name: 'flash-backup',
+      item_type: '',
+      percent: 60,
+      message: 'Uploading...',
+    })
+  })
+
+  it('clears currentItem when syncFromStatus receives an active status with no current_item', () => {
+    restoreFromStatus({
+      active: true,
+      job_id: 4,
+      run_id: 40,
+      job_name: 'test-job',
+      current_item: 'influxdb',
+      current_item_type: 'container',
+      current_item_percent: 50,
+      current_item_message: 'Working...',
+    })
+    expect(getProgress().currentItem?.name).toBe('influxdb')
+
+    syncFromStatus({
+      active: true,
+      job_id: 4,
+      run_id: 40,
+      job_name: 'test-job',
+      current_item: '',
+    })
+    expect(getProgress().currentItem).toBeNull()
+  })
+
+  it('synthesizes active run and sets currentItem on reload for item_staged and item_upload_start', () => {
+    // Reload state: activeRun is null
+    clearActiveRun()
+    expect(getProgress().activeRun).toBeNull()
+
+    handleProgressMessage({
+      type: 'item_staged',
+      job_id: 5,
+      run_id: 50,
+      job_name: 'staged-job',
+      item_name: 'mariadb',
+      item_type: 'container',
+    })
+    expect(getProgress().activeRun?.run_id).toBe(50)
+    expect(getProgress().running).toBe(true)
+    expect(getProgress().currentItem).toEqual({
+      name: 'mariadb',
+      item_type: 'container',
+      percent: 50,
+      message: 'Staged – awaiting upload',
+    })
+
+    clearActiveRun()
+    handleProgressMessage({
+      type: 'item_upload_start',
+      job_id: 6,
+      run_id: 60,
+      job_name: 'upload-job',
+      item_name: 'vaultwarden',
+      item_type: 'container',
+    })
+    expect(getProgress().activeRun?.run_id).toBe(60)
+    expect(getProgress().running).toBe(true)
+    expect(getProgress().currentItem).toEqual({
+      name: 'vaultwarden',
+      item_type: 'container',
+      percent: 60,
+      message: 'Uploading...',
+    })
+  })
+
+  it('does not clear currentItem when an out-of-order job_run_completed arrives for an older run', () => {
+    handleProgressMessage({ type: 'job_run_started', job_id: 7, run_id: 100, job_name: 'new-run' })
+    handleProgressMessage({ type: 'item_backup_start', job_id: 7, run_id: 100, item_name: 'postgres', item_type: 'container' })
+    expect(getProgress().currentItem?.name).toBe('postgres')
+
+    // Stale completion for older run_id 99
+    handleProgressMessage({ type: 'job_run_completed', job_id: 7, run_id: 99 })
+    expect(getProgress().running).toBe(true)
+    expect(getProgress().currentItem?.name).toBe('postgres')
+  })
 })

--- a/web/src/lib/progress.svelte.test.js
+++ b/web/src/lib/progress.svelte.test.js
@@ -358,4 +358,74 @@ describe('currentItem tracking', () => {
     expect(getProgress().running).toBe(true)
     expect(getProgress().currentItem?.name).toBe('postgres')
   })
+
+  it('handles restore progress and default restore messages', () => {
+    // restoreFromStatus with restore run_type and no explicit message
+    restoreFromStatus({
+      active: true,
+      job_id: 8,
+      run_id: 108,
+      job_name: 'restore-job',
+      run_type: 'restore',
+      current_item: 'nextcloud',
+      current_item_type: 'container',
+    })
+    expect(getProgress().currentItem).toEqual({
+      name: 'nextcloud',
+      item_type: 'container',
+      percent: 0,
+      message: 'Preparing restore...',
+    })
+
+    // item_restore_start and restore_progress
+    handleProgressMessage({
+      type: 'item_restore_start',
+      job_id: 8,
+      run_id: 108,
+      item_name: 'mariadb',
+      item_type: 'container',
+    })
+    expect(getProgress().currentItem).toEqual({
+      name: 'mariadb',
+      item_type: 'container',
+      percent: 0,
+      message: 'Starting...',
+    })
+
+    handleProgressMessage({
+      type: 'restore_progress',
+      item: 'mariadb',
+      item_type: 'container',
+      percent: 55,
+      message: 'Unpacking files...',
+    })
+    expect(getProgress().currentItem).toEqual({
+      name: 'mariadb',
+      item_type: 'container',
+      percent: 55,
+      message: 'Unpacking files...',
+    })
+
+    // backup_progress when currentItem was null
+    clearActiveRun()
+    handleProgressMessage({
+      type: 'job_run_started',
+      job_id: 9,
+      run_id: 109,
+      job_name: 'orphan-progress',
+    })
+    handleProgressMessage({
+      type: 'backup_progress',
+      item: 'standalone-container',
+      item_type: 'container',
+      percent: 30,
+      message: 'Hashing...',
+    })
+    expect(getProgress().currentItem).toEqual({
+      name: 'standalone-container',
+      item_type: 'container',
+      percent: 30,
+      message: 'Hashing...',
+    })
+  })
 })

--- a/web/src/pages/Dashboard.svelte
+++ b/web/src/pages/Dashboard.svelte
@@ -934,6 +934,11 @@
       <p class="text-[11px] text-text-dim mt-2 tabular-nums">
         {progress.overallDone}/{progress.overallTotal} items · {elapsedStr}{#if progress.overallFailed > 0} · <span class="text-danger">{progress.overallFailed} failed</span>{/if}{#if liveSpeed} · <span class="text-info">{liveSpeed}</span>{/if}
       </p>
+      {#if progress.currentItem}
+        <p class="text-[11px] text-text-dim mt-1 truncate">
+          {progress.activeRun.run_type === 'restore' ? 'Restoring' : 'Backing up'}: <span class="text-text font-medium">{progress.currentItem.name}</span>{#if progress.currentItem.item_type} <span class="text-text-muted">({progress.currentItem.item_type})</span>{/if}
+        </p>
+      {/if}
       {#if progress.phaseMessage}<p class="text-[11px] text-warning animate-pulse mt-1">{progress.phaseMessage}</p>{/if}
     </div>
   {:else}


### PR DESCRIPTION
## Summary

Addresses #368 by tracking the active item in the shared reactive progress store and rendering its name and type in the Dashboard "Backup in progress" / "Restore in progress" overlay.

### Changes

1. **`web/src/lib/progress.svelte.js`**:
   - Added module-level `$state` `currentItem` (`{ name, item_type, percent, message }` or `null`) and accessor `currentItem`.
   - Updated handlers for `item_backup_start`, `item_restore_start`, `item_upload_start`, and `item_staged` to track current item.
   - Updated `backup_progress` and `restore_progress` to update `percent` and `message` on active item matching.
   - Guarded item fallback across distinct items in `syncFromStatus`, `item_staged`, and `item_upload_start`.
   - Cleared `currentItem` on matching `job_run_completed`, `clearActiveRun()`, and `markJobActiveOptimistically()`.
   - Populated `currentItem` from runner status in `restoreFromStatus()` and `syncFromStatus()`.
   - Added synthetic-run initialization on reload for `item_staged` and `item_upload_start`.

2. **`web/src/pages/Dashboard.svelte`**:
   - Rendered active item name and type in `tProgress` snippet (`Backing up: <name> (<type>)` / `Restoring: <name> (<type>)`) with truncation safety and visual styling matching existing status indicators.

3. **`web/src/lib/progress.svelte.test.js`**:
   - Added comprehensive vitest coverage for all `currentItem` transitions, fallbacks, reload synthesis, and completion clearing.

4. **`CHANGELOG.md`**:
   - Added unreleased entry under `### Added`.

### Validation
- Unit tests (`vitest run`): 233 passed
- ESLint (`npm run lint`): clean
- Frontend production build (`vite build`): passed
- Backend tests (`go test ./...`): passed
- Ansible build, deploy, and live verification (`make build deploy verify`): passed
- CodeRabbit review findings addressed

Closes #368.